### PR TITLE
feat: add validations to props inspector

### DIFF
--- a/apps/builder-e2e/src/e2e/component.cy.ts
+++ b/apps/builder-e2e/src/e2e/component.cy.ts
@@ -118,6 +118,11 @@ describe('Component CRUD', () => {
         value: IPrimitiveTypeKind.String,
         type: FIELD_TYPE.SELECT,
       })
+      cy.getModal().setFormFieldValue({
+        label: 'Nullable',
+        value: true,
+        type: FIELD_TYPE.TOGGLE,
+      })
       cy.getModal()
         .getModalAction(/Create/)
         .click()

--- a/apps/builder-e2e/src/e2e/types.cy.ts
+++ b/apps/builder-e2e/src/e2e/types.cy.ts
@@ -24,6 +24,7 @@ const interfaceTypeName = 'New Interface'
 const interfaceTypeKind = ITypeKind.InterfaceType
 // Field
 const fieldName = 'Name'
+const fieldDefaultValue = 'something default'
 
 describe('Types CRUD', () => {
   before(() => {
@@ -170,9 +171,24 @@ describe('Types CRUD', () => {
         type: FIELD_TYPE.SELECT,
       })
 
+      // should show error because nullable is false by default
       cy.getModal()
         .getModalAction(/Create/)
         .click()
+
+      cy.getModal().findByText('Default values is required if not nullable')
+
+      cy.getModal().setFormFieldValue({
+        label: 'Default values',
+        value: fieldDefaultValue,
+        type: FIELD_TYPE.CODE_MIRROR,
+      })
+
+      cy.getModal()
+        .getModalAction(/Create/)
+        .click()
+
+      cy.getModal().should('not.exist')
 
       cy.findByText(interfaceTypeName)
         .closest('.ant-table-row')
@@ -182,11 +198,19 @@ describe('Types CRUD', () => {
       cy.searchTableRow({
         header: 'Key',
         row: fieldName,
+        table: cy.get('.ant-table-expanded-row'),
       }).should('exist')
 
       cy.searchTableRow({
         header: 'Kind',
         row: primitiveTypeKind,
+        table: cy.get('.ant-table-expanded-row'),
+      })
+
+      cy.searchTableRow({
+        header: 'Default',
+        row: fieldDefaultValue,
+        table: cy.get('.ant-table-expanded-row'),
       })
     })
   })

--- a/apps/builder-e2e/src/support/antd/form/form.types.ts
+++ b/apps/builder-e2e/src/support/antd/form/form.types.ts
@@ -15,6 +15,7 @@ type FieldType =
   | 'radio'
   | 'date'
   | 'codeMirror'
+  | 'toggle'
 
 export enum FIELD_TYPE {
   INPUT = 'input',
@@ -25,6 +26,7 @@ export enum FIELD_TYPE {
   RADIO = 'radio',
   DATE = 'date',
   CODE_MIRROR = 'codeMirror',
+  TOGGLE = 'toggle',
 }
 
 export interface FormFieldOptions {
@@ -34,7 +36,7 @@ export interface FormFieldOptions {
 export type FormInputOptions = FormFieldOptions & { type?: FieldType }
 
 export type FormFieldValueOptions = FormInputOptions & {
-  value: string | number | Array<string>
+  value: string | number | Array<string> | boolean
   placeholder?: string
   scrollIntoView?: boolean
 }

--- a/apps/builder-e2e/src/support/antd/table/table.command.ts
+++ b/apps/builder-e2e/src/support/antd/table/table.command.ts
@@ -83,13 +83,13 @@ export const getTableRows = (options?: CommonOptions) => {
  * @returns Row
  */
 export const searchTableRow = (
-  { header, row }: SearchCellOptions,
+  { header, row, table }: SearchCellOptions,
   options?: CommonOptions,
 ) => {
   /**
    * Get the index of the header column we're searching for
    */
-  return getTableHeader()
+  return (table ?? getTableHeader())
     .contains('.ant-table-cell', header, options)
     .invoke('index')
     .then((columnIndex) => {

--- a/apps/builder-e2e/src/support/antd/table/table.types.ts
+++ b/apps/builder-e2e/src/support/antd/table/table.types.ts
@@ -17,4 +17,7 @@ export interface SearchCellOptions {
 
   // The value to search within the row
   row: Label
+
+  // The table to search from (useful for nested tables)
+  table?: Cypress.Chainable<JQuery<HTMLElement>>
 }

--- a/libs/frontend/domain/element/src/use-cases/element/update-element-props/UpdateElementPropsForm.tsx
+++ b/libs/frontend/domain/element/src/use-cases/element/update-element-props/UpdateElementPropsForm.tsx
@@ -5,11 +5,11 @@ import { PropsForm } from '@codelab/frontend/domain/type'
 import { useStore } from '@codelab/frontend/presenter/container'
 import type { UseTrackLoadingPromises } from '@codelab/frontend/view/components'
 import { ReactQuillField, Spinner } from '@codelab/frontend/view/components'
-import { filterEmptyStrings } from '@codelab/shared/utils'
+import { filterEmptyStrings, mergeProps } from '@codelab/shared/utils'
 import type { JSONSchemaType } from 'ajv'
 import { Col, Row } from 'antd'
 import { observer } from 'mobx-react-lite'
-import React, { useRef } from 'react'
+import React from 'react'
 import { useAsync } from 'react-use'
 import tw from 'twin.macro'
 
@@ -40,8 +40,6 @@ export const UpdateElementPropsForm = observer<UpdateElementPropsFormProps>(
   ({ element, trackPromises }) => {
     const { typeService, elementService } = useStore()
     const { trackPromise } = trackPromises ?? {}
-    // cache it to not confuse the user when auto-saving
-    const initialPropsRef = useRef(element.props?.values ?? {})
 
     const apiId =
       element.atom?.current.api.id ||
@@ -75,6 +73,13 @@ export const UpdateElementPropsForm = observer<UpdateElementPropsFormProps>(
 
     const initialSchema = allowCustomText ? withCustomTextSchema : {}
 
+    // If element is a component type, we also show the component props
+    // but should prioritize the element props
+    const propsModel = mergeProps(
+      element.renderComponentType?.maybeCurrent?.props?.values,
+      element.props?.values,
+    )
+
     return (
       <Spinner isLoading={loading}>
         {interfaceType && (
@@ -85,7 +90,7 @@ export const UpdateElementPropsForm = observer<UpdateElementPropsFormProps>(
                 initialSchema={initialSchema}
                 interfaceType={interfaceType}
                 key={element.id}
-                model={initialPropsRef.current}
+                model={propsModel}
                 onSubmit={onSubmit}
                 submitField={React.Fragment}
               />

--- a/libs/frontend/domain/type/src/interface-form/fields/select-default-value/SelectDefaultValue.tsx
+++ b/libs/frontend/domain/type/src/interface-form/fields/select-default-value/SelectDefaultValue.tsx
@@ -1,7 +1,15 @@
-import type { IPropData, ITypeService } from '@codelab/frontend/abstract/core'
+import type {
+  IPrimitiveType,
+  IPropData,
+  ITypeService,
+  IValidationRules,
+} from '@codelab/frontend/abstract/core'
 import { Form } from '@codelab/frontend/view/components'
+import { PrimitiveTypeKind } from '@codelab/shared/abstract/codegen'
 import { ITypeKind } from '@codelab/shared/abstract/core'
+import type { Maybe } from '@codelab/shared/abstract/types'
 import type { JSONSchemaType } from 'ajv'
+import isNil from 'lodash/isNil'
 import React, { useMemo } from 'react'
 import { useField } from 'uniforms'
 import { AutoFields } from 'uniforms-antd'
@@ -14,11 +22,25 @@ export interface SelectDefaultValueProps {
 export const SelectDefaultValue = ({
   typeService,
 }: SelectDefaultValueProps) => {
-  const [fieldType, context] = useField('fieldType', {})
+  const [fieldType, context] = useField<{ value?: string }>('fieldType', {})
+
+  const [validationRules] = useField<{ value?: IValidationRules }>(
+    'validationRules',
+    {},
+  )
 
   const type = fieldType.value
     ? typeService.type(fieldType.value as string)
     : null
+
+  // Typecasting just for conditional check if field type is primitive
+  const primitiveKind = (type as Maybe<IPrimitiveType>)?.primitiveKind
+
+  // This prevents a nullable boolean when switching from another type to boolean
+  // Cant move this yet to ajv schema since fieldType is id and cannot determine primitive kind
+  const isRequired =
+    !validationRules.value?.general?.nullable ||
+    primitiveKind === PrimitiveTypeKind.Boolean
 
   const schema = useMemo(
     () => ({
@@ -27,9 +49,10 @@ export const SelectDefaultValue = ({
       properties: type
         ? { defaultValues: schemaTransformer.transform(type) }
         : {},
+      required: isRequired ? ['defaultValues'] : undefined,
     }),
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [type?.id],
+    [type?.id, isRequired],
   )
 
   const defaultValues =
@@ -37,16 +60,27 @@ export const SelectDefaultValue = ({
       ? []
       : context.model.defaultValues
 
+  const hasError =
+    context.submitted && isRequired && isNil(context.model.defaultValues)
+
+  // TODO: make code mirror input have an error state
+  // Simple approach for now is to just display the error message for the `defaultValues` below it
   return (
     <Form
       model={{ defaultValues }}
       onChange={(key, value) => {
-        context.onChange(key, value)
+        const formattedValue = value === '' ? undefined : value
+        context.onChange(key, formattedValue)
       }}
       onSubmit={() => Promise.resolve()}
       schema={schema as JSONSchemaType<IPropData>}
     >
       <AutoFields />
+      {hasError && (
+        <p style={{ color: 'red', marginTop: -30 }}>
+          Default values is required if not nullable
+        </p>
+      )}
     </Form>
   )
 }

--- a/libs/frontend/domain/type/src/interface-form/type-schema.factory.ts
+++ b/libs/frontend/domain/type/src/interface-form/type-schema.factory.ts
@@ -44,13 +44,6 @@ export const primitives = {
   [PrimitiveTypeKind.Boolean]: 'boolean' as const,
 }
 
-const primitivesDefaults = {
-  [PrimitiveTypeKind.Boolean]: false,
-  [PrimitiveTypeKind.Number]: 0.0,
-  [PrimitiveTypeKind.Integer]: 0,
-  [PrimitiveTypeKind.String]: '',
-}
-
 export class TypeSchemaFactory {
   constructor(private readonly options?: TransformTypeOptions) {}
 
@@ -217,31 +210,35 @@ export class TypeSchemaFactory {
     context?: UiPropertiesContext,
   ): JsonSchema {
     const extra = this.getExtraProperties(type)
-    let validation = {}
+    let rulesSchema = {}
 
     switch (type.primitiveKind) {
       case PrimitiveTypeKind.String:
-        validation = {
+        rulesSchema = {
           ...context?.validationRules?.String,
         }
         break
       case PrimitiveTypeKind.Number:
-        validation = {
+        rulesSchema = {
           ...context?.validationRules?.Number,
         }
         break
       case PrimitiveTypeKind.Integer:
-        validation = {
+        rulesSchema = {
           ...context?.validationRules?.Integer,
+        }
+        break
+      case PrimitiveTypeKind.Boolean:
+        rulesSchema = {
+          default: false,
         }
         break
     }
 
     return {
       type: primitives[type.primitiveKind],
-      ...validation,
+      ...rulesSchema,
       ...extra,
-      default: primitivesDefaults[type.primitiveKind],
     }
   }
 

--- a/libs/frontend/domain/type/src/interface-form/ui-properties/primativeUiProperties.ts
+++ b/libs/frontend/domain/type/src/interface-form/ui-properties/primativeUiProperties.ts
@@ -1,4 +1,4 @@
-import type { IAnyType, IPrimitiveType } from '@codelab/frontend/abstract/core'
+import type { IPrimitiveType } from '@codelab/frontend/abstract/core'
 import {
   CodeMirrorField,
   ToggleExpressionField,
@@ -7,9 +7,9 @@ import { IPrimitiveTypeKind } from '@codelab/shared/abstract/core'
 import type { UiPropertiesFn } from '../types'
 
 export const primitiveTypeUiProperties: UiPropertiesFn<IPrimitiveType> = (
-  type: IAnyType,
+  type,
 ) => {
-  if (type.name === IPrimitiveTypeKind.String) {
+  if (type.primitiveKind === IPrimitiveTypeKind.String) {
     return {
       uniforms: {
         component: CodeMirrorField(),

--- a/libs/frontend/domain/type/src/store/tests/schema.data.ts
+++ b/libs/frontend/domain/type/src/store/tests/schema.data.ts
@@ -2,9 +2,9 @@
 import merge from 'lodash/merge'
 import { intType, stringType } from './setup-store'
 
-export const stringTypeExpectedSchema = { type: 'string', default: '' }
+export const stringTypeExpectedSchema = { type: 'string' }
 
-export const intTypeExpectedSchema = { type: 'integer', default: 0 }
+export const intTypeExpectedSchema = { type: 'integer' }
 
 export const unionTypeExpectedSchema = {
   oneOf: [

--- a/libs/frontend/domain/type/src/use-cases/fields/create-field/CreateFieldModal.tsx
+++ b/libs/frontend/domain/type/src/use-cases/fields/create-field/CreateFieldModal.tsx
@@ -16,6 +16,7 @@ import { TypeSelect } from '../../../shared'
 import { createFieldSchema } from './createFieldSchema'
 import {
   filterValidationRules,
+  isBoolean,
   isFloat,
   isInteger,
   isInterfaceType,
@@ -76,7 +77,14 @@ export const CreateFieldModal = observer<CreateFieldModalProps>(
             ]}
           />
           <TypeSelect label="Type" name="fieldType" />
-          <AutoFields fields={['validationRules.general']} />
+          <DisplayIfField<ICreateFieldDTO>
+            condition={({ model }) =>
+              Boolean(model.fieldType) &&
+              !isBoolean(typeService, model.fieldType)
+            }
+          >
+            <AutoFields fields={['validationRules.general']} />
+          </DisplayIfField>
           <DisplayIfField<ICreateFieldDTO>
             condition={({ model }) => isPrimitive(typeService, model.fieldType)}
           >

--- a/libs/frontend/domain/type/src/use-cases/fields/create-field/createFieldSchema.ts
+++ b/libs/frontend/domain/type/src/use-cases/fields/create-field/createFieldSchema.ts
@@ -36,6 +36,7 @@ export const createFieldSchema: JSONSchemaType<ICreateFieldDTO> = {
             [GeneralValidationRules.Nullable]: {
               type: 'boolean',
               nullable: true,
+              default: false,
             },
           },
         },
@@ -126,5 +127,21 @@ export const createFieldSchema: JSONSchemaType<ICreateFieldDTO> = {
       $ref: 'customTypes#/definitions/fieldDefaultValues',
     },
   },
+  // This is overridden if the field is not nullable, which will require a value for `defaultValues`
   required: ['id', 'key', 'fieldType'],
+  if: {
+    properties: {
+      validationRules: {
+        properties: {
+          general: {
+            properties: {
+              // Using enum, we can check if it matches the current value in the form
+              [GeneralValidationRules.Nullable]: { enum: [false] },
+            },
+          },
+        },
+      },
+    },
+  },
+  then: { required: ['id', 'key', 'fieldType', 'defaultValues'] },
 }

--- a/libs/frontend/domain/type/src/use-cases/types/get-types/tables/FieldsTable.tsx
+++ b/libs/frontend/domain/type/src/use-cases/types/get-types/tables/FieldsTable.tsx
@@ -12,6 +12,7 @@ import {
 import { ITypeKind } from '@codelab/shared/abstract/core'
 import { Divider, Space, Table, Tag } from 'antd'
 import type { ColumnProps } from 'antd/lib/table/Column'
+import isNil from 'lodash/isNil'
 import { Observer, observer } from 'mobx-react-lite'
 import React from 'react'
 import tw from 'twin.macro'
@@ -105,8 +106,16 @@ export const FieldsTable = observer<FieldsTableProps>(
         dataIndex: 'defaultValues',
         key: 'defaultValues',
         onHeaderCell: headerCellProps,
-        render: () => {
-          return <div>value</div>
+        render: (_, record) => {
+          const field = interfaceType.fields.find(
+            ({ key }) => key === record.key,
+          )
+
+          const showValue =
+            record.type?.kind === ITypeKind.PrimitiveType &&
+            !isNil(field?.defaultValues)
+
+          return showValue ? <div>{String(field?.defaultValues)}</div> : ''
         },
       },
       {

--- a/libs/frontend/view/components/form/fields/CodeMirrorField.tsx
+++ b/libs/frontend/view/components/form/fields/CodeMirrorField.tsx
@@ -1,4 +1,5 @@
 import { Form } from 'antd'
+import isNil from 'lodash/isNil'
 import type { Ref } from 'react'
 import React from 'react'
 import type { FieldProps } from 'uniforms'
@@ -45,6 +46,11 @@ export const CodeMirrorField = (mainProps?: Partial<CodeMirrorFieldProps>) => {
          * currently, everything is interpreted as string
          */
 
+        // Will show blank if undefined instead of "undefined" string
+        const editorValue = !isNil(merged.value ?? merged.field?.default)
+          ? String(merged.value ?? merged.field?.default)
+          : undefined
+
         return (
           <Form.Item label={baseProps.label ?? ''}>
             <CodeMirrorEditor
@@ -53,7 +59,7 @@ export const CodeMirrorField = (mainProps?: Partial<CodeMirrorFieldProps>) => {
               // eslint-disable-next-line react/jsx-props-no-spreading
               {...merged}
               onChange={onChange}
-              value={String(merged.value || merged.field?.default)}
+              value={editorValue}
             />
           </Form.Item>
         )

--- a/libs/frontend/view/components/form/fields/ToggleExpressionField.tsx
+++ b/libs/frontend/view/components/form/fields/ToggleExpressionField.tsx
@@ -5,6 +5,7 @@ import { css } from '@emotion/react'
 import type { EmotionJSX } from '@emotion/react/types/jsx-namespace'
 import type { AutoCompleteProps } from 'antd'
 import { Button, Space, Tooltip } from 'antd'
+import isNil from 'lodash/isNil'
 import React, { useState } from 'react'
 import tw from 'twin.macro'
 import type { FieldProps } from 'uniforms'
@@ -75,8 +76,13 @@ const ToggleExpression = ({
   fieldProps,
 }: ToggleExpressionFieldProps) => {
   const { allowExpressions, appStore } = useFormContext()
-  const value = String(fieldProps.value ?? fieldProps.field.default)
-  const isExpression = hasStateExpression(value)
+
+  // Will show blank if undefined instead of "undefined" string
+  const value = !isNil(fieldProps.value ?? fieldProps.field?.default)
+    ? String(fieldProps.value ?? fieldProps.field?.default)
+    : undefined
+
+  const isExpression = value && hasStateExpression(value)
   const [showExpressionEditor, setShowExpressionEditor] = useState(isExpression)
   const [valueBeforeToggle, setValueBeforeToggle] = useState<Value>()
 


### PR DESCRIPTION
<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(libs-ui-component): must begin with lowercase` -->

## Description

<!-- This is a short description on the Pull Request -->
This PR is for validating the edited props in the props inspector with the Element's atom/component interfaceType. The validator is created when props inspector is mounted and will use the selected element's interfaceType to generate the schema to be used for the validation against the editable props.

Also moved [this](https://github.com/codelab-app/platform/pull/2250/files#diff-5dbea52d1684a4f6c0b3927d9494c9298debec9fdedf981a37957d7e4570fa09L44) out of `ref` so that when it is updated, it automatically re-renders the props form with the new values


This PR also includes updating the `defaultValues` field so that if the `nullable` for the prop is not true, it will require the `defaultValues` and will display an error if not provided. The `nullable` field is also hidden when the type is Boolean and it will be default to `false`. The default values for the primitives are also removed so that if the field is nullable and currently has a null value, there will be no value displayed in the field.

Also updated the Default cell on the fields table so that it shows the default values (for primitives only)


## Video or Image

<!-- Add video or image showing how the new feature works -->
In this video, I tested validation against atom/component props

https://user-images.githubusercontent.com/27695022/217552289-38ddf1a2-4b83-43e9-81a4-2050e62856d5.mp4

<br />
In this video, I tested the nullable defaultValues for the primitive props. The old behaviour is that there will always be a default value even if the prop is nullable

https://user-images.githubusercontent.com/27695022/218710649-71d686f9-2eaf-42e7-87fe-ee4c8c55de18.mp4

<br />

Showing defaults on the fields table
![image](https://user-images.githubusercontent.com/27695022/219104632-737fc35b-31ca-450d-8d90-2e214e8427ed.png)


## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged -->

Fixes #2229 
