### PR TITLE
fix: cloned element id is being overwritten causing the props in config to keep loading

### DIFF
--- a/libs/frontend/domain/element/src/store/element.service.ts
+++ b/libs/frontend/domain/element/src/store/element.service.ts
@@ -1017,6 +1017,8 @@ element is new parentElement's first child
       .map((element) =>
         element.writeCache({
           ...elementFragment,
+          // keep the cloned element's id
+          id: element.id,
           parentComponent: element.parentComponent?.current
             ? ({
                 id: element.parentComponent.current.id,


### PR DESCRIPTION
<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(libs-ui-component): must begin with lowercase` -->

## Description

<!-- This is a short description on the Pull Request -->
This fixes the bug where if the element props on the component's descendants get updated, the config pane will keep loading for the descendants.

Turns out, the cloned elements' ids are being overwritten when the real element is updated and somehow messes up the getting of active element tree for the selected node because the refs for the actual element will be faulty [here](https://github.com/codelab-app/platform/blob/50cae3fe053102f6908ec313d15bee7639fac514/libs/frontend/domain/element/src/store/element.model.ts#L111)

## Video or Image

<!-- Add video or image showing how the new feature works -->

In this video, im testing if the config pane will still keep loading when the descendant element props are being updated (due to the autosave happening currently when selecting a node)

https://user-images.githubusercontent.com/27695022/219381935-a7533697-2eb2-4d7c-bc84-92eb570a4261.mp4



## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged -->

Fixes #2254 
