### PR TITLE
feat: props inspector on component props

### DIFF
--- a/libs/frontend/abstract/core/src/domain/atom/atom.model.interface.ts
+++ b/libs/frontend/abstract/core/src/domain/atom/atom.model.interface.ts
@@ -3,7 +3,7 @@ import type { IEntity, Nullish } from '@codelab/shared/abstract/types'
 import type { Ref } from 'mobx-keystone'
 import type { ICacheService } from '../../service'
 import type { ITag } from '../tag'
-import type { IAnyType } from '../type'
+import type { IInterfaceType } from '../type'
 import type { IAtomDTO, IRenderAtomDTO } from './atom.dto.interface'
 
 export interface IAtom extends IEntity, ICacheService<IAtomDTO, IAtom> {
@@ -11,7 +11,7 @@ export interface IAtom extends IEntity, ICacheService<IAtomDTO, IAtom> {
   icon?: string | null
   type: IAtomType
   tags: Array<Ref<ITag>>
-  api: Ref<IAnyType>
+  api: Ref<IInterfaceType>
   allowCustomTextInjection: boolean
   /**
    * We don't need Ref here, only need id to filter the select options. Making it Ref requires dependency resolution that makes it more difficult.

--- a/libs/frontend/abstract/core/src/domain/component/component.model.interface.ts
+++ b/libs/frontend/abstract/core/src/domain/component/component.model.interface.ts
@@ -4,7 +4,7 @@ import type { INodeType } from '../../base'
 import type { ICacheService } from '../../service'
 import type { IElementTreeService } from '../element'
 import type { IProp } from '../prop'
-import type { IAnyType } from '../type'
+import type { IInterfaceType } from '../type'
 import type { IComponentDTO } from './component.dto.interface'
 
 export interface IComponent
@@ -16,7 +16,7 @@ export interface IComponent
   rootElementId: string
   childrenContainerElementId: string
   ownerId: string
-  api: Ref<IAnyType>
+  api: Ref<IInterfaceType>
   props?: Nullable<IProp>
 }
 

--- a/libs/frontend/domain/builder/src/sections/config-pane/ConfigPane-InspectorTabContainer/ConfigPane-InspectorTabContainer.tsx
+++ b/libs/frontend/domain/builder/src/sections/config-pane/ConfigPane-InspectorTabContainer/ConfigPane-InspectorTabContainer.tsx
@@ -156,11 +156,11 @@ export const ConfigPaneInspectorTabContainer = observer<MetaPaneBuilderProps>(
             title={TAB_NAMES.PropsInspector}
           />
         ),
-        children: isElement(selectedNode) && renderService && (
+        children: renderService && (
           <PropsInspectorTab
-            element={selectedNode}
             elementService={elementService}
             key={selectedNode.id}
+            node={selectedNode}
             renderer={renderService}
           />
         ),

--- a/libs/frontend/domain/builder/src/sections/config-pane/ConfigPane-InspectorTabContainer/ConfigPane-InspectorTabContainer.tsx
+++ b/libs/frontend/domain/builder/src/sections/config-pane/ConfigPane-InspectorTabContainer/ConfigPane-InspectorTabContainer.tsx
@@ -158,7 +158,6 @@ export const ConfigPaneInspectorTabContainer = observer<MetaPaneBuilderProps>(
         ),
         children: renderService && (
           <PropsInspectorTab
-            elementService={elementService}
             key={selectedNode.id}
             node={selectedNode}
             renderer={renderService}

--- a/libs/frontend/domain/builder/src/sections/config-pane/PropsInspectorTab.tsx
+++ b/libs/frontend/domain/builder/src/sections/config-pane/PropsInspectorTab.tsx
@@ -1,7 +1,6 @@
 import type {
   IComponent,
   IElement,
-  IElementService,
   IPropData,
   IRenderer,
 } from '@codelab/frontend/abstract/core'
@@ -18,34 +17,26 @@ import { usePropsInspector } from '../../hooks'
 export interface ElementPropsSectionProps {
   node: IElement | IComponent
   renderer: IRenderer
-  elementService: IElementService
 }
 
 const PropsInspectorTab = observer(
-  ({ node, renderer, elementService }: ElementPropsSectionProps) => {
+  ({ node, renderer }: ElementPropsSectionProps) => {
     const initialProps = node.props?.values ?? {}
-
-    const [editorValue, setEditorValue] = React.useState(
-      propSafeStringify(initialProps),
-    )
-
-    const [updatedProps, setUpdatedProps] = React.useState(initialProps)
+    const initialEditorValue = propSafeStringify(initialProps)
+    const [editedProps, setEditedProps] = React.useState(initialProps)
     const [isValidProps, setIsValidProps] = React.useState(true)
 
     const { save, lastRenderedPropsString, isLoading } = usePropsInspector(
       node,
       renderer,
-      elementService,
-      updatedProps,
+      editedProps,
     )
 
     const onChange = (value: string) => {
-      setEditorValue(value)
-
       try {
         const newValue = JSON.parse(value) as IPropData
         // only a valid IPropData will be saved
-        setUpdatedProps(newValue)
+        setEditedProps(newValue)
         setIsValidProps(true)
       } catch (error) {
         console.log(error)
@@ -89,12 +80,12 @@ const PropsInspectorTab = observer(
           onChange={(v: string) => onChange(v)}
           onSave={(v: string) => onSave(v)}
           title={`${isElement(node) ? 'Element' : 'Component'} props`}
-          value={editorValue}
+          value={initialEditorValue}
         />
         <Button
           disabled={!isValidProps}
           loading={isLoading}
-          onClick={() => onSave(updatedProps)}
+          onClick={() => onSave(editedProps)}
         >
           Save
         </Button>

--- a/libs/frontend/domain/builder/src/sections/config-pane/PropsInspectorTab.tsx
+++ b/libs/frontend/domain/builder/src/sections/config-pane/PropsInspectorTab.tsx
@@ -48,8 +48,23 @@ const PropsInspectorTab = observer(
         setUpdatedProps(newValue)
         setIsValidProps(true)
       } catch (error) {
-        console.error(error)
+        console.log(error)
         setIsValidProps(false)
+      }
+    }
+
+    // string argument is used for when saving in the code mirror modal
+    // TODO: Check in the code mirror component why it doesnt
+    // trigger `onChange` when editing in the modal
+    const onSave = async (data: IPropData | string) => {
+      if (typeof data === 'string') {
+        try {
+          await save(JSON.parse(data))
+        } catch (error) {
+          console.log(error)
+        }
+      } else {
+        await save(data)
       }
     }
 
@@ -71,17 +86,15 @@ const PropsInspectorTab = observer(
         <CodeMirrorEditor
           height="150px"
           language={ICodeMirrorLanguage.Json}
-          // persistedProps is state variable which means
-          // it takes time to be updated by onChange
           onChange={(v: string) => onChange(v)}
-          onSave={(v: string) => save(v)}
+          onSave={(v: string) => onSave(v)}
           title={`${isElement(node) ? 'Element' : 'Component'} props`}
           value={editorValue}
         />
         <Button
           disabled={!isValidProps}
           loading={isLoading}
-          onClick={() => save(propSafeStringify(updatedProps))}
+          onClick={() => onSave(updatedProps)}
         >
           Save
         </Button>

--- a/libs/frontend/domain/component/src/store/api.utils.ts
+++ b/libs/frontend/domain/component/src/store/api.utils.ts
@@ -1,11 +1,10 @@
 import type {
+  IComponent,
   ICreateComponentDTO,
-  IField,
-  IFieldDefaultValue,
+  IPropData,
 } from '@codelab/frontend/abstract/core'
 import { createSlug } from '@codelab/frontend/shared/utils'
 import type { ComponentCreateInput } from '@codelab/shared/abstract/codegen'
-import type { Nullish } from '@codelab/shared/abstract/types'
 import { connectOwner } from '@codelab/shared/data'
 import { v4 } from 'uuid'
 
@@ -61,17 +60,14 @@ export const mapCreateInput = (
 }
 
 /**
- * Generates a key-value pair from an array of IField
+ * Generates a key-value pair from the api fields of an IComponent
  */
-export const convertFieldsToProps = (fields: Array<IField>) => {
-  const props = fields.reduce<Record<string, Nullish<IFieldDefaultValue>>>(
-    (acc, field) => {
-      acc[field.key] = field.defaultValues
+export const getDefaultComponentFieldProps = (component: IComponent) => {
+  const props = component.api.current.fields.reduce<IPropData>((acc, field) => {
+    acc[field.key] = field.defaultValues ?? undefined
 
-      return acc
-    },
-    {},
-  )
+    return acc
+  }, {})
 
   return props
 }

--- a/libs/frontend/domain/component/src/store/api.utils.ts
+++ b/libs/frontend/domain/component/src/store/api.utils.ts
@@ -1,6 +1,11 @@
-import type { ICreateComponentDTO } from '@codelab/frontend/abstract/core'
+import type {
+  ICreateComponentDTO,
+  IField,
+  IFieldDefaultValue,
+} from '@codelab/frontend/abstract/core'
 import { createSlug } from '@codelab/frontend/shared/utils'
 import type { ComponentCreateInput } from '@codelab/shared/abstract/codegen'
+import type { Nullish } from '@codelab/shared/abstract/types'
 import { connectOwner } from '@codelab/shared/data'
 import { v4 } from 'uuid'
 
@@ -53,4 +58,20 @@ export const mapCreateInput = (
     props,
     childrenContainerElement: connectRootElement,
   }
+}
+
+/**
+ * Generates a key-value pair from an array of IField
+ */
+export const convertFieldsToProps = (fields: Array<IField>) => {
+  const props = fields.reduce<Record<string, Nullish<IFieldDefaultValue>>>(
+    (acc, field) => {
+      acc[field.key] = field.defaultValues
+
+      return acc
+    },
+    {},
+  )
+
+  return props
 }

--- a/libs/frontend/domain/component/src/store/api.utils.ts
+++ b/libs/frontend/domain/component/src/store/api.utils.ts
@@ -64,7 +64,7 @@ export const mapCreateInput = (
  */
 export const getDefaultComponentFieldProps = (component: IComponent) => {
   const props = component.api.current.fields.reduce<IPropData>((acc, field) => {
-    acc[field.key] = field.defaultValues ?? undefined
+    acc[field.key] = field.defaultValues
 
     return acc
   }, {})

--- a/libs/frontend/domain/component/src/store/index.ts
+++ b/libs/frontend/domain/component/src/store/index.ts
@@ -1,3 +1,4 @@
+export * from './api.utils'
 export * from './component.model'
 export * from './component.service'
 export * from './component.service.ref'

--- a/libs/frontend/domain/component/src/use-cases/update-component-props/UpdateComponentPropsForm.tsx
+++ b/libs/frontend/domain/component/src/use-cases/update-component-props/UpdateComponentPropsForm.tsx
@@ -4,11 +4,12 @@ import { PropsForm } from '@codelab/frontend/domain/type'
 import { useStore } from '@codelab/frontend/presenter/container'
 import type { UseTrackLoadingPromises } from '@codelab/frontend/view/components'
 import { Spinner } from '@codelab/frontend/view/components'
-import { filterEmptyStrings } from '@codelab/shared/utils'
+import { filterEmptyStrings, mergeProps } from '@codelab/shared/utils'
 import { Col, Row } from 'antd'
 import { observer } from 'mobx-react-lite'
 import React from 'react'
 import { useAsync } from 'react-use'
+import { getDefaultComponentFieldProps } from '../../store'
 
 export interface UpdateComponentPropsFormProps {
   component: IComponent
@@ -42,6 +43,13 @@ export const UpdateComponentPropsForm = observer<UpdateComponentPropsFormProps>(
       return trackPromise?.(promise) ?? promise
     }
 
+    // We only set the `defaultValues` as an initial value, not as `defaultValue` in the schema
+    // so that the value of `defaultValues` wont show when the field is cleared
+    const propsModel = mergeProps(
+      getDefaultComponentFieldProps(component),
+      component.props?.values,
+    )
+
     return (
       <Spinner isLoading={loading}>
         {interfaceType && (
@@ -51,7 +59,7 @@ export const UpdateComponentPropsForm = observer<UpdateComponentPropsFormProps>(
                 autosave
                 interfaceType={interfaceType}
                 key={component.id}
-                model={component.props?.values ?? {}}
+                model={propsModel}
                 onSubmit={onSubmit}
                 submitField={React.Fragment}
               />

--- a/libs/frontend/domain/component/src/use-cases/update-component-props/UpdateComponentPropsForm.tsx
+++ b/libs/frontend/domain/component/src/use-cases/update-component-props/UpdateComponentPropsForm.tsx
@@ -7,7 +7,7 @@ import { Spinner } from '@codelab/frontend/view/components'
 import { filterEmptyStrings } from '@codelab/shared/utils'
 import { Col, Row } from 'antd'
 import { observer } from 'mobx-react-lite'
-import React, { useRef } from 'react'
+import React from 'react'
 import { useAsync } from 'react-use'
 
 export interface UpdateComponentPropsFormProps {
@@ -19,7 +19,6 @@ export const UpdateComponentPropsForm = observer<UpdateComponentPropsFormProps>(
   ({ component, trackPromises }) => {
     const { typeService, componentService } = useStore()
     const { trackPromise } = trackPromises ?? {}
-    const initialPropsRef = useRef(component.props?.values ?? {})
     const apiId = component.api.id
 
     const { value: interfaceType, loading } = useAsync(
@@ -52,7 +51,7 @@ export const UpdateComponentPropsForm = observer<UpdateComponentPropsFormProps>(
                 autosave
                 interfaceType={interfaceType}
                 key={component.id}
-                model={initialPropsRef.current}
+                model={component.props?.values ?? {}}
                 onSubmit={onSubmit}
                 submitField={React.Fragment}
               />

--- a/libs/frontend/domain/type/src/interface-form/type-schema.factory.ts
+++ b/libs/frontend/domain/type/src/interface-form/type-schema.factory.ts
@@ -20,7 +20,6 @@ import { ITypeKind } from '@codelab/shared/abstract/core'
 import type { Maybe } from '@codelab/shared/abstract/types'
 import { compoundCaseToTitleCase } from '@codelab/shared/utils'
 import type { JSONSchema7 } from 'json-schema'
-import { isNil } from 'ramda'
 import type { UiPropertiesContext } from './types'
 import { getUiProperties } from './ui-properties'
 
@@ -104,9 +103,6 @@ export class TypeSchemaFactory {
         fieldName: field.name,
       }),
       ...field.validationRules?.general,
-      // `default` should not be included if the field does not have `defaultValues`
-      // so that `null` or `undefined` does not show in the uniforms field
-      ...(!isNil(field.defaultValues) ? { default: field.defaultValues } : {}),
     })
 
     const makeFieldProperties = (

--- a/libs/frontend/domain/type/src/interface-form/type-schema.factory.ts
+++ b/libs/frontend/domain/type/src/interface-form/type-schema.factory.ts
@@ -20,6 +20,7 @@ import { ITypeKind } from '@codelab/shared/abstract/core'
 import type { Maybe } from '@codelab/shared/abstract/types'
 import { compoundCaseToTitleCase } from '@codelab/shared/utils'
 import type { JSONSchema7 } from 'json-schema'
+import { isNil } from 'ramda'
 import type { UiPropertiesContext } from './types'
 import { getUiProperties } from './ui-properties'
 
@@ -103,6 +104,9 @@ export class TypeSchemaFactory {
         fieldName: field.name,
       }),
       ...field.validationRules?.general,
+      // `default` should not be included if the field does not have `defaultValues`
+      // so that `null` or `undefined` does not show in the uniforms field
+      ...(!isNil(field.defaultValues) ? { default: field.defaultValues } : {}),
     })
 
     const makeFieldProperties = (


### PR DESCRIPTION
<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(libs-ui-component): must begin with lowercase` -->

## Description

<!-- This is a short description on the Pull Request -->
This PR is for allowing to view and edit the component props in component builder.

Currently, we only show the props inspector if the node type is "Element". Since components can also have props in the component builder, we can update the props inspector to also show on "Component" type.

I updated the `usePropsInspector` so that it can support both node type and user can also update the props in the component builder.

## Video or Image

<!-- Add video or image showing how the new feature works -->

In this video, I tested in component props inspector:
- editing the props and it updated the api values in the props tab
- updated the api in the Props tab and it updated the values in the props inspector
- updated the props in the code mirror modal
- clearing the props resets the props to default values set in the api

https://user-images.githubusercontent.com/27695022/216574244-0b462615-d5b0-4753-a690-6016d3229946.mp4



## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged -->

Fixes #2201 
