### PR TITLE
fix: children of component instance not rendered (part 1)

### DIFF
--- a/libs/frontend/abstract/core/src/domain/component/component.model.interface.ts
+++ b/libs/frontend/abstract/core/src/domain/component/component.model.interface.ts
@@ -26,6 +26,7 @@ export interface IComponent
   sourceComponentId?: Nullable<string>
   setSourceComponentId: (id: string) => void
   setInstanceElement: (elementRef: Ref<IElement>) => void
+  setChildrenContainerElementId: (id: string) => void
   setProps(t: Nullable<IProp>): void
   clone(instanceId: string): IComponent
 }

--- a/libs/frontend/domain/element/src/store/element.model.ts
+++ b/libs/frontend/domain/element/src/store/element.model.ts
@@ -168,7 +168,7 @@ export class Element
 
   @computed
   get rootElement(): IElement {
-    return this.parentElement ? this.parentElement : this
+    return this.parentElement ? this.parentElement.rootElement : this
   }
 
   @computed


### PR DESCRIPTION
<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(libs-ui-component): must begin with lowercase` -->

## Description
- Component children were not rendered because the clone id never matched the container id.
This is the first issue fixed under #2258. (see video in issue)

- Component props are not passed to child elements
This is the second issue fixed under #2258. (see video in issue)


## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged -->

Fixes #2258
