### PR TITLE
fix: infinite render when creating state variable

### DIFF
--- a/libs/frontend/domain/renderer/src/ExtraElementProps.ts
+++ b/libs/frontend/domain/renderer/src/ExtraElementProps.ts
@@ -14,6 +14,7 @@ import {
   objectMap,
   prop,
 } from 'mobx-keystone'
+import { whereEq } from 'ramda'
 
 @model('@codelab/ExtraElementProps')
 export class ExtraElementProps
@@ -32,10 +33,14 @@ export class ExtraElementProps
 
   @modelAction
   addForElement(elementId: string, props: IPropData) {
-    this.elementPropMap.set(
-      elementId,
-      frozen(mergeProps(this.getForElement(elementId), props)),
-    )
+    const currentProps = this.getForElement(elementId)
+
+    if (!whereEq(props, currentProps)) {
+      this.elementPropMap.set(
+        elementId,
+        frozen(mergeProps(currentProps, props)),
+      )
+    }
   }
 
   @modelAction

--- a/libs/frontend/domain/renderer/src/ExtraElementProps.ts
+++ b/libs/frontend/domain/renderer/src/ExtraElementProps.ts
@@ -35,6 +35,8 @@ export class ExtraElementProps
   addForElement(elementId: string, props: IPropData) {
     const currentProps = this.getForElement(elementId)
 
+    // This prevents creating a new object if the new `props` is already
+    // in the current `props` because it can cause to render infinitely
     if (!whereEq(props, currentProps)) {
       this.elementPropMap.set(
         elementId,

--- a/libs/frontend/domain/renderer/src/renderer.model.ts
+++ b/libs/frontend/domain/renderer/src/renderer.model.ts
@@ -324,7 +324,7 @@ export class Renderer
     const props = this.processPropsForRender(
       {
         ...componentProps,
-        props: propsForCurrentElement,
+        ...propsForCurrentElement,
         [COMPONENT_INSTANCE_ID]: element.id,
       },
       element,


### PR DESCRIPTION
<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(libs-ui-component): must begin with lowercase` -->

## Description

<!-- This is a short description on the Pull Request -->
Upon investigation, it seems this [part](https://github.com/codelab-app/platform/blob/master/libs/frontend/domain/renderer/src/renderer.model.ts#L327) causes the current `props` to be recursively added to the element in this [part](https://github.com/codelab-app/platform/blob/master/libs/frontend/domain/renderer/src/renderer.model.ts#L334). But what causes the infinite renders is the use of  [this.elementPropMap.set](https://github.com/codelab-app/platform/blob/master/libs/frontend/domain/renderer/src/ExtraElementProps.ts#L35) which always sets a new object to the element even if there is no change in the props.

![image](https://user-images.githubusercontent.com/27695022/217264643-07ce570f-dca1-47a5-bcc4-ee4d93701449.png)


This PR:
- spreads the `propsForCurrentElement` into the new `props` instead of putting it inside another `props`
- used [Ramda's whereEq](https://ramdajs.com/docs/#whereEq) on [addForElement](https://github.com/codelab-app/platform/blob/master/libs/frontend/domain/renderer/src/ExtraElementProps.ts#L34) so that if the new `props` to be added already exists in the current `props`, it will just skip

## Video or Image

<!-- Add video or image showing how the new feature works -->

https://user-images.githubusercontent.com/27695022/217235111-377eeb00-307f-4922-9d56-d6e1f0d84759.mp4



## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged -->

Fixes #2216 
