### PR TITLE
fix(apps-builder): side panel incorrect padding

### DIFF
--- a/libs/frontend/domain/builder/src/sections/explorer-pane/BuilderExplorerPane.tsx
+++ b/libs/frontend/domain/builder/src/sections/explorer-pane/BuilderExplorerPane.tsx
@@ -236,8 +236,10 @@ export const BuilderExplorerPane = observer<BuilderMainPaneProps>(
         <Tabs
           css={css`
             ${tw`px-4 h-full w-full`}
-            .ant-collapse-header {
-              ${tw`px-0!`}
+            .ant-page-header-content,
+            .ant-collapse-header,
+            .ant-page-header-heading {
+              ${tw`px-0! mt-0!`}
             }
           `}
           defaultActiveKey="1"

--- a/libs/frontend/view/templates/ExplorerPaneTemplate.tsx
+++ b/libs/frontend/view/templates/ExplorerPaneTemplate.tsx
@@ -4,7 +4,7 @@ import styled from '@emotion/styled'
 import type { PageHeaderProps } from 'antd'
 import { PageHeader } from 'antd'
 import React from 'react'
-import { GlobalStyles } from 'twin.macro'
+import tw, { GlobalStyles } from 'twin.macro'
 
 export type MainPaneTemplateProps = React.PropsWithChildren<{
   title: React.ReactNode
@@ -33,11 +33,13 @@ const StyledContainer = styled.div`
     padding-right: 0;
 
     .ant-page-header-content {
+      ${tw`px-4`}
       max-height: 100%;
       min-height: 0;
       overflow-y: auto;
     }
     .ant-page-header-heading {
+      ${tw`px-4 mt-2`}
       align-items: center;
     }
   }


### PR DESCRIPTION
<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(libs-ui-component): must begin with lowercase` -->

## Description
fixes side panel incorrect padding style

<!-- This is a short description on the Pull Request -->

## Video or Image
### Before
<img width="350" alt="Screenshot 2023-02-05 at 08 28 37" src="https://user-images.githubusercontent.com/26872714/216807979-5f4cc113-8558-48db-81b9-1727c4849992.png">

### After
<img width="288" alt="Screenshot 2023-02-05 at 08 29 16" src="https://user-images.githubusercontent.com/26872714/216807996-f3deba58-32d3-4999-8a39-e5d368abd517.png">

<!-- Add video or image showing how the new feature works -->

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged -->

Fixes #2213
Closes #2213
