### PR TITLE
fix(draggable-element component): refactor DraggableElement to not use setTimeout

### DIFF
--- a/libs/frontend/domain/renderer/src/element/DraggableElement.tsx
+++ b/libs/frontend/domain/renderer/src/element/DraggableElement.tsx
@@ -46,16 +46,11 @@ export const DraggableElement = ({
   } = useDroppable({ id: element.id })
 
   useEffect(() => {
-    // Passing the setDraggableAndDroppableNodeRef as ref to makeRenderedElements
-    // doesn't work properly for some components like AntDesignImage.
-    // This works for now but could be improved later on
-    setTimeout(() => {
-      const htmlElement = document.querySelector(
-        `[data-element-id="${element.id}"]`,
-      )
+    const htmlElement = document.querySelector(
+      `[data-element-id="${element.id}"]`,
+    )
 
-      setDraggableAndDroppableNodeRef(htmlElement as HTMLElement)
-    }, 2000)
+    setDraggableAndDroppableNodeRef(htmlElement as HTMLElement)
   }, [])
 
   const dragPosition = isOver


### PR DESCRIPTION
<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(libs-ui-component): must begin with lowercase` -->

## Description

There was a setTimeout function used as a workaround to fix some rendering issues with some atoms like AntDesignImage. I removed the setTimeout function and things seemed to be working flawlessly. Please see the image below.


## Video or Image

<img width="1413" alt="image" src="https://user-images.githubusercontent.com/22745510/217476225-fe7128d7-f465-408e-8cbf-b18dd9316a0d.png">

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged -->

Fixes #2161 
