### PR TITLE
fix: fixes layout shift and duplicated requests

### DIFF
--- a/apps/builder-e2e/src/e2e/providersPage.cy.ts
+++ b/apps/builder-e2e/src/e2e/providersPage.cy.ts
@@ -62,7 +62,6 @@ describe('_app page', () => {
       .getButton({ icon: 'plus' })
       .click()
 
-    cy.getModal().findByLabelText('Name').type(CONFIG_PROVIDER_NAME)
     cy.getModal().setFormFieldValue({
       label: 'Render Type',
       value: 'Atom',
@@ -73,6 +72,7 @@ describe('_app page', () => {
       value: IAtomType.AntDesignConfigProvider,
       type: FIELD_TYPE.SELECT,
     })
+    cy.getModal().findByLabelText('Name').clear().type(CONFIG_PROVIDER_NAME)
     cy.getModal()
       .getModalAction(/Create/)
       .click()

--- a/libs/frontend/abstract/core/src/domain/atom/atom.service.interface.ts
+++ b/libs/frontend/abstract/core/src/domain/atom/atom.service.interface.ts
@@ -20,6 +20,9 @@ export interface IAtomService
     IQueryService<IAtom, AtomWhere, AtomOptions>,
     Omit<ICRUDModalService<Ref<IAtom>, { atom: Maybe<IAtom> }>, 'deleteModal'>,
     ICacheService<IAtomDTO, IAtom> {
+  // Select dropdown for atoms need to load all atoms from the db
+  // but this is a heavy operation, this flag allows to call it only once
+  allAtomsLoaded: boolean
   atoms: ObjectMap<IAtom>
   count: number
   atomsList: Array<IAtom>

--- a/libs/frontend/domain/atom/src/store/atom.service.ts
+++ b/libs/frontend/domain/atom/src/store/atom.service.ts
@@ -32,6 +32,7 @@ import { AtomModalService, AtomsModalService } from './atom-modal.service'
 export class AtomService
   extends Model({
     id: idProp,
+    allAtomsLoaded: prop(() => false),
     atoms: prop(() => objectMap<IAtom>()),
     count: prop(() => 1),
     createModal: prop(() => new ModalService({})),
@@ -104,6 +105,10 @@ export class AtomService
     const { atoms, atomsAggregate } = yield* _await(
       atomApi.GetAtoms({ where, options }),
     )
+
+    if (!where) {
+      this.allAtomsLoaded = true
+    }
 
     this.count = atomsAggregate.count
 

--- a/libs/frontend/domain/builder/src/sections/content/BuilderTabs.tsx
+++ b/libs/frontend/domain/builder/src/sections/content/BuilderTabs.tsx
@@ -44,7 +44,6 @@ export const BuilderTabs = observer<BuilderTabsProps>(
     return (
       <Layout style={{ height: '100%' }}>
         {error && <Alert message={extractErrorMessage(error)} type="error" />}
-        {isLoading && <Spin />}
         <Header style={{ background: 'rgba(0,0,0,0)', marginBottom: '5px' }}>
           <Tabs
             activeKey={builderService.activeTree}
@@ -56,6 +55,7 @@ export const BuilderTabs = observer<BuilderTabsProps>(
             <Tabs.TabPane key={RendererTab.Component} tab="Component" />
           </Tabs>
         </Header>
+        {isLoading && <Spin />}
         <Content>
           {builderService.activeTree === RendererTab.Page ? (
             elementTree && renderer ? (


### PR DESCRIPTION
## Description
During the demo app creation, some issues were detected and fixed:
- spinner appeared before the tabs component and it caused a layout shift (components below the spinner jumped down and up)
- requests for atoms were repeated a lot of times, use atom service with caching instead of manual request. Those requests are slowing down the production builder site a lot:

https://user-images.githubusercontent.com/74900868/217049644-9601e326-208e-416f-a06d-49d5bf6c787b.mov


- fix instability in e2e test because of - https://github.com/codelab-app/platform/issues/2235

## Video or Image

<!-- Add video or image showing how the new feature works -->

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged -->

#2224 

@vladyslav-polishchuk can remove fixes keyword so it’s linked at least 