### PR TITLE
1817 atom required parent validation

### DIFF
--- a/libs/backend/infra/adapter/neo4j/src/schema/model/atom.schema.ts
+++ b/libs/backend/infra/adapter/neo4j/src/schema/model/atom.schema.ts
@@ -17,6 +17,7 @@ export const atomSchema = gql`
     icon: String
     allowedChildren: [Atom!]!
       @relationship(type: "ALLOWED_CHILDREN", direction: OUT)
+    requiredParent: Atom @relationship(type: "REQUIRED_PARENT", direction: OUT)
   }
 
   extend type Atom

--- a/libs/backend/infra/adapter/neo4j/src/selectionSets/atomSelectionSet.ts
+++ b/libs/backend/infra/adapter/neo4j/src/selectionSets/atomSelectionSet.ts
@@ -16,4 +16,9 @@ export const atomSelectionSet = `{
     name
     type
   }
+  requiredParent {
+    id
+    name
+    type
+  }
 }`

--- a/libs/frontend/abstract/core/src/domain/atom/atom.dto.interface.ts
+++ b/libs/frontend/abstract/core/src/domain/atom/atom.dto.interface.ts
@@ -1,4 +1,5 @@
 import type { IAtomType } from '@codelab/shared/abstract/core'
+import type { Nullish } from '@codelab/shared/abstract/types'
 import type { ITagRef } from '../tag'
 import type { IInterfaceTypeRef } from '../type'
 import type { IAuth0Id } from '../user'
@@ -22,7 +23,7 @@ export interface ICreateAtomDTO {
   // Allow for connection to existing interface
   api?: IInterfaceTypeRef | undefined
   allowedChildren?: Array<IAtomRef>
-  requiredParent?: IAtomRef
+  requiredParent?: Nullish<IAtomRef>
 }
 
 export type IUpdateAtomDTO = Omit<ICreateAtomDTO, 'owner'>

--- a/libs/frontend/abstract/core/src/domain/atom/atom.dto.interface.ts
+++ b/libs/frontend/abstract/core/src/domain/atom/atom.dto.interface.ts
@@ -22,6 +22,7 @@ export interface ICreateAtomDTO {
   // Allow for connection to existing interface
   api?: IInterfaceTypeRef | undefined
   allowedChildren?: Array<IAtomRef>
+  requiredParent?: IAtomRef
 }
 
 export type IUpdateAtomDTO = Omit<ICreateAtomDTO, 'owner'>

--- a/libs/frontend/abstract/core/src/domain/atom/atom.fragment.graphql
+++ b/libs/frontend/abstract/core/src/domain/atom/atom.fragment.graphql
@@ -15,6 +15,11 @@ fragment Atom on Atom {
     name
     type
   }
+  requiredParent {
+    id
+    name
+    type
+  }
 }
 
 fragment RenderAtom on Atom {
@@ -30,6 +35,11 @@ fragment RenderAtom on Atom {
     name
   }
   allowedChildren {
+    id
+    name
+    type
+  }
+  requiredParent {
     id
     name
     type

--- a/libs/frontend/abstract/core/src/domain/atom/atom.fragment.graphql.gen.ts
+++ b/libs/frontend/abstract/core/src/domain/atom/atom.fragment.graphql.gen.ts
@@ -19,6 +19,7 @@ export type AtomFragment = {
   tags: Array<TagFragment>
   api: { id: string; name: string }
   allowedChildren: Array<{ id: string; name: string; type: Types.AtomType }>
+  requiredParent?: { id: string; name: string; type: Types.AtomType } | null
 }
 
 export type RenderAtomFragment = {
@@ -29,6 +30,7 @@ export type RenderAtomFragment = {
   tags: Array<TagPreviewFragment>
   api: { id: string; name: string }
   allowedChildren: Array<{ id: string; name: string; type: Types.AtomType }>
+  requiredParent?: { id: string; name: string; type: Types.AtomType } | null
 }
 
 export const AtomFragmentDoc = gql`
@@ -45,6 +47,11 @@ export const AtomFragmentDoc = gql`
       name
     }
     allowedChildren {
+      id
+      name
+      type
+    }
+    requiredParent {
       id
       name
       type
@@ -66,6 +73,11 @@ export const RenderAtomFragmentDoc = gql`
       name
     }
     allowedChildren {
+      id
+      name
+      type
+    }
+    requiredParent {
       id
       name
       type

--- a/libs/frontend/abstract/core/src/domain/atom/atom.model.interface.ts
+++ b/libs/frontend/abstract/core/src/domain/atom/atom.model.interface.ts
@@ -19,7 +19,7 @@ export interface IAtom extends IEntity, ICacheService<IAtomDTO, IAtom> {
    * We store preview data here so we can more easily display the tags in the atoms table
    */
   allowedChildren: Array<Pick<IAtomDTO, 'id' | 'name'>>
-  requiredParent: Pick<IAtomDTO, 'id' | 'name'>
+  requiredParent: Nullish<Pick<IAtomDTO, 'id' | 'name'>>
 }
 
 export type IAtomRef = string

--- a/libs/frontend/abstract/core/src/domain/atom/atom.model.interface.ts
+++ b/libs/frontend/abstract/core/src/domain/atom/atom.model.interface.ts
@@ -19,6 +19,7 @@ export interface IAtom extends IEntity, ICacheService<IAtomDTO, IAtom> {
    * We store preview data here so we can more easily display the tags in the atoms table
    */
   allowedChildren: Array<Pick<IAtomDTO, 'id' | 'name'>>
+  requiredParent: Pick<IAtomDTO, 'id' | 'name'>
 }
 
 export type IAtomRef = string

--- a/libs/frontend/domain/atom/src/store/atom.model.ts
+++ b/libs/frontend/domain/atom/src/store/atom.model.ts
@@ -4,6 +4,7 @@ import { tagRef } from '@codelab/frontend/domain/tag'
 import type { InterfaceType } from '@codelab/frontend/domain/type'
 import { typeRef } from '@codelab/frontend/domain/type'
 import type { IAtomType } from '@codelab/shared/abstract/core'
+import { Nullish } from '@codelab/shared/abstract/types'
 import { computed } from 'mobx'
 import type { Ref } from 'mobx-keystone'
 import {
@@ -26,6 +27,7 @@ const hydrate = (atom: IAtomDTO) => {
     api: typeRef(atom.api.id) as Ref<InterfaceType>,
     tags: atom.tags.map((tag) => tagRef(tag.id)),
     allowedChildren: atom.allowedChildren,
+    requiredParent: atom.requiredParent,
   })
 }
 
@@ -39,6 +41,7 @@ export class Atom
     tags: prop<Array<Ref<ITag>>>(() => []),
     api: prop<Ref<InterfaceType>>(),
     allowedChildren: prop<Array<Pick<IAtomDTO, 'id' | 'name'>>>(() => []),
+    requiredParent: prop<Nullish<Pick<IAtom, 'id' | 'name'>>>(),
   })
   implements IAtom
 {
@@ -61,6 +64,7 @@ export class Atom
     this.tags = atom.tags.map((tag) => tagRef(tag.id))
     this.icon = atom.icon
     this.allowedChildren = atom.allowedChildren
+    this.requiredParent = atom.requiredParent
 
     return this
   }

--- a/libs/frontend/domain/atom/src/store/atom.service.ts
+++ b/libs/frontend/domain/atom/src/store/atom.service.ts
@@ -8,7 +8,12 @@ import { IAtomDTO } from '@codelab/frontend/abstract/core'
 import { getTagService } from '@codelab/frontend/domain/tag'
 import { ModalService } from '@codelab/frontend/shared/utils'
 import type { AtomOptions, AtomWhere } from '@codelab/shared/abstract/codegen'
-import { connectNode, connectOwner, reconnectNodes } from '@codelab/shared/data'
+import {
+  connectNode,
+  connectOwner,
+  reconnectNode,
+  reconnectNodes,
+} from '@codelab/shared/data'
 import { computed } from 'mobx'
 import {
   _async,
@@ -47,7 +52,13 @@ export class AtomService
   update = _async(function* (
     this: AtomService,
     existingAtom: IAtom,
-    { name, type, tags = [], allowedChildren = [] }: IUpdateAtomDTO,
+    {
+      name,
+      type,
+      tags = [],
+      allowedChildren = [],
+      requiredParent,
+    }: IUpdateAtomDTO,
   ) {
     const allowedChildrenIds = allowedChildren.map(
       (allowedChild) => allowedChild,
@@ -61,6 +72,7 @@ export class AtomService
           name,
           type,
           allowedChildren: [reconnectNodes(allowedChildrenIds)],
+          requiredParent: reconnectNode(requiredParent),
           tags: [reconnectNodes(tags)],
         },
         where: { id: existingAtom.id },

--- a/libs/frontend/domain/atom/src/use-cases/create-atom/createAtomSchema.ts
+++ b/libs/frontend/domain/atom/src/use-cases/create-atom/createAtomSchema.ts
@@ -53,6 +53,11 @@ export const createAtomSchema: JSONSchemaType<ICreateAtomDTO> = {
       nullable: true,
       showSearch: true,
     },
+    requiredParent: {
+      type: 'string',
+      nullable: true,
+      showSearch: true,
+    },
   },
   required: ['name', 'type', 'owner'],
 } as const

--- a/libs/frontend/domain/atom/src/use-cases/get-atoms/GetAtomsTable.tsx
+++ b/libs/frontend/domain/atom/src/use-cases/get-atoms/GetAtomsTable.tsx
@@ -84,6 +84,7 @@ export const GetAtomsTable = observer<GetAtomsTableProps>(
         tags: atom.tags.map((tag) => tag.current),
         library: getAtomLibrary(atom.type),
         allowedChildren: atom.allowedChildren,
+        requiredParent: atom.requiredParent,
       }))
 
     return (

--- a/libs/frontend/domain/atom/src/use-cases/get-atoms/columns/RequiredParentColumn.tsx
+++ b/libs/frontend/domain/atom/src/use-cases/get-atoms/columns/RequiredParentColumn.tsx
@@ -1,0 +1,10 @@
+import React from 'react'
+import { Tag } from 'antd'
+
+import type { AtomRecord } from './types'
+
+export const RequiredParentColumn = ({
+  requiredParent,
+}: Pick<AtomRecord, 'requiredParent'>) => {
+  return <Tag color="green">{requiredParent?.name}</Tag>
+}

--- a/libs/frontend/domain/atom/src/use-cases/get-atoms/columns/index.ts
+++ b/libs/frontend/domain/atom/src/use-cases/get-atoms/columns/index.ts
@@ -1,5 +1,7 @@
 export * from './ActionColumn'
+export * from './AllowedChildrenColumn'
 export * from './LibraryColumn'
 export * from './PropsColumn'
+export * from './RequiredParentColumn'
 export * from './TagsColumn'
 export * from './types'

--- a/libs/frontend/domain/atom/src/use-cases/get-atoms/columns/types.ts
+++ b/libs/frontend/domain/atom/src/use-cases/get-atoms/columns/types.ts
@@ -7,6 +7,7 @@ import type {
   ITypeService,
 } from '@codelab/frontend/abstract/core'
 import type { IAtomType } from '@codelab/shared/abstract/core'
+import type { Nullish } from '@codelab/shared/abstract/types'
 
 export interface AtomLibrary {
   name: string
@@ -21,6 +22,7 @@ export interface AtomRecord {
   apiId: IInterfaceTypeRef
   library: AtomLibrary
   allowedChildren: Array<Pick<IAtomDTO, 'id' | 'name'>>
+  requiredParent: Nullish<Pick<IAtomDTO, 'id' | 'name'>>
 }
 
 export type ActionColumnProps = {

--- a/libs/frontend/domain/atom/src/use-cases/get-atoms/useAtomTable.tsx
+++ b/libs/frontend/domain/atom/src/use-cases/get-atoms/useAtomTable.tsx
@@ -16,8 +16,14 @@ import debounce from 'lodash/debounce'
 import isEqual from 'lodash/isEqual'
 import { arraySet } from 'mobx-keystone'
 import React, { useCallback, useState } from 'react'
-import { ActionColumn, LibraryColumn, PropsColumn, TagsColumn } from './columns'
-import { AllowedChildrenColumn } from './columns/AllowedChildrenColumn'
+import {
+  ActionColumn,
+  AllowedChildrenColumn,
+  LibraryColumn,
+  PropsColumn,
+  RequiredParentColumn,
+  TagsColumn,
+} from './columns'
 import type { AtomRecord } from './columns/types'
 
 const onLibraryFilter = (
@@ -98,12 +104,21 @@ export const useAtomTable = ({
       render: (tags) => <TagsColumn tags={tags} />,
     },
     {
-      title: 'Allowed',
+      title: 'Allowed Children',
       dataIndex: 'allowedChildren',
       key: 'allowedChildren',
       onHeaderCell: headerCellProps,
       render: (allowedChildren) => {
         return <AllowedChildrenColumn allowedChildren={allowedChildren} />
+      },
+    },
+    {
+      title: 'Required Parent',
+      dataIndex: 'requiredParent',
+      key: 'requiredParent',
+      onHeaderCell: headerCellProps,
+      render: (requiredParent) => {
+        return <RequiredParentColumn requiredParent={requiredParent} />
       },
     },
     {

--- a/libs/frontend/domain/atom/src/use-cases/update-atom/UpdateAtomModal.tsx
+++ b/libs/frontend/domain/atom/src/use-cases/update-atom/UpdateAtomModal.tsx
@@ -37,6 +37,7 @@ export const UpdateAtomModal = observer<{
     allowedChildren: atom?.allowedChildren.map(
       (allowedChild) => allowedChild.id,
     ),
+    requiredParent: atom?.requiredParent?.id,
   }
 
   const tagListOption = tagService.tagsSelectOptions
@@ -64,6 +65,7 @@ export const UpdateAtomModal = observer<{
           showSearch={true}
         />
         <SelectAtom label="Allowed Children" name="allowedChildren" />
+        <SelectAtom label="Required Parent" name="requiredParent" />
         {/* <SelectField */}
         {/*  label="Allowed Children" */}
         {/*  mode="multiple" */}

--- a/libs/frontend/domain/atom/src/use-cases/update-atom/updateAtomSchema.ts
+++ b/libs/frontend/domain/atom/src/use-cases/update-atom/updateAtomSchema.ts
@@ -48,6 +48,11 @@ export const updateAtomSchema: JSONSchemaType<IUpdateAtomDTO> = {
       nullable: true,
       showSearch: true,
     },
+    requiredParent: {
+      type: 'string',
+      nullable: true,
+      showSearch: true,
+    },
   },
   required: ['name', 'type'],
 } as const

--- a/libs/shared/abstract/codegen/src/ogm-types.gen.ts
+++ b/libs/shared/abstract/codegen/src/ogm-types.gen.ts
@@ -107,6 +107,9 @@ export type Query = {
   props: Array<Prop>
   propsAggregate: PropAggregateSelection
   propsConnection: PropsConnection
+  propMapBindings: Array<PropMapBinding>
+  propMapBindingsAggregate: PropMapBindingAggregateSelection
+  propMapBindingsConnection: PropMapBindingsConnection
   hooks: Array<Hook>
   hooksAggregate: HookAggregateSelection
   hooksConnection: HooksConnection
@@ -578,6 +581,22 @@ export type QueryPropsConnectionArgs = {
   sort?: InputMaybe<Array<InputMaybe<PropSort>>>
 }
 
+export type QueryPropMapBindingsArgs = {
+  where?: InputMaybe<PropMapBindingWhere>
+  options?: InputMaybe<PropMapBindingOptions>
+}
+
+export type QueryPropMapBindingsAggregateArgs = {
+  where?: InputMaybe<PropMapBindingWhere>
+}
+
+export type QueryPropMapBindingsConnectionArgs = {
+  first?: InputMaybe<Scalars['Int']>
+  after?: InputMaybe<Scalars['String']>
+  where?: InputMaybe<PropMapBindingWhere>
+  sort?: InputMaybe<Array<InputMaybe<PropMapBindingSort>>>
+}
+
 export type QueryHooksArgs = {
   where?: InputMaybe<HookWhere>
   options?: InputMaybe<HookOptions>
@@ -833,6 +852,9 @@ export type Mutation = {
   createProps: CreatePropsMutationResponse
   deleteProps: DeleteInfo
   updateProps: UpdatePropsMutationResponse
+  createPropMapBindings: CreatePropMapBindingsMutationResponse
+  deletePropMapBindings: DeleteInfo
+  updatePropMapBindings: UpdatePropMapBindingsMutationResponse
   createHooks: CreateHooksMutationResponse
   deleteHooks: DeleteInfo
   updateHooks: UpdateHooksMutationResponse
@@ -1363,6 +1385,25 @@ export type MutationDeletePropsArgs = {
 export type MutationUpdatePropsArgs = {
   where?: InputMaybe<PropWhere>
   update?: InputMaybe<PropUpdateInput>
+}
+
+export type MutationCreatePropMapBindingsArgs = {
+  input: Array<PropMapBindingCreateInput>
+}
+
+export type MutationDeletePropMapBindingsArgs = {
+  where?: InputMaybe<PropMapBindingWhere>
+  delete?: InputMaybe<PropMapBindingDeleteInput>
+}
+
+export type MutationUpdatePropMapBindingsArgs = {
+  where?: InputMaybe<PropMapBindingWhere>
+  update?: InputMaybe<PropMapBindingUpdateInput>
+  connect?: InputMaybe<PropMapBindingConnectInput>
+  disconnect?: InputMaybe<PropMapBindingDisconnectInput>
+  create?: InputMaybe<PropMapBindingRelationInput>
+  delete?: InputMaybe<PropMapBindingDeleteInput>
+  connectOrCreate?: InputMaybe<PropMapBindingConnectOrCreateInput>
 }
 
 export type MutationCreateHooksArgs = {
@@ -3509,6 +3550,12 @@ export type CreatePrimitiveTypesMutationResponse = {
   primitiveTypes: Array<PrimitiveType>
 }
 
+export type CreatePropMapBindingsMutationResponse = {
+  __typename?: 'CreatePropMapBindingsMutationResponse'
+  info: CreateInfo
+  propMapBindings: Array<PropMapBinding>
+}
+
 export type CreatePropsMutationResponse = {
   __typename?: 'CreatePropsMutationResponse'
   info: CreateInfo
@@ -3718,6 +3765,8 @@ export type Element = {
   renderAtomTypeAggregate?: Maybe<ElementAtomRenderAtomTypeAggregationSelection>
   hooks: Array<Hook>
   hooksAggregate?: Maybe<ElementHookHooksAggregationSelection>
+  propMapBindings: Array<PropMapBinding>
+  propMapBindingsAggregate?: Maybe<ElementPropMapBindingPropMapBindingsAggregationSelection>
   nextSiblingConnection: ElementNextSiblingConnection
   prevSiblingConnection: ElementPrevSiblingConnection
   firstChildConnection: ElementFirstChildConnection
@@ -3728,6 +3777,7 @@ export type Element = {
   renderComponentTypeConnection: ElementRenderComponentTypeConnection
   renderAtomTypeConnection: ElementRenderAtomTypeConnection
   hooksConnection: ElementHooksConnection
+  propMapBindingsConnection: ElementPropMapBindingsConnection
 }
 
 export type ElementNextSiblingArgs = {
@@ -3840,6 +3890,17 @@ export type ElementHooksAggregateArgs = {
   directed?: InputMaybe<Scalars['Boolean']>
 }
 
+export type ElementPropMapBindingsArgs = {
+  where?: InputMaybe<PropMapBindingWhere>
+  options?: InputMaybe<PropMapBindingOptions>
+  directed?: InputMaybe<Scalars['Boolean']>
+}
+
+export type ElementPropMapBindingsAggregateArgs = {
+  where?: InputMaybe<PropMapBindingWhere>
+  directed?: InputMaybe<Scalars['Boolean']>
+}
+
 export type ElementNextSiblingConnectionArgs = {
   where?: InputMaybe<ElementNextSiblingConnectionWhere>
   first?: InputMaybe<Scalars['Int']>
@@ -3918,6 +3979,14 @@ export type ElementHooksConnectionArgs = {
   after?: InputMaybe<Scalars['String']>
   directed?: InputMaybe<Scalars['Boolean']>
   sort?: InputMaybe<Array<ElementHooksConnectionSort>>
+}
+
+export type ElementPropMapBindingsConnectionArgs = {
+  where?: InputMaybe<ElementPropMapBindingsConnectionWhere>
+  first?: InputMaybe<Scalars['Int']>
+  after?: InputMaybe<Scalars['String']>
+  directed?: InputMaybe<Scalars['Boolean']>
+  sort?: InputMaybe<Array<ElementPropMapBindingsConnectionSort>>
 }
 
 export type ElementAggregateSelection = {
@@ -4172,6 +4241,32 @@ export type ElementPrevSiblingRelationship = {
   __typename?: 'ElementPrevSiblingRelationship'
   cursor: Scalars['String']
   node: Element
+}
+
+export type ElementPropMapBindingPropMapBindingsAggregationSelection = {
+  __typename?: 'ElementPropMapBindingPropMapBindingsAggregationSelection'
+  count: Scalars['Int']
+  node?: Maybe<ElementPropMapBindingPropMapBindingsNodeAggregateSelection>
+}
+
+export type ElementPropMapBindingPropMapBindingsNodeAggregateSelection = {
+  __typename?: 'ElementPropMapBindingPropMapBindingsNodeAggregateSelection'
+  id: IdAggregateSelectionNonNullable
+  sourceKey: StringAggregateSelectionNonNullable
+  targetKey: StringAggregateSelectionNonNullable
+}
+
+export type ElementPropMapBindingsConnection = {
+  __typename?: 'ElementPropMapBindingsConnection'
+  edges: Array<ElementPropMapBindingsRelationship>
+  totalCount: Scalars['Int']
+  pageInfo: PageInfo
+}
+
+export type ElementPropMapBindingsRelationship = {
+  __typename?: 'ElementPropMapBindingsRelationship'
+  cursor: Scalars['String']
+  node: PropMapBinding
 }
 
 export type ElementPropPropsAggregationSelection = {
@@ -5440,6 +5535,144 @@ export type PropEdge = {
   node: Prop
 }
 
+export type PropMapBinding = {
+  __typename?: 'PropMapBinding'
+  id: Scalars['ID']
+  sourceKey: Scalars['String']
+  targetKey: Scalars['String']
+  element: Element
+  elementAggregate?: Maybe<PropMapBindingElementElementAggregationSelection>
+  targetElement?: Maybe<Element>
+  targetElementAggregate?: Maybe<PropMapBindingElementTargetElementAggregationSelection>
+  elementConnection: PropMapBindingElementConnection
+  targetElementConnection: PropMapBindingTargetElementConnection
+}
+
+export type PropMapBindingElementArgs = {
+  where?: InputMaybe<ElementWhere>
+  options?: InputMaybe<ElementOptions>
+  directed?: InputMaybe<Scalars['Boolean']>
+}
+
+export type PropMapBindingElementAggregateArgs = {
+  where?: InputMaybe<ElementWhere>
+  directed?: InputMaybe<Scalars['Boolean']>
+}
+
+export type PropMapBindingTargetElementArgs = {
+  where?: InputMaybe<ElementWhere>
+  options?: InputMaybe<ElementOptions>
+  directed?: InputMaybe<Scalars['Boolean']>
+}
+
+export type PropMapBindingTargetElementAggregateArgs = {
+  where?: InputMaybe<ElementWhere>
+  directed?: InputMaybe<Scalars['Boolean']>
+}
+
+export type PropMapBindingElementConnectionArgs = {
+  where?: InputMaybe<PropMapBindingElementConnectionWhere>
+  first?: InputMaybe<Scalars['Int']>
+  after?: InputMaybe<Scalars['String']>
+  directed?: InputMaybe<Scalars['Boolean']>
+  sort?: InputMaybe<Array<PropMapBindingElementConnectionSort>>
+}
+
+export type PropMapBindingTargetElementConnectionArgs = {
+  where?: InputMaybe<PropMapBindingTargetElementConnectionWhere>
+  first?: InputMaybe<Scalars['Int']>
+  after?: InputMaybe<Scalars['String']>
+  directed?: InputMaybe<Scalars['Boolean']>
+  sort?: InputMaybe<Array<PropMapBindingTargetElementConnectionSort>>
+}
+
+export type PropMapBindingAggregateSelection = {
+  __typename?: 'PropMapBindingAggregateSelection'
+  count: Scalars['Int']
+  id: IdAggregateSelectionNonNullable
+  sourceKey: StringAggregateSelectionNonNullable
+  targetKey: StringAggregateSelectionNonNullable
+}
+
+export type PropMapBindingEdge = {
+  __typename?: 'PropMapBindingEdge'
+  cursor: Scalars['String']
+  node: PropMapBinding
+}
+
+export type PropMapBindingElementConnection = {
+  __typename?: 'PropMapBindingElementConnection'
+  edges: Array<PropMapBindingElementRelationship>
+  totalCount: Scalars['Int']
+  pageInfo: PageInfo
+}
+
+export type PropMapBindingElementElementAggregationSelection = {
+  __typename?: 'PropMapBindingElementElementAggregationSelection'
+  count: Scalars['Int']
+  node?: Maybe<PropMapBindingElementElementNodeAggregateSelection>
+}
+
+export type PropMapBindingElementElementNodeAggregateSelection = {
+  __typename?: 'PropMapBindingElementElementNodeAggregateSelection'
+  id: IdAggregateSelectionNonNullable
+  slug: StringAggregateSelectionNonNullable
+  name: StringAggregateSelectionNullable
+  customCss: StringAggregateSelectionNullable
+  guiCss: StringAggregateSelectionNullable
+  propTransformationJs: StringAggregateSelectionNullable
+  renderForEachPropKey: StringAggregateSelectionNullable
+  renderIfExpression: StringAggregateSelectionNullable
+  preRenderActionId: StringAggregateSelectionNullable
+  postRenderActionId: StringAggregateSelectionNullable
+}
+
+export type PropMapBindingElementRelationship = {
+  __typename?: 'PropMapBindingElementRelationship'
+  cursor: Scalars['String']
+  node: Element
+}
+
+export type PropMapBindingElementTargetElementAggregationSelection = {
+  __typename?: 'PropMapBindingElementTargetElementAggregationSelection'
+  count: Scalars['Int']
+  node?: Maybe<PropMapBindingElementTargetElementNodeAggregateSelection>
+}
+
+export type PropMapBindingElementTargetElementNodeAggregateSelection = {
+  __typename?: 'PropMapBindingElementTargetElementNodeAggregateSelection'
+  id: IdAggregateSelectionNonNullable
+  slug: StringAggregateSelectionNonNullable
+  name: StringAggregateSelectionNullable
+  customCss: StringAggregateSelectionNullable
+  guiCss: StringAggregateSelectionNullable
+  propTransformationJs: StringAggregateSelectionNullable
+  renderForEachPropKey: StringAggregateSelectionNullable
+  renderIfExpression: StringAggregateSelectionNullable
+  preRenderActionId: StringAggregateSelectionNullable
+  postRenderActionId: StringAggregateSelectionNullable
+}
+
+export type PropMapBindingsConnection = {
+  __typename?: 'PropMapBindingsConnection'
+  totalCount: Scalars['Int']
+  pageInfo: PageInfo
+  edges: Array<PropMapBindingEdge>
+}
+
+export type PropMapBindingTargetElementConnection = {
+  __typename?: 'PropMapBindingTargetElementConnection'
+  edges: Array<PropMapBindingTargetElementRelationship>
+  totalCount: Scalars['Int']
+  pageInfo: PageInfo
+}
+
+export type PropMapBindingTargetElementRelationship = {
+  __typename?: 'PropMapBindingTargetElementRelationship'
+  cursor: Scalars['String']
+  node: Element
+}
+
 export type PropsConnection = {
   __typename?: 'PropsConnection'
   totalCount: Scalars['Int']
@@ -6406,6 +6639,12 @@ export type UpdatePrimitiveTypesMutationResponse = {
   __typename?: 'UpdatePrimitiveTypesMutationResponse'
   info: UpdateInfo
   primitiveTypes: Array<PrimitiveType>
+}
+
+export type UpdatePropMapBindingsMutationResponse = {
+  __typename?: 'UpdatePropMapBindingsMutationResponse'
+  info: UpdateInfo
+  propMapBindings: Array<PropMapBinding>
 }
 
 export type UpdatePropsMutationResponse = {
@@ -11829,6 +12068,7 @@ export type ElementConnectInput = {
   renderComponentType?: InputMaybe<ElementRenderComponentTypeConnectFieldInput>
   renderAtomType?: InputMaybe<ElementRenderAtomTypeConnectFieldInput>
   hooks?: InputMaybe<Array<ElementHooksConnectFieldInput>>
+  propMapBindings?: InputMaybe<Array<ElementPropMapBindingsConnectFieldInput>>
 }
 
 export type ElementConnectOrCreateInput = {
@@ -11842,6 +12082,9 @@ export type ElementConnectOrCreateInput = {
   renderComponentType?: InputMaybe<ElementRenderComponentTypeConnectOrCreateFieldInput>
   renderAtomType?: InputMaybe<ElementRenderAtomTypeConnectOrCreateFieldInput>
   hooks?: InputMaybe<Array<ElementHooksConnectOrCreateFieldInput>>
+  propMapBindings?: InputMaybe<
+    Array<ElementPropMapBindingsConnectOrCreateFieldInput>
+  >
 }
 
 export type ElementConnectOrCreateWhere = {
@@ -11873,6 +12116,7 @@ export type ElementCreateInput = {
   renderComponentType?: InputMaybe<ElementRenderComponentTypeFieldInput>
   renderAtomType?: InputMaybe<ElementRenderAtomTypeFieldInput>
   hooks?: InputMaybe<ElementHooksFieldInput>
+  propMapBindings?: InputMaybe<ElementPropMapBindingsFieldInput>
 }
 
 export type ElementDeleteInput = {
@@ -11886,6 +12130,7 @@ export type ElementDeleteInput = {
   renderComponentType?: InputMaybe<ElementRenderComponentTypeDeleteFieldInput>
   renderAtomType?: InputMaybe<ElementRenderAtomTypeDeleteFieldInput>
   hooks?: InputMaybe<Array<ElementHooksDeleteFieldInput>>
+  propMapBindings?: InputMaybe<Array<ElementPropMapBindingsDeleteFieldInput>>
 }
 
 export type ElementDisconnectInput = {
@@ -11899,6 +12144,9 @@ export type ElementDisconnectInput = {
   renderComponentType?: InputMaybe<ElementRenderComponentTypeDisconnectFieldInput>
   renderAtomType?: InputMaybe<ElementRenderAtomTypeDisconnectFieldInput>
   hooks?: InputMaybe<Array<ElementHooksDisconnectFieldInput>>
+  propMapBindings?: InputMaybe<
+    Array<ElementPropMapBindingsDisconnectFieldInput>
+  >
 }
 
 export type ElementFirstChildAggregateInput = {
@@ -13253,6 +13501,126 @@ export type ElementPrevSiblingUpdateFieldInput = {
   connectOrCreate?: InputMaybe<ElementPrevSiblingConnectOrCreateFieldInput>
 }
 
+export type ElementPropMapBindingsAggregateInput = {
+  count?: InputMaybe<Scalars['Int']>
+  count_LT?: InputMaybe<Scalars['Int']>
+  count_LTE?: InputMaybe<Scalars['Int']>
+  count_GT?: InputMaybe<Scalars['Int']>
+  count_GTE?: InputMaybe<Scalars['Int']>
+  AND?: InputMaybe<Array<ElementPropMapBindingsAggregateInput>>
+  OR?: InputMaybe<Array<ElementPropMapBindingsAggregateInput>>
+  node?: InputMaybe<ElementPropMapBindingsNodeAggregationWhereInput>
+}
+
+export type ElementPropMapBindingsConnectFieldInput = {
+  where?: InputMaybe<PropMapBindingConnectWhere>
+  connect?: InputMaybe<Array<PropMapBindingConnectInput>>
+}
+
+export type ElementPropMapBindingsConnectionSort = {
+  node?: InputMaybe<PropMapBindingSort>
+}
+
+export type ElementPropMapBindingsConnectionWhere = {
+  AND?: InputMaybe<Array<ElementPropMapBindingsConnectionWhere>>
+  OR?: InputMaybe<Array<ElementPropMapBindingsConnectionWhere>>
+  node?: InputMaybe<PropMapBindingWhere>
+  node_NOT?: InputMaybe<PropMapBindingWhere>
+}
+
+export type ElementPropMapBindingsConnectOrCreateFieldInput = {
+  where: PropMapBindingConnectOrCreateWhere
+  onCreate: ElementPropMapBindingsConnectOrCreateFieldInputOnCreate
+}
+
+export type ElementPropMapBindingsConnectOrCreateFieldInputOnCreate = {
+  node: PropMapBindingOnCreateInput
+}
+
+export type ElementPropMapBindingsCreateFieldInput = {
+  node: PropMapBindingCreateInput
+}
+
+export type ElementPropMapBindingsDeleteFieldInput = {
+  where?: InputMaybe<ElementPropMapBindingsConnectionWhere>
+  delete?: InputMaybe<PropMapBindingDeleteInput>
+}
+
+export type ElementPropMapBindingsDisconnectFieldInput = {
+  where?: InputMaybe<ElementPropMapBindingsConnectionWhere>
+  disconnect?: InputMaybe<PropMapBindingDisconnectInput>
+}
+
+export type ElementPropMapBindingsFieldInput = {
+  create?: InputMaybe<Array<ElementPropMapBindingsCreateFieldInput>>
+  connect?: InputMaybe<Array<ElementPropMapBindingsConnectFieldInput>>
+  connectOrCreate?: InputMaybe<
+    Array<ElementPropMapBindingsConnectOrCreateFieldInput>
+  >
+}
+
+export type ElementPropMapBindingsNodeAggregationWhereInput = {
+  AND?: InputMaybe<Array<ElementPropMapBindingsNodeAggregationWhereInput>>
+  OR?: InputMaybe<Array<ElementPropMapBindingsNodeAggregationWhereInput>>
+  id_EQUAL?: InputMaybe<Scalars['ID']>
+  sourceKey_EQUAL?: InputMaybe<Scalars['String']>
+  sourceKey_AVERAGE_EQUAL?: InputMaybe<Scalars['Float']>
+  sourceKey_LONGEST_EQUAL?: InputMaybe<Scalars['Int']>
+  sourceKey_SHORTEST_EQUAL?: InputMaybe<Scalars['Int']>
+  sourceKey_GT?: InputMaybe<Scalars['Int']>
+  sourceKey_AVERAGE_GT?: InputMaybe<Scalars['Float']>
+  sourceKey_LONGEST_GT?: InputMaybe<Scalars['Int']>
+  sourceKey_SHORTEST_GT?: InputMaybe<Scalars['Int']>
+  sourceKey_GTE?: InputMaybe<Scalars['Int']>
+  sourceKey_AVERAGE_GTE?: InputMaybe<Scalars['Float']>
+  sourceKey_LONGEST_GTE?: InputMaybe<Scalars['Int']>
+  sourceKey_SHORTEST_GTE?: InputMaybe<Scalars['Int']>
+  sourceKey_LT?: InputMaybe<Scalars['Int']>
+  sourceKey_AVERAGE_LT?: InputMaybe<Scalars['Float']>
+  sourceKey_LONGEST_LT?: InputMaybe<Scalars['Int']>
+  sourceKey_SHORTEST_LT?: InputMaybe<Scalars['Int']>
+  sourceKey_LTE?: InputMaybe<Scalars['Int']>
+  sourceKey_AVERAGE_LTE?: InputMaybe<Scalars['Float']>
+  sourceKey_LONGEST_LTE?: InputMaybe<Scalars['Int']>
+  sourceKey_SHORTEST_LTE?: InputMaybe<Scalars['Int']>
+  targetKey_EQUAL?: InputMaybe<Scalars['String']>
+  targetKey_AVERAGE_EQUAL?: InputMaybe<Scalars['Float']>
+  targetKey_LONGEST_EQUAL?: InputMaybe<Scalars['Int']>
+  targetKey_SHORTEST_EQUAL?: InputMaybe<Scalars['Int']>
+  targetKey_GT?: InputMaybe<Scalars['Int']>
+  targetKey_AVERAGE_GT?: InputMaybe<Scalars['Float']>
+  targetKey_LONGEST_GT?: InputMaybe<Scalars['Int']>
+  targetKey_SHORTEST_GT?: InputMaybe<Scalars['Int']>
+  targetKey_GTE?: InputMaybe<Scalars['Int']>
+  targetKey_AVERAGE_GTE?: InputMaybe<Scalars['Float']>
+  targetKey_LONGEST_GTE?: InputMaybe<Scalars['Int']>
+  targetKey_SHORTEST_GTE?: InputMaybe<Scalars['Int']>
+  targetKey_LT?: InputMaybe<Scalars['Int']>
+  targetKey_AVERAGE_LT?: InputMaybe<Scalars['Float']>
+  targetKey_LONGEST_LT?: InputMaybe<Scalars['Int']>
+  targetKey_SHORTEST_LT?: InputMaybe<Scalars['Int']>
+  targetKey_LTE?: InputMaybe<Scalars['Int']>
+  targetKey_AVERAGE_LTE?: InputMaybe<Scalars['Float']>
+  targetKey_LONGEST_LTE?: InputMaybe<Scalars['Int']>
+  targetKey_SHORTEST_LTE?: InputMaybe<Scalars['Int']>
+}
+
+export type ElementPropMapBindingsUpdateConnectionInput = {
+  node?: InputMaybe<PropMapBindingUpdateInput>
+}
+
+export type ElementPropMapBindingsUpdateFieldInput = {
+  where?: InputMaybe<ElementPropMapBindingsConnectionWhere>
+  update?: InputMaybe<ElementPropMapBindingsUpdateConnectionInput>
+  connect?: InputMaybe<Array<ElementPropMapBindingsConnectFieldInput>>
+  disconnect?: InputMaybe<Array<ElementPropMapBindingsDisconnectFieldInput>>
+  create?: InputMaybe<Array<ElementPropMapBindingsCreateFieldInput>>
+  delete?: InputMaybe<Array<ElementPropMapBindingsDeleteFieldInput>>
+  connectOrCreate?: InputMaybe<
+    Array<ElementPropMapBindingsConnectOrCreateFieldInput>
+  >
+}
+
 export type ElementPropsAggregateInput = {
   count?: InputMaybe<Scalars['Int']>
   count_LT?: InputMaybe<Scalars['Int']>
@@ -13357,6 +13725,7 @@ export type ElementRelationInput = {
   renderComponentType?: InputMaybe<ElementRenderComponentTypeCreateFieldInput>
   renderAtomType?: InputMaybe<ElementRenderAtomTypeCreateFieldInput>
   hooks?: InputMaybe<Array<ElementHooksCreateFieldInput>>
+  propMapBindings?: InputMaybe<Array<ElementPropMapBindingsCreateFieldInput>>
 }
 
 export type ElementRenderAtomTypeAggregateInput = {
@@ -13798,6 +14167,7 @@ export type ElementUpdateInput = {
   renderComponentType?: InputMaybe<ElementRenderComponentTypeUpdateFieldInput>
   renderAtomType?: InputMaybe<ElementRenderAtomTypeUpdateFieldInput>
   hooks?: InputMaybe<Array<ElementHooksUpdateFieldInput>>
+  propMapBindings?: InputMaybe<Array<ElementPropMapBindingsUpdateFieldInput>>
 }
 
 export type ElementWhere = {
@@ -13953,6 +14323,19 @@ export type ElementWhere = {
   hooks_SINGLE?: InputMaybe<HookWhere>
   /** Return Elements where some of the related Hooks match this filter */
   hooks_SOME?: InputMaybe<HookWhere>
+  /** @deprecated Use `propMapBindings_SOME` instead. */
+  propMapBindings?: InputMaybe<PropMapBindingWhere>
+  /** @deprecated Use `propMapBindings_NONE` instead. */
+  propMapBindings_NOT?: InputMaybe<PropMapBindingWhere>
+  propMapBindingsAggregate?: InputMaybe<ElementPropMapBindingsAggregateInput>
+  /** Return Elements where all of the related PropMapBindings match this filter */
+  propMapBindings_ALL?: InputMaybe<PropMapBindingWhere>
+  /** Return Elements where none of the related PropMapBindings match this filter */
+  propMapBindings_NONE?: InputMaybe<PropMapBindingWhere>
+  /** Return Elements where one of the related PropMapBindings match this filter */
+  propMapBindings_SINGLE?: InputMaybe<PropMapBindingWhere>
+  /** Return Elements where some of the related PropMapBindings match this filter */
+  propMapBindings_SOME?: InputMaybe<PropMapBindingWhere>
   nextSiblingConnection?: InputMaybe<ElementNextSiblingConnectionWhere>
   nextSiblingConnection_NOT?: InputMaybe<ElementNextSiblingConnectionWhere>
   prevSiblingConnection?: InputMaybe<ElementPrevSiblingConnectionWhere>
@@ -13979,6 +14362,14 @@ export type ElementWhere = {
   hooksConnection_NONE?: InputMaybe<ElementHooksConnectionWhere>
   hooksConnection_SINGLE?: InputMaybe<ElementHooksConnectionWhere>
   hooksConnection_SOME?: InputMaybe<ElementHooksConnectionWhere>
+  /** @deprecated Use `propMapBindingsConnection_SOME` instead. */
+  propMapBindingsConnection?: InputMaybe<ElementPropMapBindingsConnectionWhere>
+  /** @deprecated Use `propMapBindingsConnection_NONE` instead. */
+  propMapBindingsConnection_NOT?: InputMaybe<ElementPropMapBindingsConnectionWhere>
+  propMapBindingsConnection_ALL?: InputMaybe<ElementPropMapBindingsConnectionWhere>
+  propMapBindingsConnection_NONE?: InputMaybe<ElementPropMapBindingsConnectionWhere>
+  propMapBindingsConnection_SINGLE?: InputMaybe<ElementPropMapBindingsConnectionWhere>
+  propMapBindingsConnection_SOME?: InputMaybe<ElementPropMapBindingsConnectionWhere>
 }
 
 export type EnumTypeAllowedValuesAggregateInput = {
@@ -17427,6 +17818,636 @@ export type PropConnectWhere = {
 
 export type PropCreateInput = {
   data?: Scalars['String']
+}
+
+export type PropMapBindingConnectInput = {
+  element?: InputMaybe<PropMapBindingElementConnectFieldInput>
+  targetElement?: InputMaybe<PropMapBindingTargetElementConnectFieldInput>
+}
+
+export type PropMapBindingConnectOrCreateInput = {
+  element?: InputMaybe<PropMapBindingElementConnectOrCreateFieldInput>
+  targetElement?: InputMaybe<PropMapBindingTargetElementConnectOrCreateFieldInput>
+}
+
+export type PropMapBindingConnectOrCreateWhere = {
+  node: PropMapBindingUniqueWhere
+}
+
+export type PropMapBindingConnectWhere = {
+  node: PropMapBindingWhere
+}
+
+export type PropMapBindingCreateInput = {
+  sourceKey: Scalars['String']
+  targetKey: Scalars['String']
+  element?: InputMaybe<PropMapBindingElementFieldInput>
+  targetElement?: InputMaybe<PropMapBindingTargetElementFieldInput>
+}
+
+export type PropMapBindingDeleteInput = {
+  element?: InputMaybe<PropMapBindingElementDeleteFieldInput>
+  targetElement?: InputMaybe<PropMapBindingTargetElementDeleteFieldInput>
+}
+
+export type PropMapBindingDisconnectInput = {
+  element?: InputMaybe<PropMapBindingElementDisconnectFieldInput>
+  targetElement?: InputMaybe<PropMapBindingTargetElementDisconnectFieldInput>
+}
+
+export type PropMapBindingElementAggregateInput = {
+  count?: InputMaybe<Scalars['Int']>
+  count_LT?: InputMaybe<Scalars['Int']>
+  count_LTE?: InputMaybe<Scalars['Int']>
+  count_GT?: InputMaybe<Scalars['Int']>
+  count_GTE?: InputMaybe<Scalars['Int']>
+  AND?: InputMaybe<Array<PropMapBindingElementAggregateInput>>
+  OR?: InputMaybe<Array<PropMapBindingElementAggregateInput>>
+  node?: InputMaybe<PropMapBindingElementNodeAggregationWhereInput>
+}
+
+export type PropMapBindingElementConnectFieldInput = {
+  where?: InputMaybe<ElementConnectWhere>
+  connect?: InputMaybe<ElementConnectInput>
+}
+
+export type PropMapBindingElementConnectionSort = {
+  node?: InputMaybe<ElementSort>
+}
+
+export type PropMapBindingElementConnectionWhere = {
+  AND?: InputMaybe<Array<PropMapBindingElementConnectionWhere>>
+  OR?: InputMaybe<Array<PropMapBindingElementConnectionWhere>>
+  node?: InputMaybe<ElementWhere>
+  node_NOT?: InputMaybe<ElementWhere>
+}
+
+export type PropMapBindingElementConnectOrCreateFieldInput = {
+  where: ElementConnectOrCreateWhere
+  onCreate: PropMapBindingElementConnectOrCreateFieldInputOnCreate
+}
+
+export type PropMapBindingElementConnectOrCreateFieldInputOnCreate = {
+  node: ElementOnCreateInput
+}
+
+export type PropMapBindingElementCreateFieldInput = {
+  node: ElementCreateInput
+}
+
+export type PropMapBindingElementDeleteFieldInput = {
+  where?: InputMaybe<PropMapBindingElementConnectionWhere>
+  delete?: InputMaybe<ElementDeleteInput>
+}
+
+export type PropMapBindingElementDisconnectFieldInput = {
+  where?: InputMaybe<PropMapBindingElementConnectionWhere>
+  disconnect?: InputMaybe<ElementDisconnectInput>
+}
+
+export type PropMapBindingElementFieldInput = {
+  create?: InputMaybe<PropMapBindingElementCreateFieldInput>
+  connect?: InputMaybe<PropMapBindingElementConnectFieldInput>
+  connectOrCreate?: InputMaybe<PropMapBindingElementConnectOrCreateFieldInput>
+}
+
+export type PropMapBindingElementNodeAggregationWhereInput = {
+  AND?: InputMaybe<Array<PropMapBindingElementNodeAggregationWhereInput>>
+  OR?: InputMaybe<Array<PropMapBindingElementNodeAggregationWhereInput>>
+  id_EQUAL?: InputMaybe<Scalars['ID']>
+  slug_EQUAL?: InputMaybe<Scalars['String']>
+  slug_AVERAGE_EQUAL?: InputMaybe<Scalars['Float']>
+  slug_LONGEST_EQUAL?: InputMaybe<Scalars['Int']>
+  slug_SHORTEST_EQUAL?: InputMaybe<Scalars['Int']>
+  slug_GT?: InputMaybe<Scalars['Int']>
+  slug_AVERAGE_GT?: InputMaybe<Scalars['Float']>
+  slug_LONGEST_GT?: InputMaybe<Scalars['Int']>
+  slug_SHORTEST_GT?: InputMaybe<Scalars['Int']>
+  slug_GTE?: InputMaybe<Scalars['Int']>
+  slug_AVERAGE_GTE?: InputMaybe<Scalars['Float']>
+  slug_LONGEST_GTE?: InputMaybe<Scalars['Int']>
+  slug_SHORTEST_GTE?: InputMaybe<Scalars['Int']>
+  slug_LT?: InputMaybe<Scalars['Int']>
+  slug_AVERAGE_LT?: InputMaybe<Scalars['Float']>
+  slug_LONGEST_LT?: InputMaybe<Scalars['Int']>
+  slug_SHORTEST_LT?: InputMaybe<Scalars['Int']>
+  slug_LTE?: InputMaybe<Scalars['Int']>
+  slug_AVERAGE_LTE?: InputMaybe<Scalars['Float']>
+  slug_LONGEST_LTE?: InputMaybe<Scalars['Int']>
+  slug_SHORTEST_LTE?: InputMaybe<Scalars['Int']>
+  name_EQUAL?: InputMaybe<Scalars['String']>
+  name_AVERAGE_EQUAL?: InputMaybe<Scalars['Float']>
+  name_LONGEST_EQUAL?: InputMaybe<Scalars['Int']>
+  name_SHORTEST_EQUAL?: InputMaybe<Scalars['Int']>
+  name_GT?: InputMaybe<Scalars['Int']>
+  name_AVERAGE_GT?: InputMaybe<Scalars['Float']>
+  name_LONGEST_GT?: InputMaybe<Scalars['Int']>
+  name_SHORTEST_GT?: InputMaybe<Scalars['Int']>
+  name_GTE?: InputMaybe<Scalars['Int']>
+  name_AVERAGE_GTE?: InputMaybe<Scalars['Float']>
+  name_LONGEST_GTE?: InputMaybe<Scalars['Int']>
+  name_SHORTEST_GTE?: InputMaybe<Scalars['Int']>
+  name_LT?: InputMaybe<Scalars['Int']>
+  name_AVERAGE_LT?: InputMaybe<Scalars['Float']>
+  name_LONGEST_LT?: InputMaybe<Scalars['Int']>
+  name_SHORTEST_LT?: InputMaybe<Scalars['Int']>
+  name_LTE?: InputMaybe<Scalars['Int']>
+  name_AVERAGE_LTE?: InputMaybe<Scalars['Float']>
+  name_LONGEST_LTE?: InputMaybe<Scalars['Int']>
+  name_SHORTEST_LTE?: InputMaybe<Scalars['Int']>
+  customCss_EQUAL?: InputMaybe<Scalars['String']>
+  customCss_AVERAGE_EQUAL?: InputMaybe<Scalars['Float']>
+  customCss_LONGEST_EQUAL?: InputMaybe<Scalars['Int']>
+  customCss_SHORTEST_EQUAL?: InputMaybe<Scalars['Int']>
+  customCss_GT?: InputMaybe<Scalars['Int']>
+  customCss_AVERAGE_GT?: InputMaybe<Scalars['Float']>
+  customCss_LONGEST_GT?: InputMaybe<Scalars['Int']>
+  customCss_SHORTEST_GT?: InputMaybe<Scalars['Int']>
+  customCss_GTE?: InputMaybe<Scalars['Int']>
+  customCss_AVERAGE_GTE?: InputMaybe<Scalars['Float']>
+  customCss_LONGEST_GTE?: InputMaybe<Scalars['Int']>
+  customCss_SHORTEST_GTE?: InputMaybe<Scalars['Int']>
+  customCss_LT?: InputMaybe<Scalars['Int']>
+  customCss_AVERAGE_LT?: InputMaybe<Scalars['Float']>
+  customCss_LONGEST_LT?: InputMaybe<Scalars['Int']>
+  customCss_SHORTEST_LT?: InputMaybe<Scalars['Int']>
+  customCss_LTE?: InputMaybe<Scalars['Int']>
+  customCss_AVERAGE_LTE?: InputMaybe<Scalars['Float']>
+  customCss_LONGEST_LTE?: InputMaybe<Scalars['Int']>
+  customCss_SHORTEST_LTE?: InputMaybe<Scalars['Int']>
+  guiCss_EQUAL?: InputMaybe<Scalars['String']>
+  guiCss_AVERAGE_EQUAL?: InputMaybe<Scalars['Float']>
+  guiCss_LONGEST_EQUAL?: InputMaybe<Scalars['Int']>
+  guiCss_SHORTEST_EQUAL?: InputMaybe<Scalars['Int']>
+  guiCss_GT?: InputMaybe<Scalars['Int']>
+  guiCss_AVERAGE_GT?: InputMaybe<Scalars['Float']>
+  guiCss_LONGEST_GT?: InputMaybe<Scalars['Int']>
+  guiCss_SHORTEST_GT?: InputMaybe<Scalars['Int']>
+  guiCss_GTE?: InputMaybe<Scalars['Int']>
+  guiCss_AVERAGE_GTE?: InputMaybe<Scalars['Float']>
+  guiCss_LONGEST_GTE?: InputMaybe<Scalars['Int']>
+  guiCss_SHORTEST_GTE?: InputMaybe<Scalars['Int']>
+  guiCss_LT?: InputMaybe<Scalars['Int']>
+  guiCss_AVERAGE_LT?: InputMaybe<Scalars['Float']>
+  guiCss_LONGEST_LT?: InputMaybe<Scalars['Int']>
+  guiCss_SHORTEST_LT?: InputMaybe<Scalars['Int']>
+  guiCss_LTE?: InputMaybe<Scalars['Int']>
+  guiCss_AVERAGE_LTE?: InputMaybe<Scalars['Float']>
+  guiCss_LONGEST_LTE?: InputMaybe<Scalars['Int']>
+  guiCss_SHORTEST_LTE?: InputMaybe<Scalars['Int']>
+  propTransformationJs_EQUAL?: InputMaybe<Scalars['String']>
+  propTransformationJs_AVERAGE_EQUAL?: InputMaybe<Scalars['Float']>
+  propTransformationJs_LONGEST_EQUAL?: InputMaybe<Scalars['Int']>
+  propTransformationJs_SHORTEST_EQUAL?: InputMaybe<Scalars['Int']>
+  propTransformationJs_GT?: InputMaybe<Scalars['Int']>
+  propTransformationJs_AVERAGE_GT?: InputMaybe<Scalars['Float']>
+  propTransformationJs_LONGEST_GT?: InputMaybe<Scalars['Int']>
+  propTransformationJs_SHORTEST_GT?: InputMaybe<Scalars['Int']>
+  propTransformationJs_GTE?: InputMaybe<Scalars['Int']>
+  propTransformationJs_AVERAGE_GTE?: InputMaybe<Scalars['Float']>
+  propTransformationJs_LONGEST_GTE?: InputMaybe<Scalars['Int']>
+  propTransformationJs_SHORTEST_GTE?: InputMaybe<Scalars['Int']>
+  propTransformationJs_LT?: InputMaybe<Scalars['Int']>
+  propTransformationJs_AVERAGE_LT?: InputMaybe<Scalars['Float']>
+  propTransformationJs_LONGEST_LT?: InputMaybe<Scalars['Int']>
+  propTransformationJs_SHORTEST_LT?: InputMaybe<Scalars['Int']>
+  propTransformationJs_LTE?: InputMaybe<Scalars['Int']>
+  propTransformationJs_AVERAGE_LTE?: InputMaybe<Scalars['Float']>
+  propTransformationJs_LONGEST_LTE?: InputMaybe<Scalars['Int']>
+  propTransformationJs_SHORTEST_LTE?: InputMaybe<Scalars['Int']>
+  renderForEachPropKey_EQUAL?: InputMaybe<Scalars['String']>
+  renderForEachPropKey_AVERAGE_EQUAL?: InputMaybe<Scalars['Float']>
+  renderForEachPropKey_LONGEST_EQUAL?: InputMaybe<Scalars['Int']>
+  renderForEachPropKey_SHORTEST_EQUAL?: InputMaybe<Scalars['Int']>
+  renderForEachPropKey_GT?: InputMaybe<Scalars['Int']>
+  renderForEachPropKey_AVERAGE_GT?: InputMaybe<Scalars['Float']>
+  renderForEachPropKey_LONGEST_GT?: InputMaybe<Scalars['Int']>
+  renderForEachPropKey_SHORTEST_GT?: InputMaybe<Scalars['Int']>
+  renderForEachPropKey_GTE?: InputMaybe<Scalars['Int']>
+  renderForEachPropKey_AVERAGE_GTE?: InputMaybe<Scalars['Float']>
+  renderForEachPropKey_LONGEST_GTE?: InputMaybe<Scalars['Int']>
+  renderForEachPropKey_SHORTEST_GTE?: InputMaybe<Scalars['Int']>
+  renderForEachPropKey_LT?: InputMaybe<Scalars['Int']>
+  renderForEachPropKey_AVERAGE_LT?: InputMaybe<Scalars['Float']>
+  renderForEachPropKey_LONGEST_LT?: InputMaybe<Scalars['Int']>
+  renderForEachPropKey_SHORTEST_LT?: InputMaybe<Scalars['Int']>
+  renderForEachPropKey_LTE?: InputMaybe<Scalars['Int']>
+  renderForEachPropKey_AVERAGE_LTE?: InputMaybe<Scalars['Float']>
+  renderForEachPropKey_LONGEST_LTE?: InputMaybe<Scalars['Int']>
+  renderForEachPropKey_SHORTEST_LTE?: InputMaybe<Scalars['Int']>
+  renderIfExpression_EQUAL?: InputMaybe<Scalars['String']>
+  renderIfExpression_AVERAGE_EQUAL?: InputMaybe<Scalars['Float']>
+  renderIfExpression_LONGEST_EQUAL?: InputMaybe<Scalars['Int']>
+  renderIfExpression_SHORTEST_EQUAL?: InputMaybe<Scalars['Int']>
+  renderIfExpression_GT?: InputMaybe<Scalars['Int']>
+  renderIfExpression_AVERAGE_GT?: InputMaybe<Scalars['Float']>
+  renderIfExpression_LONGEST_GT?: InputMaybe<Scalars['Int']>
+  renderIfExpression_SHORTEST_GT?: InputMaybe<Scalars['Int']>
+  renderIfExpression_GTE?: InputMaybe<Scalars['Int']>
+  renderIfExpression_AVERAGE_GTE?: InputMaybe<Scalars['Float']>
+  renderIfExpression_LONGEST_GTE?: InputMaybe<Scalars['Int']>
+  renderIfExpression_SHORTEST_GTE?: InputMaybe<Scalars['Int']>
+  renderIfExpression_LT?: InputMaybe<Scalars['Int']>
+  renderIfExpression_AVERAGE_LT?: InputMaybe<Scalars['Float']>
+  renderIfExpression_LONGEST_LT?: InputMaybe<Scalars['Int']>
+  renderIfExpression_SHORTEST_LT?: InputMaybe<Scalars['Int']>
+  renderIfExpression_LTE?: InputMaybe<Scalars['Int']>
+  renderIfExpression_AVERAGE_LTE?: InputMaybe<Scalars['Float']>
+  renderIfExpression_LONGEST_LTE?: InputMaybe<Scalars['Int']>
+  renderIfExpression_SHORTEST_LTE?: InputMaybe<Scalars['Int']>
+  preRenderActionId_EQUAL?: InputMaybe<Scalars['String']>
+  preRenderActionId_AVERAGE_EQUAL?: InputMaybe<Scalars['Float']>
+  preRenderActionId_LONGEST_EQUAL?: InputMaybe<Scalars['Int']>
+  preRenderActionId_SHORTEST_EQUAL?: InputMaybe<Scalars['Int']>
+  preRenderActionId_GT?: InputMaybe<Scalars['Int']>
+  preRenderActionId_AVERAGE_GT?: InputMaybe<Scalars['Float']>
+  preRenderActionId_LONGEST_GT?: InputMaybe<Scalars['Int']>
+  preRenderActionId_SHORTEST_GT?: InputMaybe<Scalars['Int']>
+  preRenderActionId_GTE?: InputMaybe<Scalars['Int']>
+  preRenderActionId_AVERAGE_GTE?: InputMaybe<Scalars['Float']>
+  preRenderActionId_LONGEST_GTE?: InputMaybe<Scalars['Int']>
+  preRenderActionId_SHORTEST_GTE?: InputMaybe<Scalars['Int']>
+  preRenderActionId_LT?: InputMaybe<Scalars['Int']>
+  preRenderActionId_AVERAGE_LT?: InputMaybe<Scalars['Float']>
+  preRenderActionId_LONGEST_LT?: InputMaybe<Scalars['Int']>
+  preRenderActionId_SHORTEST_LT?: InputMaybe<Scalars['Int']>
+  preRenderActionId_LTE?: InputMaybe<Scalars['Int']>
+  preRenderActionId_AVERAGE_LTE?: InputMaybe<Scalars['Float']>
+  preRenderActionId_LONGEST_LTE?: InputMaybe<Scalars['Int']>
+  preRenderActionId_SHORTEST_LTE?: InputMaybe<Scalars['Int']>
+  postRenderActionId_EQUAL?: InputMaybe<Scalars['String']>
+  postRenderActionId_AVERAGE_EQUAL?: InputMaybe<Scalars['Float']>
+  postRenderActionId_LONGEST_EQUAL?: InputMaybe<Scalars['Int']>
+  postRenderActionId_SHORTEST_EQUAL?: InputMaybe<Scalars['Int']>
+  postRenderActionId_GT?: InputMaybe<Scalars['Int']>
+  postRenderActionId_AVERAGE_GT?: InputMaybe<Scalars['Float']>
+  postRenderActionId_LONGEST_GT?: InputMaybe<Scalars['Int']>
+  postRenderActionId_SHORTEST_GT?: InputMaybe<Scalars['Int']>
+  postRenderActionId_GTE?: InputMaybe<Scalars['Int']>
+  postRenderActionId_AVERAGE_GTE?: InputMaybe<Scalars['Float']>
+  postRenderActionId_LONGEST_GTE?: InputMaybe<Scalars['Int']>
+  postRenderActionId_SHORTEST_GTE?: InputMaybe<Scalars['Int']>
+  postRenderActionId_LT?: InputMaybe<Scalars['Int']>
+  postRenderActionId_AVERAGE_LT?: InputMaybe<Scalars['Float']>
+  postRenderActionId_LONGEST_LT?: InputMaybe<Scalars['Int']>
+  postRenderActionId_SHORTEST_LT?: InputMaybe<Scalars['Int']>
+  postRenderActionId_LTE?: InputMaybe<Scalars['Int']>
+  postRenderActionId_AVERAGE_LTE?: InputMaybe<Scalars['Float']>
+  postRenderActionId_LONGEST_LTE?: InputMaybe<Scalars['Int']>
+  postRenderActionId_SHORTEST_LTE?: InputMaybe<Scalars['Int']>
+}
+
+export type PropMapBindingElementUpdateConnectionInput = {
+  node?: InputMaybe<ElementUpdateInput>
+}
+
+export type PropMapBindingElementUpdateFieldInput = {
+  where?: InputMaybe<PropMapBindingElementConnectionWhere>
+  update?: InputMaybe<PropMapBindingElementUpdateConnectionInput>
+  connect?: InputMaybe<PropMapBindingElementConnectFieldInput>
+  disconnect?: InputMaybe<PropMapBindingElementDisconnectFieldInput>
+  create?: InputMaybe<PropMapBindingElementCreateFieldInput>
+  delete?: InputMaybe<PropMapBindingElementDeleteFieldInput>
+  connectOrCreate?: InputMaybe<PropMapBindingElementConnectOrCreateFieldInput>
+}
+
+export type PropMapBindingOnCreateInput = {
+  sourceKey: Scalars['String']
+  targetKey: Scalars['String']
+}
+
+export type PropMapBindingOptions = {
+  /** Specify one or more PropMapBindingSort objects to sort PropMapBindings by. The sorts will be applied in the order in which they are arranged in the array. */
+  sort?: InputMaybe<Array<PropMapBindingSort>>
+  limit?: InputMaybe<Scalars['Int']>
+  offset?: InputMaybe<Scalars['Int']>
+}
+
+export type PropMapBindingRelationInput = {
+  element?: InputMaybe<PropMapBindingElementCreateFieldInput>
+  targetElement?: InputMaybe<PropMapBindingTargetElementCreateFieldInput>
+}
+
+/** Fields to sort PropMapBindings by. The order in which sorts are applied is not guaranteed when specifying many fields in one PropMapBindingSort object. */
+export type PropMapBindingSort = {
+  id?: InputMaybe<SortDirection>
+  sourceKey?: InputMaybe<SortDirection>
+  targetKey?: InputMaybe<SortDirection>
+}
+
+export type PropMapBindingTargetElementAggregateInput = {
+  count?: InputMaybe<Scalars['Int']>
+  count_LT?: InputMaybe<Scalars['Int']>
+  count_LTE?: InputMaybe<Scalars['Int']>
+  count_GT?: InputMaybe<Scalars['Int']>
+  count_GTE?: InputMaybe<Scalars['Int']>
+  AND?: InputMaybe<Array<PropMapBindingTargetElementAggregateInput>>
+  OR?: InputMaybe<Array<PropMapBindingTargetElementAggregateInput>>
+  node?: InputMaybe<PropMapBindingTargetElementNodeAggregationWhereInput>
+}
+
+export type PropMapBindingTargetElementConnectFieldInput = {
+  where?: InputMaybe<ElementConnectWhere>
+  connect?: InputMaybe<ElementConnectInput>
+}
+
+export type PropMapBindingTargetElementConnectionSort = {
+  node?: InputMaybe<ElementSort>
+}
+
+export type PropMapBindingTargetElementConnectionWhere = {
+  AND?: InputMaybe<Array<PropMapBindingTargetElementConnectionWhere>>
+  OR?: InputMaybe<Array<PropMapBindingTargetElementConnectionWhere>>
+  node?: InputMaybe<ElementWhere>
+  node_NOT?: InputMaybe<ElementWhere>
+}
+
+export type PropMapBindingTargetElementConnectOrCreateFieldInput = {
+  where: ElementConnectOrCreateWhere
+  onCreate: PropMapBindingTargetElementConnectOrCreateFieldInputOnCreate
+}
+
+export type PropMapBindingTargetElementConnectOrCreateFieldInputOnCreate = {
+  node: ElementOnCreateInput
+}
+
+export type PropMapBindingTargetElementCreateFieldInput = {
+  node: ElementCreateInput
+}
+
+export type PropMapBindingTargetElementDeleteFieldInput = {
+  where?: InputMaybe<PropMapBindingTargetElementConnectionWhere>
+  delete?: InputMaybe<ElementDeleteInput>
+}
+
+export type PropMapBindingTargetElementDisconnectFieldInput = {
+  where?: InputMaybe<PropMapBindingTargetElementConnectionWhere>
+  disconnect?: InputMaybe<ElementDisconnectInput>
+}
+
+export type PropMapBindingTargetElementFieldInput = {
+  create?: InputMaybe<PropMapBindingTargetElementCreateFieldInput>
+  connect?: InputMaybe<PropMapBindingTargetElementConnectFieldInput>
+  connectOrCreate?: InputMaybe<PropMapBindingTargetElementConnectOrCreateFieldInput>
+}
+
+export type PropMapBindingTargetElementNodeAggregationWhereInput = {
+  AND?: InputMaybe<Array<PropMapBindingTargetElementNodeAggregationWhereInput>>
+  OR?: InputMaybe<Array<PropMapBindingTargetElementNodeAggregationWhereInput>>
+  id_EQUAL?: InputMaybe<Scalars['ID']>
+  slug_EQUAL?: InputMaybe<Scalars['String']>
+  slug_AVERAGE_EQUAL?: InputMaybe<Scalars['Float']>
+  slug_LONGEST_EQUAL?: InputMaybe<Scalars['Int']>
+  slug_SHORTEST_EQUAL?: InputMaybe<Scalars['Int']>
+  slug_GT?: InputMaybe<Scalars['Int']>
+  slug_AVERAGE_GT?: InputMaybe<Scalars['Float']>
+  slug_LONGEST_GT?: InputMaybe<Scalars['Int']>
+  slug_SHORTEST_GT?: InputMaybe<Scalars['Int']>
+  slug_GTE?: InputMaybe<Scalars['Int']>
+  slug_AVERAGE_GTE?: InputMaybe<Scalars['Float']>
+  slug_LONGEST_GTE?: InputMaybe<Scalars['Int']>
+  slug_SHORTEST_GTE?: InputMaybe<Scalars['Int']>
+  slug_LT?: InputMaybe<Scalars['Int']>
+  slug_AVERAGE_LT?: InputMaybe<Scalars['Float']>
+  slug_LONGEST_LT?: InputMaybe<Scalars['Int']>
+  slug_SHORTEST_LT?: InputMaybe<Scalars['Int']>
+  slug_LTE?: InputMaybe<Scalars['Int']>
+  slug_AVERAGE_LTE?: InputMaybe<Scalars['Float']>
+  slug_LONGEST_LTE?: InputMaybe<Scalars['Int']>
+  slug_SHORTEST_LTE?: InputMaybe<Scalars['Int']>
+  name_EQUAL?: InputMaybe<Scalars['String']>
+  name_AVERAGE_EQUAL?: InputMaybe<Scalars['Float']>
+  name_LONGEST_EQUAL?: InputMaybe<Scalars['Int']>
+  name_SHORTEST_EQUAL?: InputMaybe<Scalars['Int']>
+  name_GT?: InputMaybe<Scalars['Int']>
+  name_AVERAGE_GT?: InputMaybe<Scalars['Float']>
+  name_LONGEST_GT?: InputMaybe<Scalars['Int']>
+  name_SHORTEST_GT?: InputMaybe<Scalars['Int']>
+  name_GTE?: InputMaybe<Scalars['Int']>
+  name_AVERAGE_GTE?: InputMaybe<Scalars['Float']>
+  name_LONGEST_GTE?: InputMaybe<Scalars['Int']>
+  name_SHORTEST_GTE?: InputMaybe<Scalars['Int']>
+  name_LT?: InputMaybe<Scalars['Int']>
+  name_AVERAGE_LT?: InputMaybe<Scalars['Float']>
+  name_LONGEST_LT?: InputMaybe<Scalars['Int']>
+  name_SHORTEST_LT?: InputMaybe<Scalars['Int']>
+  name_LTE?: InputMaybe<Scalars['Int']>
+  name_AVERAGE_LTE?: InputMaybe<Scalars['Float']>
+  name_LONGEST_LTE?: InputMaybe<Scalars['Int']>
+  name_SHORTEST_LTE?: InputMaybe<Scalars['Int']>
+  customCss_EQUAL?: InputMaybe<Scalars['String']>
+  customCss_AVERAGE_EQUAL?: InputMaybe<Scalars['Float']>
+  customCss_LONGEST_EQUAL?: InputMaybe<Scalars['Int']>
+  customCss_SHORTEST_EQUAL?: InputMaybe<Scalars['Int']>
+  customCss_GT?: InputMaybe<Scalars['Int']>
+  customCss_AVERAGE_GT?: InputMaybe<Scalars['Float']>
+  customCss_LONGEST_GT?: InputMaybe<Scalars['Int']>
+  customCss_SHORTEST_GT?: InputMaybe<Scalars['Int']>
+  customCss_GTE?: InputMaybe<Scalars['Int']>
+  customCss_AVERAGE_GTE?: InputMaybe<Scalars['Float']>
+  customCss_LONGEST_GTE?: InputMaybe<Scalars['Int']>
+  customCss_SHORTEST_GTE?: InputMaybe<Scalars['Int']>
+  customCss_LT?: InputMaybe<Scalars['Int']>
+  customCss_AVERAGE_LT?: InputMaybe<Scalars['Float']>
+  customCss_LONGEST_LT?: InputMaybe<Scalars['Int']>
+  customCss_SHORTEST_LT?: InputMaybe<Scalars['Int']>
+  customCss_LTE?: InputMaybe<Scalars['Int']>
+  customCss_AVERAGE_LTE?: InputMaybe<Scalars['Float']>
+  customCss_LONGEST_LTE?: InputMaybe<Scalars['Int']>
+  customCss_SHORTEST_LTE?: InputMaybe<Scalars['Int']>
+  guiCss_EQUAL?: InputMaybe<Scalars['String']>
+  guiCss_AVERAGE_EQUAL?: InputMaybe<Scalars['Float']>
+  guiCss_LONGEST_EQUAL?: InputMaybe<Scalars['Int']>
+  guiCss_SHORTEST_EQUAL?: InputMaybe<Scalars['Int']>
+  guiCss_GT?: InputMaybe<Scalars['Int']>
+  guiCss_AVERAGE_GT?: InputMaybe<Scalars['Float']>
+  guiCss_LONGEST_GT?: InputMaybe<Scalars['Int']>
+  guiCss_SHORTEST_GT?: InputMaybe<Scalars['Int']>
+  guiCss_GTE?: InputMaybe<Scalars['Int']>
+  guiCss_AVERAGE_GTE?: InputMaybe<Scalars['Float']>
+  guiCss_LONGEST_GTE?: InputMaybe<Scalars['Int']>
+  guiCss_SHORTEST_GTE?: InputMaybe<Scalars['Int']>
+  guiCss_LT?: InputMaybe<Scalars['Int']>
+  guiCss_AVERAGE_LT?: InputMaybe<Scalars['Float']>
+  guiCss_LONGEST_LT?: InputMaybe<Scalars['Int']>
+  guiCss_SHORTEST_LT?: InputMaybe<Scalars['Int']>
+  guiCss_LTE?: InputMaybe<Scalars['Int']>
+  guiCss_AVERAGE_LTE?: InputMaybe<Scalars['Float']>
+  guiCss_LONGEST_LTE?: InputMaybe<Scalars['Int']>
+  guiCss_SHORTEST_LTE?: InputMaybe<Scalars['Int']>
+  propTransformationJs_EQUAL?: InputMaybe<Scalars['String']>
+  propTransformationJs_AVERAGE_EQUAL?: InputMaybe<Scalars['Float']>
+  propTransformationJs_LONGEST_EQUAL?: InputMaybe<Scalars['Int']>
+  propTransformationJs_SHORTEST_EQUAL?: InputMaybe<Scalars['Int']>
+  propTransformationJs_GT?: InputMaybe<Scalars['Int']>
+  propTransformationJs_AVERAGE_GT?: InputMaybe<Scalars['Float']>
+  propTransformationJs_LONGEST_GT?: InputMaybe<Scalars['Int']>
+  propTransformationJs_SHORTEST_GT?: InputMaybe<Scalars['Int']>
+  propTransformationJs_GTE?: InputMaybe<Scalars['Int']>
+  propTransformationJs_AVERAGE_GTE?: InputMaybe<Scalars['Float']>
+  propTransformationJs_LONGEST_GTE?: InputMaybe<Scalars['Int']>
+  propTransformationJs_SHORTEST_GTE?: InputMaybe<Scalars['Int']>
+  propTransformationJs_LT?: InputMaybe<Scalars['Int']>
+  propTransformationJs_AVERAGE_LT?: InputMaybe<Scalars['Float']>
+  propTransformationJs_LONGEST_LT?: InputMaybe<Scalars['Int']>
+  propTransformationJs_SHORTEST_LT?: InputMaybe<Scalars['Int']>
+  propTransformationJs_LTE?: InputMaybe<Scalars['Int']>
+  propTransformationJs_AVERAGE_LTE?: InputMaybe<Scalars['Float']>
+  propTransformationJs_LONGEST_LTE?: InputMaybe<Scalars['Int']>
+  propTransformationJs_SHORTEST_LTE?: InputMaybe<Scalars['Int']>
+  renderForEachPropKey_EQUAL?: InputMaybe<Scalars['String']>
+  renderForEachPropKey_AVERAGE_EQUAL?: InputMaybe<Scalars['Float']>
+  renderForEachPropKey_LONGEST_EQUAL?: InputMaybe<Scalars['Int']>
+  renderForEachPropKey_SHORTEST_EQUAL?: InputMaybe<Scalars['Int']>
+  renderForEachPropKey_GT?: InputMaybe<Scalars['Int']>
+  renderForEachPropKey_AVERAGE_GT?: InputMaybe<Scalars['Float']>
+  renderForEachPropKey_LONGEST_GT?: InputMaybe<Scalars['Int']>
+  renderForEachPropKey_SHORTEST_GT?: InputMaybe<Scalars['Int']>
+  renderForEachPropKey_GTE?: InputMaybe<Scalars['Int']>
+  renderForEachPropKey_AVERAGE_GTE?: InputMaybe<Scalars['Float']>
+  renderForEachPropKey_LONGEST_GTE?: InputMaybe<Scalars['Int']>
+  renderForEachPropKey_SHORTEST_GTE?: InputMaybe<Scalars['Int']>
+  renderForEachPropKey_LT?: InputMaybe<Scalars['Int']>
+  renderForEachPropKey_AVERAGE_LT?: InputMaybe<Scalars['Float']>
+  renderForEachPropKey_LONGEST_LT?: InputMaybe<Scalars['Int']>
+  renderForEachPropKey_SHORTEST_LT?: InputMaybe<Scalars['Int']>
+  renderForEachPropKey_LTE?: InputMaybe<Scalars['Int']>
+  renderForEachPropKey_AVERAGE_LTE?: InputMaybe<Scalars['Float']>
+  renderForEachPropKey_LONGEST_LTE?: InputMaybe<Scalars['Int']>
+  renderForEachPropKey_SHORTEST_LTE?: InputMaybe<Scalars['Int']>
+  renderIfExpression_EQUAL?: InputMaybe<Scalars['String']>
+  renderIfExpression_AVERAGE_EQUAL?: InputMaybe<Scalars['Float']>
+  renderIfExpression_LONGEST_EQUAL?: InputMaybe<Scalars['Int']>
+  renderIfExpression_SHORTEST_EQUAL?: InputMaybe<Scalars['Int']>
+  renderIfExpression_GT?: InputMaybe<Scalars['Int']>
+  renderIfExpression_AVERAGE_GT?: InputMaybe<Scalars['Float']>
+  renderIfExpression_LONGEST_GT?: InputMaybe<Scalars['Int']>
+  renderIfExpression_SHORTEST_GT?: InputMaybe<Scalars['Int']>
+  renderIfExpression_GTE?: InputMaybe<Scalars['Int']>
+  renderIfExpression_AVERAGE_GTE?: InputMaybe<Scalars['Float']>
+  renderIfExpression_LONGEST_GTE?: InputMaybe<Scalars['Int']>
+  renderIfExpression_SHORTEST_GTE?: InputMaybe<Scalars['Int']>
+  renderIfExpression_LT?: InputMaybe<Scalars['Int']>
+  renderIfExpression_AVERAGE_LT?: InputMaybe<Scalars['Float']>
+  renderIfExpression_LONGEST_LT?: InputMaybe<Scalars['Int']>
+  renderIfExpression_SHORTEST_LT?: InputMaybe<Scalars['Int']>
+  renderIfExpression_LTE?: InputMaybe<Scalars['Int']>
+  renderIfExpression_AVERAGE_LTE?: InputMaybe<Scalars['Float']>
+  renderIfExpression_LONGEST_LTE?: InputMaybe<Scalars['Int']>
+  renderIfExpression_SHORTEST_LTE?: InputMaybe<Scalars['Int']>
+  preRenderActionId_EQUAL?: InputMaybe<Scalars['String']>
+  preRenderActionId_AVERAGE_EQUAL?: InputMaybe<Scalars['Float']>
+  preRenderActionId_LONGEST_EQUAL?: InputMaybe<Scalars['Int']>
+  preRenderActionId_SHORTEST_EQUAL?: InputMaybe<Scalars['Int']>
+  preRenderActionId_GT?: InputMaybe<Scalars['Int']>
+  preRenderActionId_AVERAGE_GT?: InputMaybe<Scalars['Float']>
+  preRenderActionId_LONGEST_GT?: InputMaybe<Scalars['Int']>
+  preRenderActionId_SHORTEST_GT?: InputMaybe<Scalars['Int']>
+  preRenderActionId_GTE?: InputMaybe<Scalars['Int']>
+  preRenderActionId_AVERAGE_GTE?: InputMaybe<Scalars['Float']>
+  preRenderActionId_LONGEST_GTE?: InputMaybe<Scalars['Int']>
+  preRenderActionId_SHORTEST_GTE?: InputMaybe<Scalars['Int']>
+  preRenderActionId_LT?: InputMaybe<Scalars['Int']>
+  preRenderActionId_AVERAGE_LT?: InputMaybe<Scalars['Float']>
+  preRenderActionId_LONGEST_LT?: InputMaybe<Scalars['Int']>
+  preRenderActionId_SHORTEST_LT?: InputMaybe<Scalars['Int']>
+  preRenderActionId_LTE?: InputMaybe<Scalars['Int']>
+  preRenderActionId_AVERAGE_LTE?: InputMaybe<Scalars['Float']>
+  preRenderActionId_LONGEST_LTE?: InputMaybe<Scalars['Int']>
+  preRenderActionId_SHORTEST_LTE?: InputMaybe<Scalars['Int']>
+  postRenderActionId_EQUAL?: InputMaybe<Scalars['String']>
+  postRenderActionId_AVERAGE_EQUAL?: InputMaybe<Scalars['Float']>
+  postRenderActionId_LONGEST_EQUAL?: InputMaybe<Scalars['Int']>
+  postRenderActionId_SHORTEST_EQUAL?: InputMaybe<Scalars['Int']>
+  postRenderActionId_GT?: InputMaybe<Scalars['Int']>
+  postRenderActionId_AVERAGE_GT?: InputMaybe<Scalars['Float']>
+  postRenderActionId_LONGEST_GT?: InputMaybe<Scalars['Int']>
+  postRenderActionId_SHORTEST_GT?: InputMaybe<Scalars['Int']>
+  postRenderActionId_GTE?: InputMaybe<Scalars['Int']>
+  postRenderActionId_AVERAGE_GTE?: InputMaybe<Scalars['Float']>
+  postRenderActionId_LONGEST_GTE?: InputMaybe<Scalars['Int']>
+  postRenderActionId_SHORTEST_GTE?: InputMaybe<Scalars['Int']>
+  postRenderActionId_LT?: InputMaybe<Scalars['Int']>
+  postRenderActionId_AVERAGE_LT?: InputMaybe<Scalars['Float']>
+  postRenderActionId_LONGEST_LT?: InputMaybe<Scalars['Int']>
+  postRenderActionId_SHORTEST_LT?: InputMaybe<Scalars['Int']>
+  postRenderActionId_LTE?: InputMaybe<Scalars['Int']>
+  postRenderActionId_AVERAGE_LTE?: InputMaybe<Scalars['Float']>
+  postRenderActionId_LONGEST_LTE?: InputMaybe<Scalars['Int']>
+  postRenderActionId_SHORTEST_LTE?: InputMaybe<Scalars['Int']>
+}
+
+export type PropMapBindingTargetElementUpdateConnectionInput = {
+  node?: InputMaybe<ElementUpdateInput>
+}
+
+export type PropMapBindingTargetElementUpdateFieldInput = {
+  where?: InputMaybe<PropMapBindingTargetElementConnectionWhere>
+  update?: InputMaybe<PropMapBindingTargetElementUpdateConnectionInput>
+  connect?: InputMaybe<PropMapBindingTargetElementConnectFieldInput>
+  disconnect?: InputMaybe<PropMapBindingTargetElementDisconnectFieldInput>
+  create?: InputMaybe<PropMapBindingTargetElementCreateFieldInput>
+  delete?: InputMaybe<PropMapBindingTargetElementDeleteFieldInput>
+  connectOrCreate?: InputMaybe<PropMapBindingTargetElementConnectOrCreateFieldInput>
+}
+
+export type PropMapBindingUniqueWhere = {
+  id?: InputMaybe<Scalars['ID']>
+}
+
+export type PropMapBindingUpdateInput = {
+  sourceKey?: InputMaybe<Scalars['String']>
+  targetKey?: InputMaybe<Scalars['String']>
+  element?: InputMaybe<PropMapBindingElementUpdateFieldInput>
+  targetElement?: InputMaybe<PropMapBindingTargetElementUpdateFieldInput>
+}
+
+export type PropMapBindingWhere = {
+  OR?: InputMaybe<Array<PropMapBindingWhere>>
+  AND?: InputMaybe<Array<PropMapBindingWhere>>
+  id?: InputMaybe<Scalars['ID']>
+  id_NOT?: InputMaybe<Scalars['ID']>
+  id_IN?: InputMaybe<Array<Scalars['ID']>>
+  id_NOT_IN?: InputMaybe<Array<Scalars['ID']>>
+  id_MATCHES?: InputMaybe<Scalars['String']>
+  id_CONTAINS?: InputMaybe<Scalars['ID']>
+  id_NOT_CONTAINS?: InputMaybe<Scalars['ID']>
+  id_STARTS_WITH?: InputMaybe<Scalars['ID']>
+  id_NOT_STARTS_WITH?: InputMaybe<Scalars['ID']>
+  id_ENDS_WITH?: InputMaybe<Scalars['ID']>
+  id_NOT_ENDS_WITH?: InputMaybe<Scalars['ID']>
+  sourceKey?: InputMaybe<Scalars['String']>
+  sourceKey_NOT?: InputMaybe<Scalars['String']>
+  sourceKey_IN?: InputMaybe<Array<Scalars['String']>>
+  sourceKey_NOT_IN?: InputMaybe<Array<Scalars['String']>>
+  sourceKey_MATCHES?: InputMaybe<Scalars['String']>
+  sourceKey_CONTAINS?: InputMaybe<Scalars['String']>
+  sourceKey_NOT_CONTAINS?: InputMaybe<Scalars['String']>
+  sourceKey_STARTS_WITH?: InputMaybe<Scalars['String']>
+  sourceKey_NOT_STARTS_WITH?: InputMaybe<Scalars['String']>
+  sourceKey_ENDS_WITH?: InputMaybe<Scalars['String']>
+  sourceKey_NOT_ENDS_WITH?: InputMaybe<Scalars['String']>
+  targetKey?: InputMaybe<Scalars['String']>
+  targetKey_NOT?: InputMaybe<Scalars['String']>
+  targetKey_IN?: InputMaybe<Array<Scalars['String']>>
+  targetKey_NOT_IN?: InputMaybe<Array<Scalars['String']>>
+  targetKey_MATCHES?: InputMaybe<Scalars['String']>
+  targetKey_CONTAINS?: InputMaybe<Scalars['String']>
+  targetKey_NOT_CONTAINS?: InputMaybe<Scalars['String']>
+  targetKey_STARTS_WITH?: InputMaybe<Scalars['String']>
+  targetKey_NOT_STARTS_WITH?: InputMaybe<Scalars['String']>
+  targetKey_ENDS_WITH?: InputMaybe<Scalars['String']>
+  targetKey_NOT_ENDS_WITH?: InputMaybe<Scalars['String']>
+  element?: InputMaybe<ElementWhere>
+  element_NOT?: InputMaybe<ElementWhere>
+  elementAggregate?: InputMaybe<PropMapBindingElementAggregateInput>
+  targetElement?: InputMaybe<ElementWhere>
+  targetElement_NOT?: InputMaybe<ElementWhere>
+  targetElementAggregate?: InputMaybe<PropMapBindingTargetElementAggregateInput>
+  elementConnection?: InputMaybe<PropMapBindingElementConnectionWhere>
+  elementConnection_NOT?: InputMaybe<PropMapBindingElementConnectionWhere>
+  targetElementConnection?: InputMaybe<PropMapBindingTargetElementConnectionWhere>
+  targetElementConnection_NOT?: InputMaybe<PropMapBindingTargetElementConnectionWhere>
 }
 
 export type PropOnCreateInput = {
@@ -23379,6 +24400,75 @@ export interface IntAggregateInputNonNullable {
   average?: boolean
   sum?: boolean
 }
+export interface PropMapBindingAggregateSelectionInput {
+  count?: boolean
+  id?: IdAggregateInputNonNullable
+  sourceKey?: StringAggregateInputNonNullable
+  targetKey?: StringAggregateInputNonNullable
+}
+
+export declare class PropMapBindingModel {
+  public find(args?: {
+    where?: PropMapBindingWhere
+
+    options?: PropMapBindingOptions
+    selectionSet?: string | DocumentNode | SelectionSetNode
+    args?: any
+    context?: any
+    rootValue?: any
+  }): Promise<PropMapBinding[]>
+  public create(args: {
+    input: PropMapBindingCreateInput[]
+    selectionSet?: string | DocumentNode | SelectionSetNode
+    args?: any
+    context?: any
+    rootValue?: any
+  }): Promise<CreatePropMapBindingsMutationResponse>
+  public update(args: {
+    where?: PropMapBindingWhere
+    update?: PropMapBindingUpdateInput
+    connect?: PropMapBindingConnectInput
+    disconnect?: PropMapBindingDisconnectInput
+    create?: PropMapBindingCreateInput
+    connectOrCreate?: PropMapBindingConnectOrCreateInput
+    selectionSet?: string | DocumentNode | SelectionSetNode
+    args?: any
+    context?: any
+    rootValue?: any
+  }): Promise<UpdatePropMapBindingsMutationResponse>
+  public delete(args: {
+    where?: PropMapBindingWhere
+    delete?: PropMapBindingDeleteInput
+    context?: any
+    rootValue?: any
+  }): Promise<{ nodesDeleted: number; relationshipsDeleted: number }>
+  public aggregate(args: {
+    where?: PropMapBindingWhere
+
+    aggregate: PropMapBindingAggregateSelectionInput
+    context?: any
+    rootValue?: any
+  }): Promise<PropMapBindingAggregateSelection>
+}
+
+export interface IdAggregateInputNonNullable {
+  shortest?: boolean
+  longest?: boolean
+}
+export interface StringAggregateInputNonNullable {
+  shortest?: boolean
+  longest?: boolean
+}
+export interface StringAggregateInputNullable {
+  shortest?: boolean
+  longest?: boolean
+}
+export interface IntAggregateInputNonNullable {
+  max?: boolean
+  min?: boolean
+  average?: boolean
+  sum?: boolean
+}
 export interface HookAggregateSelectionInput {
   count?: boolean
   id?: IdAggregateInputNonNullable
@@ -24057,6 +25147,7 @@ export interface ModelMap {
   Tag: TagModel
   Element: ElementModel
   Prop: PropModel
+  PropMapBinding: PropMapBindingModel
   Hook: HookModel
   Component: ComponentModel
   Store: StoreModel

--- a/libs/shared/abstract/codegen/src/ogm-types.gen.ts
+++ b/libs/shared/abstract/codegen/src/ogm-types.gen.ts
@@ -107,9 +107,6 @@ export type Query = {
   props: Array<Prop>
   propsAggregate: PropAggregateSelection
   propsConnection: PropsConnection
-  propMapBindings: Array<PropMapBinding>
-  propMapBindingsAggregate: PropMapBindingAggregateSelection
-  propMapBindingsConnection: PropMapBindingsConnection
   hooks: Array<Hook>
   hooksAggregate: HookAggregateSelection
   hooksConnection: HooksConnection
@@ -581,22 +578,6 @@ export type QueryPropsConnectionArgs = {
   sort?: InputMaybe<Array<InputMaybe<PropSort>>>
 }
 
-export type QueryPropMapBindingsArgs = {
-  where?: InputMaybe<PropMapBindingWhere>
-  options?: InputMaybe<PropMapBindingOptions>
-}
-
-export type QueryPropMapBindingsAggregateArgs = {
-  where?: InputMaybe<PropMapBindingWhere>
-}
-
-export type QueryPropMapBindingsConnectionArgs = {
-  first?: InputMaybe<Scalars['Int']>
-  after?: InputMaybe<Scalars['String']>
-  where?: InputMaybe<PropMapBindingWhere>
-  sort?: InputMaybe<Array<InputMaybe<PropMapBindingSort>>>
-}
-
 export type QueryHooksArgs = {
   where?: InputMaybe<HookWhere>
   options?: InputMaybe<HookOptions>
@@ -852,9 +833,6 @@ export type Mutation = {
   createProps: CreatePropsMutationResponse
   deleteProps: DeleteInfo
   updateProps: UpdatePropsMutationResponse
-  createPropMapBindings: CreatePropMapBindingsMutationResponse
-  deletePropMapBindings: DeleteInfo
-  updatePropMapBindings: UpdatePropMapBindingsMutationResponse
   createHooks: CreateHooksMutationResponse
   deleteHooks: DeleteInfo
   updateHooks: UpdateHooksMutationResponse
@@ -1385,25 +1363,6 @@ export type MutationDeletePropsArgs = {
 export type MutationUpdatePropsArgs = {
   where?: InputMaybe<PropWhere>
   update?: InputMaybe<PropUpdateInput>
-}
-
-export type MutationCreatePropMapBindingsArgs = {
-  input: Array<PropMapBindingCreateInput>
-}
-
-export type MutationDeletePropMapBindingsArgs = {
-  where?: InputMaybe<PropMapBindingWhere>
-  delete?: InputMaybe<PropMapBindingDeleteInput>
-}
-
-export type MutationUpdatePropMapBindingsArgs = {
-  where?: InputMaybe<PropMapBindingWhere>
-  update?: InputMaybe<PropMapBindingUpdateInput>
-  connect?: InputMaybe<PropMapBindingConnectInput>
-  disconnect?: InputMaybe<PropMapBindingDisconnectInput>
-  create?: InputMaybe<PropMapBindingRelationInput>
-  delete?: InputMaybe<PropMapBindingDeleteInput>
-  connectOrCreate?: InputMaybe<PropMapBindingConnectOrCreateInput>
 }
 
 export type MutationCreateHooksArgs = {
@@ -2751,9 +2710,12 @@ export type Atom = {
   apiAggregate?: Maybe<AtomInterfaceTypeApiAggregationSelection>
   allowedChildren: Array<Atom>
   allowedChildrenAggregate?: Maybe<AtomAtomAllowedChildrenAggregationSelection>
+  requiredParent?: Maybe<Atom>
+  requiredParentAggregate?: Maybe<AtomAtomRequiredParentAggregationSelection>
   tagsConnection: AtomTagsConnection
   apiConnection: AtomApiConnection
   allowedChildrenConnection: AtomAllowedChildrenConnection
+  requiredParentConnection: AtomRequiredParentConnection
 }
 
 export type AtomTagsArgs = {
@@ -2789,6 +2751,17 @@ export type AtomAllowedChildrenAggregateArgs = {
   directed?: InputMaybe<Scalars['Boolean']>
 }
 
+export type AtomRequiredParentArgs = {
+  where?: InputMaybe<AtomWhere>
+  options?: InputMaybe<AtomOptions>
+  directed?: InputMaybe<Scalars['Boolean']>
+}
+
+export type AtomRequiredParentAggregateArgs = {
+  where?: InputMaybe<AtomWhere>
+  directed?: InputMaybe<Scalars['Boolean']>
+}
+
 export type AtomTagsConnectionArgs = {
   where?: InputMaybe<AtomTagsConnectionWhere>
   first?: InputMaybe<Scalars['Int']>
@@ -2811,6 +2784,14 @@ export type AtomAllowedChildrenConnectionArgs = {
   after?: InputMaybe<Scalars['String']>
   directed?: InputMaybe<Scalars['Boolean']>
   sort?: InputMaybe<Array<AtomAllowedChildrenConnectionSort>>
+}
+
+export type AtomRequiredParentConnectionArgs = {
+  where?: InputMaybe<AtomRequiredParentConnectionWhere>
+  first?: InputMaybe<Scalars['Int']>
+  after?: InputMaybe<Scalars['String']>
+  directed?: InputMaybe<Scalars['Boolean']>
+  sort?: InputMaybe<Array<AtomRequiredParentConnectionSort>>
 }
 
 export type AtomAggregateSelection = {
@@ -2860,6 +2841,19 @@ export type AtomAtomAllowedChildrenNodeAggregateSelection = {
   icon: StringAggregateSelectionNullable
 }
 
+export type AtomAtomRequiredParentAggregationSelection = {
+  __typename?: 'AtomAtomRequiredParentAggregationSelection'
+  count: Scalars['Int']
+  node?: Maybe<AtomAtomRequiredParentNodeAggregateSelection>
+}
+
+export type AtomAtomRequiredParentNodeAggregateSelection = {
+  __typename?: 'AtomAtomRequiredParentNodeAggregateSelection'
+  id: IdAggregateSelectionNonNullable
+  name: StringAggregateSelectionNonNullable
+  icon: StringAggregateSelectionNullable
+}
+
 export type AtomEdge = {
   __typename?: 'AtomEdge'
   cursor: Scalars['String']
@@ -2876,6 +2870,19 @@ export type AtomInterfaceTypeApiNodeAggregateSelection = {
   __typename?: 'AtomInterfaceTypeApiNodeAggregateSelection'
   id: IdAggregateSelectionNonNullable
   name: StringAggregateSelectionNonNullable
+}
+
+export type AtomRequiredParentConnection = {
+  __typename?: 'AtomRequiredParentConnection'
+  edges: Array<AtomRequiredParentRelationship>
+  totalCount: Scalars['Int']
+  pageInfo: PageInfo
+}
+
+export type AtomRequiredParentRelationship = {
+  __typename?: 'AtomRequiredParentRelationship'
+  cursor: Scalars['String']
+  node: Atom
 }
 
 export type AtomsConnection = {
@@ -3550,12 +3557,6 @@ export type CreatePrimitiveTypesMutationResponse = {
   primitiveTypes: Array<PrimitiveType>
 }
 
-export type CreatePropMapBindingsMutationResponse = {
-  __typename?: 'CreatePropMapBindingsMutationResponse'
-  info: CreateInfo
-  propMapBindings: Array<PropMapBinding>
-}
-
 export type CreatePropsMutationResponse = {
   __typename?: 'CreatePropsMutationResponse'
   info: CreateInfo
@@ -3765,8 +3766,6 @@ export type Element = {
   renderAtomTypeAggregate?: Maybe<ElementAtomRenderAtomTypeAggregationSelection>
   hooks: Array<Hook>
   hooksAggregate?: Maybe<ElementHookHooksAggregationSelection>
-  propMapBindings: Array<PropMapBinding>
-  propMapBindingsAggregate?: Maybe<ElementPropMapBindingPropMapBindingsAggregationSelection>
   nextSiblingConnection: ElementNextSiblingConnection
   prevSiblingConnection: ElementPrevSiblingConnection
   firstChildConnection: ElementFirstChildConnection
@@ -3777,7 +3776,6 @@ export type Element = {
   renderComponentTypeConnection: ElementRenderComponentTypeConnection
   renderAtomTypeConnection: ElementRenderAtomTypeConnection
   hooksConnection: ElementHooksConnection
-  propMapBindingsConnection: ElementPropMapBindingsConnection
 }
 
 export type ElementNextSiblingArgs = {
@@ -3890,17 +3888,6 @@ export type ElementHooksAggregateArgs = {
   directed?: InputMaybe<Scalars['Boolean']>
 }
 
-export type ElementPropMapBindingsArgs = {
-  where?: InputMaybe<PropMapBindingWhere>
-  options?: InputMaybe<PropMapBindingOptions>
-  directed?: InputMaybe<Scalars['Boolean']>
-}
-
-export type ElementPropMapBindingsAggregateArgs = {
-  where?: InputMaybe<PropMapBindingWhere>
-  directed?: InputMaybe<Scalars['Boolean']>
-}
-
 export type ElementNextSiblingConnectionArgs = {
   where?: InputMaybe<ElementNextSiblingConnectionWhere>
   first?: InputMaybe<Scalars['Int']>
@@ -3979,14 +3966,6 @@ export type ElementHooksConnectionArgs = {
   after?: InputMaybe<Scalars['String']>
   directed?: InputMaybe<Scalars['Boolean']>
   sort?: InputMaybe<Array<ElementHooksConnectionSort>>
-}
-
-export type ElementPropMapBindingsConnectionArgs = {
-  where?: InputMaybe<ElementPropMapBindingsConnectionWhere>
-  first?: InputMaybe<Scalars['Int']>
-  after?: InputMaybe<Scalars['String']>
-  directed?: InputMaybe<Scalars['Boolean']>
-  sort?: InputMaybe<Array<ElementPropMapBindingsConnectionSort>>
 }
 
 export type ElementAggregateSelection = {
@@ -4241,32 +4220,6 @@ export type ElementPrevSiblingRelationship = {
   __typename?: 'ElementPrevSiblingRelationship'
   cursor: Scalars['String']
   node: Element
-}
-
-export type ElementPropMapBindingPropMapBindingsAggregationSelection = {
-  __typename?: 'ElementPropMapBindingPropMapBindingsAggregationSelection'
-  count: Scalars['Int']
-  node?: Maybe<ElementPropMapBindingPropMapBindingsNodeAggregateSelection>
-}
-
-export type ElementPropMapBindingPropMapBindingsNodeAggregateSelection = {
-  __typename?: 'ElementPropMapBindingPropMapBindingsNodeAggregateSelection'
-  id: IdAggregateSelectionNonNullable
-  sourceKey: StringAggregateSelectionNonNullable
-  targetKey: StringAggregateSelectionNonNullable
-}
-
-export type ElementPropMapBindingsConnection = {
-  __typename?: 'ElementPropMapBindingsConnection'
-  edges: Array<ElementPropMapBindingsRelationship>
-  totalCount: Scalars['Int']
-  pageInfo: PageInfo
-}
-
-export type ElementPropMapBindingsRelationship = {
-  __typename?: 'ElementPropMapBindingsRelationship'
-  cursor: Scalars['String']
-  node: PropMapBinding
 }
 
 export type ElementPropPropsAggregationSelection = {
@@ -5535,144 +5488,6 @@ export type PropEdge = {
   node: Prop
 }
 
-export type PropMapBinding = {
-  __typename?: 'PropMapBinding'
-  id: Scalars['ID']
-  sourceKey: Scalars['String']
-  targetKey: Scalars['String']
-  element: Element
-  elementAggregate?: Maybe<PropMapBindingElementElementAggregationSelection>
-  targetElement?: Maybe<Element>
-  targetElementAggregate?: Maybe<PropMapBindingElementTargetElementAggregationSelection>
-  elementConnection: PropMapBindingElementConnection
-  targetElementConnection: PropMapBindingTargetElementConnection
-}
-
-export type PropMapBindingElementArgs = {
-  where?: InputMaybe<ElementWhere>
-  options?: InputMaybe<ElementOptions>
-  directed?: InputMaybe<Scalars['Boolean']>
-}
-
-export type PropMapBindingElementAggregateArgs = {
-  where?: InputMaybe<ElementWhere>
-  directed?: InputMaybe<Scalars['Boolean']>
-}
-
-export type PropMapBindingTargetElementArgs = {
-  where?: InputMaybe<ElementWhere>
-  options?: InputMaybe<ElementOptions>
-  directed?: InputMaybe<Scalars['Boolean']>
-}
-
-export type PropMapBindingTargetElementAggregateArgs = {
-  where?: InputMaybe<ElementWhere>
-  directed?: InputMaybe<Scalars['Boolean']>
-}
-
-export type PropMapBindingElementConnectionArgs = {
-  where?: InputMaybe<PropMapBindingElementConnectionWhere>
-  first?: InputMaybe<Scalars['Int']>
-  after?: InputMaybe<Scalars['String']>
-  directed?: InputMaybe<Scalars['Boolean']>
-  sort?: InputMaybe<Array<PropMapBindingElementConnectionSort>>
-}
-
-export type PropMapBindingTargetElementConnectionArgs = {
-  where?: InputMaybe<PropMapBindingTargetElementConnectionWhere>
-  first?: InputMaybe<Scalars['Int']>
-  after?: InputMaybe<Scalars['String']>
-  directed?: InputMaybe<Scalars['Boolean']>
-  sort?: InputMaybe<Array<PropMapBindingTargetElementConnectionSort>>
-}
-
-export type PropMapBindingAggregateSelection = {
-  __typename?: 'PropMapBindingAggregateSelection'
-  count: Scalars['Int']
-  id: IdAggregateSelectionNonNullable
-  sourceKey: StringAggregateSelectionNonNullable
-  targetKey: StringAggregateSelectionNonNullable
-}
-
-export type PropMapBindingEdge = {
-  __typename?: 'PropMapBindingEdge'
-  cursor: Scalars['String']
-  node: PropMapBinding
-}
-
-export type PropMapBindingElementConnection = {
-  __typename?: 'PropMapBindingElementConnection'
-  edges: Array<PropMapBindingElementRelationship>
-  totalCount: Scalars['Int']
-  pageInfo: PageInfo
-}
-
-export type PropMapBindingElementElementAggregationSelection = {
-  __typename?: 'PropMapBindingElementElementAggregationSelection'
-  count: Scalars['Int']
-  node?: Maybe<PropMapBindingElementElementNodeAggregateSelection>
-}
-
-export type PropMapBindingElementElementNodeAggregateSelection = {
-  __typename?: 'PropMapBindingElementElementNodeAggregateSelection'
-  id: IdAggregateSelectionNonNullable
-  slug: StringAggregateSelectionNonNullable
-  name: StringAggregateSelectionNullable
-  customCss: StringAggregateSelectionNullable
-  guiCss: StringAggregateSelectionNullable
-  propTransformationJs: StringAggregateSelectionNullable
-  renderForEachPropKey: StringAggregateSelectionNullable
-  renderIfExpression: StringAggregateSelectionNullable
-  preRenderActionId: StringAggregateSelectionNullable
-  postRenderActionId: StringAggregateSelectionNullable
-}
-
-export type PropMapBindingElementRelationship = {
-  __typename?: 'PropMapBindingElementRelationship'
-  cursor: Scalars['String']
-  node: Element
-}
-
-export type PropMapBindingElementTargetElementAggregationSelection = {
-  __typename?: 'PropMapBindingElementTargetElementAggregationSelection'
-  count: Scalars['Int']
-  node?: Maybe<PropMapBindingElementTargetElementNodeAggregateSelection>
-}
-
-export type PropMapBindingElementTargetElementNodeAggregateSelection = {
-  __typename?: 'PropMapBindingElementTargetElementNodeAggregateSelection'
-  id: IdAggregateSelectionNonNullable
-  slug: StringAggregateSelectionNonNullable
-  name: StringAggregateSelectionNullable
-  customCss: StringAggregateSelectionNullable
-  guiCss: StringAggregateSelectionNullable
-  propTransformationJs: StringAggregateSelectionNullable
-  renderForEachPropKey: StringAggregateSelectionNullable
-  renderIfExpression: StringAggregateSelectionNullable
-  preRenderActionId: StringAggregateSelectionNullable
-  postRenderActionId: StringAggregateSelectionNullable
-}
-
-export type PropMapBindingsConnection = {
-  __typename?: 'PropMapBindingsConnection'
-  totalCount: Scalars['Int']
-  pageInfo: PageInfo
-  edges: Array<PropMapBindingEdge>
-}
-
-export type PropMapBindingTargetElementConnection = {
-  __typename?: 'PropMapBindingTargetElementConnection'
-  edges: Array<PropMapBindingTargetElementRelationship>
-  totalCount: Scalars['Int']
-  pageInfo: PageInfo
-}
-
-export type PropMapBindingTargetElementRelationship = {
-  __typename?: 'PropMapBindingTargetElementRelationship'
-  cursor: Scalars['String']
-  node: Element
-}
-
 export type PropsConnection = {
   __typename?: 'PropsConnection'
   totalCount: Scalars['Int']
@@ -6639,12 +6454,6 @@ export type UpdatePrimitiveTypesMutationResponse = {
   __typename?: 'UpdatePrimitiveTypesMutationResponse'
   info: UpdateInfo
   primitiveTypes: Array<PrimitiveType>
-}
-
-export type UpdatePropMapBindingsMutationResponse = {
-  __typename?: 'UpdatePropMapBindingsMutationResponse'
-  info: UpdateInfo
-  propMapBindings: Array<PropMapBinding>
 }
 
 export type UpdatePropsMutationResponse = {
@@ -10008,6 +9817,7 @@ export type AtomConnectInput = {
   tags?: InputMaybe<Array<AtomTagsConnectFieldInput>>
   api?: InputMaybe<AtomApiConnectFieldInput>
   allowedChildren?: InputMaybe<Array<AtomAllowedChildrenConnectFieldInput>>
+  requiredParent?: InputMaybe<AtomRequiredParentConnectFieldInput>
 }
 
 export type AtomConnectOrCreateInput = {
@@ -10016,6 +9826,7 @@ export type AtomConnectOrCreateInput = {
   allowedChildren?: InputMaybe<
     Array<AtomAllowedChildrenConnectOrCreateFieldInput>
   >
+  requiredParent?: InputMaybe<AtomRequiredParentConnectOrCreateFieldInput>
 }
 
 export type AtomConnectOrCreateWhere = {
@@ -10034,18 +9845,21 @@ export type AtomCreateInput = {
   tags?: InputMaybe<AtomTagsFieldInput>
   api?: InputMaybe<AtomApiFieldInput>
   allowedChildren?: InputMaybe<AtomAllowedChildrenFieldInput>
+  requiredParent?: InputMaybe<AtomRequiredParentFieldInput>
 }
 
 export type AtomDeleteInput = {
   tags?: InputMaybe<Array<AtomTagsDeleteFieldInput>>
   api?: InputMaybe<AtomApiDeleteFieldInput>
   allowedChildren?: InputMaybe<Array<AtomAllowedChildrenDeleteFieldInput>>
+  requiredParent?: InputMaybe<AtomRequiredParentDeleteFieldInput>
 }
 
 export type AtomDisconnectInput = {
   tags?: InputMaybe<Array<AtomTagsDisconnectFieldInput>>
   api?: InputMaybe<AtomApiDisconnectFieldInput>
   allowedChildren?: InputMaybe<Array<AtomAllowedChildrenDisconnectFieldInput>>
+  requiredParent?: InputMaybe<AtomRequiredParentDisconnectFieldInput>
 }
 
 export type AtomOnCreateInput = {
@@ -10066,6 +9880,123 @@ export type AtomRelationInput = {
   tags?: InputMaybe<Array<AtomTagsCreateFieldInput>>
   api?: InputMaybe<AtomApiCreateFieldInput>
   allowedChildren?: InputMaybe<Array<AtomAllowedChildrenCreateFieldInput>>
+  requiredParent?: InputMaybe<AtomRequiredParentCreateFieldInput>
+}
+
+export type AtomRequiredParentAggregateInput = {
+  count?: InputMaybe<Scalars['Int']>
+  count_LT?: InputMaybe<Scalars['Int']>
+  count_LTE?: InputMaybe<Scalars['Int']>
+  count_GT?: InputMaybe<Scalars['Int']>
+  count_GTE?: InputMaybe<Scalars['Int']>
+  AND?: InputMaybe<Array<AtomRequiredParentAggregateInput>>
+  OR?: InputMaybe<Array<AtomRequiredParentAggregateInput>>
+  node?: InputMaybe<AtomRequiredParentNodeAggregationWhereInput>
+}
+
+export type AtomRequiredParentConnectFieldInput = {
+  where?: InputMaybe<AtomConnectWhere>
+  connect?: InputMaybe<AtomConnectInput>
+}
+
+export type AtomRequiredParentConnectionSort = {
+  node?: InputMaybe<AtomSort>
+}
+
+export type AtomRequiredParentConnectionWhere = {
+  AND?: InputMaybe<Array<AtomRequiredParentConnectionWhere>>
+  OR?: InputMaybe<Array<AtomRequiredParentConnectionWhere>>
+  node?: InputMaybe<AtomWhere>
+  node_NOT?: InputMaybe<AtomWhere>
+}
+
+export type AtomRequiredParentConnectOrCreateFieldInput = {
+  where: AtomConnectOrCreateWhere
+  onCreate: AtomRequiredParentConnectOrCreateFieldInputOnCreate
+}
+
+export type AtomRequiredParentConnectOrCreateFieldInputOnCreate = {
+  node: AtomOnCreateInput
+}
+
+export type AtomRequiredParentCreateFieldInput = {
+  node: AtomCreateInput
+}
+
+export type AtomRequiredParentDeleteFieldInput = {
+  where?: InputMaybe<AtomRequiredParentConnectionWhere>
+  delete?: InputMaybe<AtomDeleteInput>
+}
+
+export type AtomRequiredParentDisconnectFieldInput = {
+  where?: InputMaybe<AtomRequiredParentConnectionWhere>
+  disconnect?: InputMaybe<AtomDisconnectInput>
+}
+
+export type AtomRequiredParentFieldInput = {
+  create?: InputMaybe<AtomRequiredParentCreateFieldInput>
+  connect?: InputMaybe<AtomRequiredParentConnectFieldInput>
+  connectOrCreate?: InputMaybe<AtomRequiredParentConnectOrCreateFieldInput>
+}
+
+export type AtomRequiredParentNodeAggregationWhereInput = {
+  AND?: InputMaybe<Array<AtomRequiredParentNodeAggregationWhereInput>>
+  OR?: InputMaybe<Array<AtomRequiredParentNodeAggregationWhereInput>>
+  id_EQUAL?: InputMaybe<Scalars['ID']>
+  name_EQUAL?: InputMaybe<Scalars['String']>
+  name_AVERAGE_EQUAL?: InputMaybe<Scalars['Float']>
+  name_LONGEST_EQUAL?: InputMaybe<Scalars['Int']>
+  name_SHORTEST_EQUAL?: InputMaybe<Scalars['Int']>
+  name_GT?: InputMaybe<Scalars['Int']>
+  name_AVERAGE_GT?: InputMaybe<Scalars['Float']>
+  name_LONGEST_GT?: InputMaybe<Scalars['Int']>
+  name_SHORTEST_GT?: InputMaybe<Scalars['Int']>
+  name_GTE?: InputMaybe<Scalars['Int']>
+  name_AVERAGE_GTE?: InputMaybe<Scalars['Float']>
+  name_LONGEST_GTE?: InputMaybe<Scalars['Int']>
+  name_SHORTEST_GTE?: InputMaybe<Scalars['Int']>
+  name_LT?: InputMaybe<Scalars['Int']>
+  name_AVERAGE_LT?: InputMaybe<Scalars['Float']>
+  name_LONGEST_LT?: InputMaybe<Scalars['Int']>
+  name_SHORTEST_LT?: InputMaybe<Scalars['Int']>
+  name_LTE?: InputMaybe<Scalars['Int']>
+  name_AVERAGE_LTE?: InputMaybe<Scalars['Float']>
+  name_LONGEST_LTE?: InputMaybe<Scalars['Int']>
+  name_SHORTEST_LTE?: InputMaybe<Scalars['Int']>
+  icon_EQUAL?: InputMaybe<Scalars['String']>
+  icon_AVERAGE_EQUAL?: InputMaybe<Scalars['Float']>
+  icon_LONGEST_EQUAL?: InputMaybe<Scalars['Int']>
+  icon_SHORTEST_EQUAL?: InputMaybe<Scalars['Int']>
+  icon_GT?: InputMaybe<Scalars['Int']>
+  icon_AVERAGE_GT?: InputMaybe<Scalars['Float']>
+  icon_LONGEST_GT?: InputMaybe<Scalars['Int']>
+  icon_SHORTEST_GT?: InputMaybe<Scalars['Int']>
+  icon_GTE?: InputMaybe<Scalars['Int']>
+  icon_AVERAGE_GTE?: InputMaybe<Scalars['Float']>
+  icon_LONGEST_GTE?: InputMaybe<Scalars['Int']>
+  icon_SHORTEST_GTE?: InputMaybe<Scalars['Int']>
+  icon_LT?: InputMaybe<Scalars['Int']>
+  icon_AVERAGE_LT?: InputMaybe<Scalars['Float']>
+  icon_LONGEST_LT?: InputMaybe<Scalars['Int']>
+  icon_SHORTEST_LT?: InputMaybe<Scalars['Int']>
+  icon_LTE?: InputMaybe<Scalars['Int']>
+  icon_AVERAGE_LTE?: InputMaybe<Scalars['Float']>
+  icon_LONGEST_LTE?: InputMaybe<Scalars['Int']>
+  icon_SHORTEST_LTE?: InputMaybe<Scalars['Int']>
+}
+
+export type AtomRequiredParentUpdateConnectionInput = {
+  node?: InputMaybe<AtomUpdateInput>
+}
+
+export type AtomRequiredParentUpdateFieldInput = {
+  where?: InputMaybe<AtomRequiredParentConnectionWhere>
+  update?: InputMaybe<AtomRequiredParentUpdateConnectionInput>
+  connect?: InputMaybe<AtomRequiredParentConnectFieldInput>
+  disconnect?: InputMaybe<AtomRequiredParentDisconnectFieldInput>
+  create?: InputMaybe<AtomRequiredParentCreateFieldInput>
+  delete?: InputMaybe<AtomRequiredParentDeleteFieldInput>
+  connectOrCreate?: InputMaybe<AtomRequiredParentConnectOrCreateFieldInput>
 }
 
 /** Fields to sort Atoms by. The order in which sorts are applied is not guaranteed when specifying many fields in one AtomSort object. */
@@ -10186,6 +10117,7 @@ export type AtomUpdateInput = {
   tags?: InputMaybe<Array<AtomTagsUpdateFieldInput>>
   api?: InputMaybe<AtomApiUpdateFieldInput>
   allowedChildren?: InputMaybe<Array<AtomAllowedChildrenUpdateFieldInput>>
+  requiredParent?: InputMaybe<AtomRequiredParentUpdateFieldInput>
 }
 
 export type AtomWhere = {
@@ -10257,6 +10189,9 @@ export type AtomWhere = {
   allowedChildren_SINGLE?: InputMaybe<AtomWhere>
   /** Return Atoms where some of the related Atoms match this filter */
   allowedChildren_SOME?: InputMaybe<AtomWhere>
+  requiredParent?: InputMaybe<AtomWhere>
+  requiredParent_NOT?: InputMaybe<AtomWhere>
+  requiredParentAggregate?: InputMaybe<AtomRequiredParentAggregateInput>
   /** @deprecated Use `tagsConnection_SOME` instead. */
   tagsConnection?: InputMaybe<AtomTagsConnectionWhere>
   /** @deprecated Use `tagsConnection_NONE` instead. */
@@ -10275,6 +10210,8 @@ export type AtomWhere = {
   allowedChildrenConnection_NONE?: InputMaybe<AtomAllowedChildrenConnectionWhere>
   allowedChildrenConnection_SINGLE?: InputMaybe<AtomAllowedChildrenConnectionWhere>
   allowedChildrenConnection_SOME?: InputMaybe<AtomAllowedChildrenConnectionWhere>
+  requiredParentConnection?: InputMaybe<AtomRequiredParentConnectionWhere>
+  requiredParentConnection_NOT?: InputMaybe<AtomRequiredParentConnectionWhere>
 }
 
 export type BaseTypeConnectInput = {
@@ -12068,7 +12005,6 @@ export type ElementConnectInput = {
   renderComponentType?: InputMaybe<ElementRenderComponentTypeConnectFieldInput>
   renderAtomType?: InputMaybe<ElementRenderAtomTypeConnectFieldInput>
   hooks?: InputMaybe<Array<ElementHooksConnectFieldInput>>
-  propMapBindings?: InputMaybe<Array<ElementPropMapBindingsConnectFieldInput>>
 }
 
 export type ElementConnectOrCreateInput = {
@@ -12082,9 +12018,6 @@ export type ElementConnectOrCreateInput = {
   renderComponentType?: InputMaybe<ElementRenderComponentTypeConnectOrCreateFieldInput>
   renderAtomType?: InputMaybe<ElementRenderAtomTypeConnectOrCreateFieldInput>
   hooks?: InputMaybe<Array<ElementHooksConnectOrCreateFieldInput>>
-  propMapBindings?: InputMaybe<
-    Array<ElementPropMapBindingsConnectOrCreateFieldInput>
-  >
 }
 
 export type ElementConnectOrCreateWhere = {
@@ -12116,7 +12049,6 @@ export type ElementCreateInput = {
   renderComponentType?: InputMaybe<ElementRenderComponentTypeFieldInput>
   renderAtomType?: InputMaybe<ElementRenderAtomTypeFieldInput>
   hooks?: InputMaybe<ElementHooksFieldInput>
-  propMapBindings?: InputMaybe<ElementPropMapBindingsFieldInput>
 }
 
 export type ElementDeleteInput = {
@@ -12130,7 +12062,6 @@ export type ElementDeleteInput = {
   renderComponentType?: InputMaybe<ElementRenderComponentTypeDeleteFieldInput>
   renderAtomType?: InputMaybe<ElementRenderAtomTypeDeleteFieldInput>
   hooks?: InputMaybe<Array<ElementHooksDeleteFieldInput>>
-  propMapBindings?: InputMaybe<Array<ElementPropMapBindingsDeleteFieldInput>>
 }
 
 export type ElementDisconnectInput = {
@@ -12144,9 +12075,6 @@ export type ElementDisconnectInput = {
   renderComponentType?: InputMaybe<ElementRenderComponentTypeDisconnectFieldInput>
   renderAtomType?: InputMaybe<ElementRenderAtomTypeDisconnectFieldInput>
   hooks?: InputMaybe<Array<ElementHooksDisconnectFieldInput>>
-  propMapBindings?: InputMaybe<
-    Array<ElementPropMapBindingsDisconnectFieldInput>
-  >
 }
 
 export type ElementFirstChildAggregateInput = {
@@ -13501,126 +13429,6 @@ export type ElementPrevSiblingUpdateFieldInput = {
   connectOrCreate?: InputMaybe<ElementPrevSiblingConnectOrCreateFieldInput>
 }
 
-export type ElementPropMapBindingsAggregateInput = {
-  count?: InputMaybe<Scalars['Int']>
-  count_LT?: InputMaybe<Scalars['Int']>
-  count_LTE?: InputMaybe<Scalars['Int']>
-  count_GT?: InputMaybe<Scalars['Int']>
-  count_GTE?: InputMaybe<Scalars['Int']>
-  AND?: InputMaybe<Array<ElementPropMapBindingsAggregateInput>>
-  OR?: InputMaybe<Array<ElementPropMapBindingsAggregateInput>>
-  node?: InputMaybe<ElementPropMapBindingsNodeAggregationWhereInput>
-}
-
-export type ElementPropMapBindingsConnectFieldInput = {
-  where?: InputMaybe<PropMapBindingConnectWhere>
-  connect?: InputMaybe<Array<PropMapBindingConnectInput>>
-}
-
-export type ElementPropMapBindingsConnectionSort = {
-  node?: InputMaybe<PropMapBindingSort>
-}
-
-export type ElementPropMapBindingsConnectionWhere = {
-  AND?: InputMaybe<Array<ElementPropMapBindingsConnectionWhere>>
-  OR?: InputMaybe<Array<ElementPropMapBindingsConnectionWhere>>
-  node?: InputMaybe<PropMapBindingWhere>
-  node_NOT?: InputMaybe<PropMapBindingWhere>
-}
-
-export type ElementPropMapBindingsConnectOrCreateFieldInput = {
-  where: PropMapBindingConnectOrCreateWhere
-  onCreate: ElementPropMapBindingsConnectOrCreateFieldInputOnCreate
-}
-
-export type ElementPropMapBindingsConnectOrCreateFieldInputOnCreate = {
-  node: PropMapBindingOnCreateInput
-}
-
-export type ElementPropMapBindingsCreateFieldInput = {
-  node: PropMapBindingCreateInput
-}
-
-export type ElementPropMapBindingsDeleteFieldInput = {
-  where?: InputMaybe<ElementPropMapBindingsConnectionWhere>
-  delete?: InputMaybe<PropMapBindingDeleteInput>
-}
-
-export type ElementPropMapBindingsDisconnectFieldInput = {
-  where?: InputMaybe<ElementPropMapBindingsConnectionWhere>
-  disconnect?: InputMaybe<PropMapBindingDisconnectInput>
-}
-
-export type ElementPropMapBindingsFieldInput = {
-  create?: InputMaybe<Array<ElementPropMapBindingsCreateFieldInput>>
-  connect?: InputMaybe<Array<ElementPropMapBindingsConnectFieldInput>>
-  connectOrCreate?: InputMaybe<
-    Array<ElementPropMapBindingsConnectOrCreateFieldInput>
-  >
-}
-
-export type ElementPropMapBindingsNodeAggregationWhereInput = {
-  AND?: InputMaybe<Array<ElementPropMapBindingsNodeAggregationWhereInput>>
-  OR?: InputMaybe<Array<ElementPropMapBindingsNodeAggregationWhereInput>>
-  id_EQUAL?: InputMaybe<Scalars['ID']>
-  sourceKey_EQUAL?: InputMaybe<Scalars['String']>
-  sourceKey_AVERAGE_EQUAL?: InputMaybe<Scalars['Float']>
-  sourceKey_LONGEST_EQUAL?: InputMaybe<Scalars['Int']>
-  sourceKey_SHORTEST_EQUAL?: InputMaybe<Scalars['Int']>
-  sourceKey_GT?: InputMaybe<Scalars['Int']>
-  sourceKey_AVERAGE_GT?: InputMaybe<Scalars['Float']>
-  sourceKey_LONGEST_GT?: InputMaybe<Scalars['Int']>
-  sourceKey_SHORTEST_GT?: InputMaybe<Scalars['Int']>
-  sourceKey_GTE?: InputMaybe<Scalars['Int']>
-  sourceKey_AVERAGE_GTE?: InputMaybe<Scalars['Float']>
-  sourceKey_LONGEST_GTE?: InputMaybe<Scalars['Int']>
-  sourceKey_SHORTEST_GTE?: InputMaybe<Scalars['Int']>
-  sourceKey_LT?: InputMaybe<Scalars['Int']>
-  sourceKey_AVERAGE_LT?: InputMaybe<Scalars['Float']>
-  sourceKey_LONGEST_LT?: InputMaybe<Scalars['Int']>
-  sourceKey_SHORTEST_LT?: InputMaybe<Scalars['Int']>
-  sourceKey_LTE?: InputMaybe<Scalars['Int']>
-  sourceKey_AVERAGE_LTE?: InputMaybe<Scalars['Float']>
-  sourceKey_LONGEST_LTE?: InputMaybe<Scalars['Int']>
-  sourceKey_SHORTEST_LTE?: InputMaybe<Scalars['Int']>
-  targetKey_EQUAL?: InputMaybe<Scalars['String']>
-  targetKey_AVERAGE_EQUAL?: InputMaybe<Scalars['Float']>
-  targetKey_LONGEST_EQUAL?: InputMaybe<Scalars['Int']>
-  targetKey_SHORTEST_EQUAL?: InputMaybe<Scalars['Int']>
-  targetKey_GT?: InputMaybe<Scalars['Int']>
-  targetKey_AVERAGE_GT?: InputMaybe<Scalars['Float']>
-  targetKey_LONGEST_GT?: InputMaybe<Scalars['Int']>
-  targetKey_SHORTEST_GT?: InputMaybe<Scalars['Int']>
-  targetKey_GTE?: InputMaybe<Scalars['Int']>
-  targetKey_AVERAGE_GTE?: InputMaybe<Scalars['Float']>
-  targetKey_LONGEST_GTE?: InputMaybe<Scalars['Int']>
-  targetKey_SHORTEST_GTE?: InputMaybe<Scalars['Int']>
-  targetKey_LT?: InputMaybe<Scalars['Int']>
-  targetKey_AVERAGE_LT?: InputMaybe<Scalars['Float']>
-  targetKey_LONGEST_LT?: InputMaybe<Scalars['Int']>
-  targetKey_SHORTEST_LT?: InputMaybe<Scalars['Int']>
-  targetKey_LTE?: InputMaybe<Scalars['Int']>
-  targetKey_AVERAGE_LTE?: InputMaybe<Scalars['Float']>
-  targetKey_LONGEST_LTE?: InputMaybe<Scalars['Int']>
-  targetKey_SHORTEST_LTE?: InputMaybe<Scalars['Int']>
-}
-
-export type ElementPropMapBindingsUpdateConnectionInput = {
-  node?: InputMaybe<PropMapBindingUpdateInput>
-}
-
-export type ElementPropMapBindingsUpdateFieldInput = {
-  where?: InputMaybe<ElementPropMapBindingsConnectionWhere>
-  update?: InputMaybe<ElementPropMapBindingsUpdateConnectionInput>
-  connect?: InputMaybe<Array<ElementPropMapBindingsConnectFieldInput>>
-  disconnect?: InputMaybe<Array<ElementPropMapBindingsDisconnectFieldInput>>
-  create?: InputMaybe<Array<ElementPropMapBindingsCreateFieldInput>>
-  delete?: InputMaybe<Array<ElementPropMapBindingsDeleteFieldInput>>
-  connectOrCreate?: InputMaybe<
-    Array<ElementPropMapBindingsConnectOrCreateFieldInput>
-  >
-}
-
 export type ElementPropsAggregateInput = {
   count?: InputMaybe<Scalars['Int']>
   count_LT?: InputMaybe<Scalars['Int']>
@@ -13725,7 +13533,6 @@ export type ElementRelationInput = {
   renderComponentType?: InputMaybe<ElementRenderComponentTypeCreateFieldInput>
   renderAtomType?: InputMaybe<ElementRenderAtomTypeCreateFieldInput>
   hooks?: InputMaybe<Array<ElementHooksCreateFieldInput>>
-  propMapBindings?: InputMaybe<Array<ElementPropMapBindingsCreateFieldInput>>
 }
 
 export type ElementRenderAtomTypeAggregateInput = {
@@ -14167,7 +13974,6 @@ export type ElementUpdateInput = {
   renderComponentType?: InputMaybe<ElementRenderComponentTypeUpdateFieldInput>
   renderAtomType?: InputMaybe<ElementRenderAtomTypeUpdateFieldInput>
   hooks?: InputMaybe<Array<ElementHooksUpdateFieldInput>>
-  propMapBindings?: InputMaybe<Array<ElementPropMapBindingsUpdateFieldInput>>
 }
 
 export type ElementWhere = {
@@ -14323,19 +14129,6 @@ export type ElementWhere = {
   hooks_SINGLE?: InputMaybe<HookWhere>
   /** Return Elements where some of the related Hooks match this filter */
   hooks_SOME?: InputMaybe<HookWhere>
-  /** @deprecated Use `propMapBindings_SOME` instead. */
-  propMapBindings?: InputMaybe<PropMapBindingWhere>
-  /** @deprecated Use `propMapBindings_NONE` instead. */
-  propMapBindings_NOT?: InputMaybe<PropMapBindingWhere>
-  propMapBindingsAggregate?: InputMaybe<ElementPropMapBindingsAggregateInput>
-  /** Return Elements where all of the related PropMapBindings match this filter */
-  propMapBindings_ALL?: InputMaybe<PropMapBindingWhere>
-  /** Return Elements where none of the related PropMapBindings match this filter */
-  propMapBindings_NONE?: InputMaybe<PropMapBindingWhere>
-  /** Return Elements where one of the related PropMapBindings match this filter */
-  propMapBindings_SINGLE?: InputMaybe<PropMapBindingWhere>
-  /** Return Elements where some of the related PropMapBindings match this filter */
-  propMapBindings_SOME?: InputMaybe<PropMapBindingWhere>
   nextSiblingConnection?: InputMaybe<ElementNextSiblingConnectionWhere>
   nextSiblingConnection_NOT?: InputMaybe<ElementNextSiblingConnectionWhere>
   prevSiblingConnection?: InputMaybe<ElementPrevSiblingConnectionWhere>
@@ -14362,14 +14155,6 @@ export type ElementWhere = {
   hooksConnection_NONE?: InputMaybe<ElementHooksConnectionWhere>
   hooksConnection_SINGLE?: InputMaybe<ElementHooksConnectionWhere>
   hooksConnection_SOME?: InputMaybe<ElementHooksConnectionWhere>
-  /** @deprecated Use `propMapBindingsConnection_SOME` instead. */
-  propMapBindingsConnection?: InputMaybe<ElementPropMapBindingsConnectionWhere>
-  /** @deprecated Use `propMapBindingsConnection_NONE` instead. */
-  propMapBindingsConnection_NOT?: InputMaybe<ElementPropMapBindingsConnectionWhere>
-  propMapBindingsConnection_ALL?: InputMaybe<ElementPropMapBindingsConnectionWhere>
-  propMapBindingsConnection_NONE?: InputMaybe<ElementPropMapBindingsConnectionWhere>
-  propMapBindingsConnection_SINGLE?: InputMaybe<ElementPropMapBindingsConnectionWhere>
-  propMapBindingsConnection_SOME?: InputMaybe<ElementPropMapBindingsConnectionWhere>
 }
 
 export type EnumTypeAllowedValuesAggregateInput = {
@@ -17818,636 +17603,6 @@ export type PropConnectWhere = {
 
 export type PropCreateInput = {
   data?: Scalars['String']
-}
-
-export type PropMapBindingConnectInput = {
-  element?: InputMaybe<PropMapBindingElementConnectFieldInput>
-  targetElement?: InputMaybe<PropMapBindingTargetElementConnectFieldInput>
-}
-
-export type PropMapBindingConnectOrCreateInput = {
-  element?: InputMaybe<PropMapBindingElementConnectOrCreateFieldInput>
-  targetElement?: InputMaybe<PropMapBindingTargetElementConnectOrCreateFieldInput>
-}
-
-export type PropMapBindingConnectOrCreateWhere = {
-  node: PropMapBindingUniqueWhere
-}
-
-export type PropMapBindingConnectWhere = {
-  node: PropMapBindingWhere
-}
-
-export type PropMapBindingCreateInput = {
-  sourceKey: Scalars['String']
-  targetKey: Scalars['String']
-  element?: InputMaybe<PropMapBindingElementFieldInput>
-  targetElement?: InputMaybe<PropMapBindingTargetElementFieldInput>
-}
-
-export type PropMapBindingDeleteInput = {
-  element?: InputMaybe<PropMapBindingElementDeleteFieldInput>
-  targetElement?: InputMaybe<PropMapBindingTargetElementDeleteFieldInput>
-}
-
-export type PropMapBindingDisconnectInput = {
-  element?: InputMaybe<PropMapBindingElementDisconnectFieldInput>
-  targetElement?: InputMaybe<PropMapBindingTargetElementDisconnectFieldInput>
-}
-
-export type PropMapBindingElementAggregateInput = {
-  count?: InputMaybe<Scalars['Int']>
-  count_LT?: InputMaybe<Scalars['Int']>
-  count_LTE?: InputMaybe<Scalars['Int']>
-  count_GT?: InputMaybe<Scalars['Int']>
-  count_GTE?: InputMaybe<Scalars['Int']>
-  AND?: InputMaybe<Array<PropMapBindingElementAggregateInput>>
-  OR?: InputMaybe<Array<PropMapBindingElementAggregateInput>>
-  node?: InputMaybe<PropMapBindingElementNodeAggregationWhereInput>
-}
-
-export type PropMapBindingElementConnectFieldInput = {
-  where?: InputMaybe<ElementConnectWhere>
-  connect?: InputMaybe<ElementConnectInput>
-}
-
-export type PropMapBindingElementConnectionSort = {
-  node?: InputMaybe<ElementSort>
-}
-
-export type PropMapBindingElementConnectionWhere = {
-  AND?: InputMaybe<Array<PropMapBindingElementConnectionWhere>>
-  OR?: InputMaybe<Array<PropMapBindingElementConnectionWhere>>
-  node?: InputMaybe<ElementWhere>
-  node_NOT?: InputMaybe<ElementWhere>
-}
-
-export type PropMapBindingElementConnectOrCreateFieldInput = {
-  where: ElementConnectOrCreateWhere
-  onCreate: PropMapBindingElementConnectOrCreateFieldInputOnCreate
-}
-
-export type PropMapBindingElementConnectOrCreateFieldInputOnCreate = {
-  node: ElementOnCreateInput
-}
-
-export type PropMapBindingElementCreateFieldInput = {
-  node: ElementCreateInput
-}
-
-export type PropMapBindingElementDeleteFieldInput = {
-  where?: InputMaybe<PropMapBindingElementConnectionWhere>
-  delete?: InputMaybe<ElementDeleteInput>
-}
-
-export type PropMapBindingElementDisconnectFieldInput = {
-  where?: InputMaybe<PropMapBindingElementConnectionWhere>
-  disconnect?: InputMaybe<ElementDisconnectInput>
-}
-
-export type PropMapBindingElementFieldInput = {
-  create?: InputMaybe<PropMapBindingElementCreateFieldInput>
-  connect?: InputMaybe<PropMapBindingElementConnectFieldInput>
-  connectOrCreate?: InputMaybe<PropMapBindingElementConnectOrCreateFieldInput>
-}
-
-export type PropMapBindingElementNodeAggregationWhereInput = {
-  AND?: InputMaybe<Array<PropMapBindingElementNodeAggregationWhereInput>>
-  OR?: InputMaybe<Array<PropMapBindingElementNodeAggregationWhereInput>>
-  id_EQUAL?: InputMaybe<Scalars['ID']>
-  slug_EQUAL?: InputMaybe<Scalars['String']>
-  slug_AVERAGE_EQUAL?: InputMaybe<Scalars['Float']>
-  slug_LONGEST_EQUAL?: InputMaybe<Scalars['Int']>
-  slug_SHORTEST_EQUAL?: InputMaybe<Scalars['Int']>
-  slug_GT?: InputMaybe<Scalars['Int']>
-  slug_AVERAGE_GT?: InputMaybe<Scalars['Float']>
-  slug_LONGEST_GT?: InputMaybe<Scalars['Int']>
-  slug_SHORTEST_GT?: InputMaybe<Scalars['Int']>
-  slug_GTE?: InputMaybe<Scalars['Int']>
-  slug_AVERAGE_GTE?: InputMaybe<Scalars['Float']>
-  slug_LONGEST_GTE?: InputMaybe<Scalars['Int']>
-  slug_SHORTEST_GTE?: InputMaybe<Scalars['Int']>
-  slug_LT?: InputMaybe<Scalars['Int']>
-  slug_AVERAGE_LT?: InputMaybe<Scalars['Float']>
-  slug_LONGEST_LT?: InputMaybe<Scalars['Int']>
-  slug_SHORTEST_LT?: InputMaybe<Scalars['Int']>
-  slug_LTE?: InputMaybe<Scalars['Int']>
-  slug_AVERAGE_LTE?: InputMaybe<Scalars['Float']>
-  slug_LONGEST_LTE?: InputMaybe<Scalars['Int']>
-  slug_SHORTEST_LTE?: InputMaybe<Scalars['Int']>
-  name_EQUAL?: InputMaybe<Scalars['String']>
-  name_AVERAGE_EQUAL?: InputMaybe<Scalars['Float']>
-  name_LONGEST_EQUAL?: InputMaybe<Scalars['Int']>
-  name_SHORTEST_EQUAL?: InputMaybe<Scalars['Int']>
-  name_GT?: InputMaybe<Scalars['Int']>
-  name_AVERAGE_GT?: InputMaybe<Scalars['Float']>
-  name_LONGEST_GT?: InputMaybe<Scalars['Int']>
-  name_SHORTEST_GT?: InputMaybe<Scalars['Int']>
-  name_GTE?: InputMaybe<Scalars['Int']>
-  name_AVERAGE_GTE?: InputMaybe<Scalars['Float']>
-  name_LONGEST_GTE?: InputMaybe<Scalars['Int']>
-  name_SHORTEST_GTE?: InputMaybe<Scalars['Int']>
-  name_LT?: InputMaybe<Scalars['Int']>
-  name_AVERAGE_LT?: InputMaybe<Scalars['Float']>
-  name_LONGEST_LT?: InputMaybe<Scalars['Int']>
-  name_SHORTEST_LT?: InputMaybe<Scalars['Int']>
-  name_LTE?: InputMaybe<Scalars['Int']>
-  name_AVERAGE_LTE?: InputMaybe<Scalars['Float']>
-  name_LONGEST_LTE?: InputMaybe<Scalars['Int']>
-  name_SHORTEST_LTE?: InputMaybe<Scalars['Int']>
-  customCss_EQUAL?: InputMaybe<Scalars['String']>
-  customCss_AVERAGE_EQUAL?: InputMaybe<Scalars['Float']>
-  customCss_LONGEST_EQUAL?: InputMaybe<Scalars['Int']>
-  customCss_SHORTEST_EQUAL?: InputMaybe<Scalars['Int']>
-  customCss_GT?: InputMaybe<Scalars['Int']>
-  customCss_AVERAGE_GT?: InputMaybe<Scalars['Float']>
-  customCss_LONGEST_GT?: InputMaybe<Scalars['Int']>
-  customCss_SHORTEST_GT?: InputMaybe<Scalars['Int']>
-  customCss_GTE?: InputMaybe<Scalars['Int']>
-  customCss_AVERAGE_GTE?: InputMaybe<Scalars['Float']>
-  customCss_LONGEST_GTE?: InputMaybe<Scalars['Int']>
-  customCss_SHORTEST_GTE?: InputMaybe<Scalars['Int']>
-  customCss_LT?: InputMaybe<Scalars['Int']>
-  customCss_AVERAGE_LT?: InputMaybe<Scalars['Float']>
-  customCss_LONGEST_LT?: InputMaybe<Scalars['Int']>
-  customCss_SHORTEST_LT?: InputMaybe<Scalars['Int']>
-  customCss_LTE?: InputMaybe<Scalars['Int']>
-  customCss_AVERAGE_LTE?: InputMaybe<Scalars['Float']>
-  customCss_LONGEST_LTE?: InputMaybe<Scalars['Int']>
-  customCss_SHORTEST_LTE?: InputMaybe<Scalars['Int']>
-  guiCss_EQUAL?: InputMaybe<Scalars['String']>
-  guiCss_AVERAGE_EQUAL?: InputMaybe<Scalars['Float']>
-  guiCss_LONGEST_EQUAL?: InputMaybe<Scalars['Int']>
-  guiCss_SHORTEST_EQUAL?: InputMaybe<Scalars['Int']>
-  guiCss_GT?: InputMaybe<Scalars['Int']>
-  guiCss_AVERAGE_GT?: InputMaybe<Scalars['Float']>
-  guiCss_LONGEST_GT?: InputMaybe<Scalars['Int']>
-  guiCss_SHORTEST_GT?: InputMaybe<Scalars['Int']>
-  guiCss_GTE?: InputMaybe<Scalars['Int']>
-  guiCss_AVERAGE_GTE?: InputMaybe<Scalars['Float']>
-  guiCss_LONGEST_GTE?: InputMaybe<Scalars['Int']>
-  guiCss_SHORTEST_GTE?: InputMaybe<Scalars['Int']>
-  guiCss_LT?: InputMaybe<Scalars['Int']>
-  guiCss_AVERAGE_LT?: InputMaybe<Scalars['Float']>
-  guiCss_LONGEST_LT?: InputMaybe<Scalars['Int']>
-  guiCss_SHORTEST_LT?: InputMaybe<Scalars['Int']>
-  guiCss_LTE?: InputMaybe<Scalars['Int']>
-  guiCss_AVERAGE_LTE?: InputMaybe<Scalars['Float']>
-  guiCss_LONGEST_LTE?: InputMaybe<Scalars['Int']>
-  guiCss_SHORTEST_LTE?: InputMaybe<Scalars['Int']>
-  propTransformationJs_EQUAL?: InputMaybe<Scalars['String']>
-  propTransformationJs_AVERAGE_EQUAL?: InputMaybe<Scalars['Float']>
-  propTransformationJs_LONGEST_EQUAL?: InputMaybe<Scalars['Int']>
-  propTransformationJs_SHORTEST_EQUAL?: InputMaybe<Scalars['Int']>
-  propTransformationJs_GT?: InputMaybe<Scalars['Int']>
-  propTransformationJs_AVERAGE_GT?: InputMaybe<Scalars['Float']>
-  propTransformationJs_LONGEST_GT?: InputMaybe<Scalars['Int']>
-  propTransformationJs_SHORTEST_GT?: InputMaybe<Scalars['Int']>
-  propTransformationJs_GTE?: InputMaybe<Scalars['Int']>
-  propTransformationJs_AVERAGE_GTE?: InputMaybe<Scalars['Float']>
-  propTransformationJs_LONGEST_GTE?: InputMaybe<Scalars['Int']>
-  propTransformationJs_SHORTEST_GTE?: InputMaybe<Scalars['Int']>
-  propTransformationJs_LT?: InputMaybe<Scalars['Int']>
-  propTransformationJs_AVERAGE_LT?: InputMaybe<Scalars['Float']>
-  propTransformationJs_LONGEST_LT?: InputMaybe<Scalars['Int']>
-  propTransformationJs_SHORTEST_LT?: InputMaybe<Scalars['Int']>
-  propTransformationJs_LTE?: InputMaybe<Scalars['Int']>
-  propTransformationJs_AVERAGE_LTE?: InputMaybe<Scalars['Float']>
-  propTransformationJs_LONGEST_LTE?: InputMaybe<Scalars['Int']>
-  propTransformationJs_SHORTEST_LTE?: InputMaybe<Scalars['Int']>
-  renderForEachPropKey_EQUAL?: InputMaybe<Scalars['String']>
-  renderForEachPropKey_AVERAGE_EQUAL?: InputMaybe<Scalars['Float']>
-  renderForEachPropKey_LONGEST_EQUAL?: InputMaybe<Scalars['Int']>
-  renderForEachPropKey_SHORTEST_EQUAL?: InputMaybe<Scalars['Int']>
-  renderForEachPropKey_GT?: InputMaybe<Scalars['Int']>
-  renderForEachPropKey_AVERAGE_GT?: InputMaybe<Scalars['Float']>
-  renderForEachPropKey_LONGEST_GT?: InputMaybe<Scalars['Int']>
-  renderForEachPropKey_SHORTEST_GT?: InputMaybe<Scalars['Int']>
-  renderForEachPropKey_GTE?: InputMaybe<Scalars['Int']>
-  renderForEachPropKey_AVERAGE_GTE?: InputMaybe<Scalars['Float']>
-  renderForEachPropKey_LONGEST_GTE?: InputMaybe<Scalars['Int']>
-  renderForEachPropKey_SHORTEST_GTE?: InputMaybe<Scalars['Int']>
-  renderForEachPropKey_LT?: InputMaybe<Scalars['Int']>
-  renderForEachPropKey_AVERAGE_LT?: InputMaybe<Scalars['Float']>
-  renderForEachPropKey_LONGEST_LT?: InputMaybe<Scalars['Int']>
-  renderForEachPropKey_SHORTEST_LT?: InputMaybe<Scalars['Int']>
-  renderForEachPropKey_LTE?: InputMaybe<Scalars['Int']>
-  renderForEachPropKey_AVERAGE_LTE?: InputMaybe<Scalars['Float']>
-  renderForEachPropKey_LONGEST_LTE?: InputMaybe<Scalars['Int']>
-  renderForEachPropKey_SHORTEST_LTE?: InputMaybe<Scalars['Int']>
-  renderIfExpression_EQUAL?: InputMaybe<Scalars['String']>
-  renderIfExpression_AVERAGE_EQUAL?: InputMaybe<Scalars['Float']>
-  renderIfExpression_LONGEST_EQUAL?: InputMaybe<Scalars['Int']>
-  renderIfExpression_SHORTEST_EQUAL?: InputMaybe<Scalars['Int']>
-  renderIfExpression_GT?: InputMaybe<Scalars['Int']>
-  renderIfExpression_AVERAGE_GT?: InputMaybe<Scalars['Float']>
-  renderIfExpression_LONGEST_GT?: InputMaybe<Scalars['Int']>
-  renderIfExpression_SHORTEST_GT?: InputMaybe<Scalars['Int']>
-  renderIfExpression_GTE?: InputMaybe<Scalars['Int']>
-  renderIfExpression_AVERAGE_GTE?: InputMaybe<Scalars['Float']>
-  renderIfExpression_LONGEST_GTE?: InputMaybe<Scalars['Int']>
-  renderIfExpression_SHORTEST_GTE?: InputMaybe<Scalars['Int']>
-  renderIfExpression_LT?: InputMaybe<Scalars['Int']>
-  renderIfExpression_AVERAGE_LT?: InputMaybe<Scalars['Float']>
-  renderIfExpression_LONGEST_LT?: InputMaybe<Scalars['Int']>
-  renderIfExpression_SHORTEST_LT?: InputMaybe<Scalars['Int']>
-  renderIfExpression_LTE?: InputMaybe<Scalars['Int']>
-  renderIfExpression_AVERAGE_LTE?: InputMaybe<Scalars['Float']>
-  renderIfExpression_LONGEST_LTE?: InputMaybe<Scalars['Int']>
-  renderIfExpression_SHORTEST_LTE?: InputMaybe<Scalars['Int']>
-  preRenderActionId_EQUAL?: InputMaybe<Scalars['String']>
-  preRenderActionId_AVERAGE_EQUAL?: InputMaybe<Scalars['Float']>
-  preRenderActionId_LONGEST_EQUAL?: InputMaybe<Scalars['Int']>
-  preRenderActionId_SHORTEST_EQUAL?: InputMaybe<Scalars['Int']>
-  preRenderActionId_GT?: InputMaybe<Scalars['Int']>
-  preRenderActionId_AVERAGE_GT?: InputMaybe<Scalars['Float']>
-  preRenderActionId_LONGEST_GT?: InputMaybe<Scalars['Int']>
-  preRenderActionId_SHORTEST_GT?: InputMaybe<Scalars['Int']>
-  preRenderActionId_GTE?: InputMaybe<Scalars['Int']>
-  preRenderActionId_AVERAGE_GTE?: InputMaybe<Scalars['Float']>
-  preRenderActionId_LONGEST_GTE?: InputMaybe<Scalars['Int']>
-  preRenderActionId_SHORTEST_GTE?: InputMaybe<Scalars['Int']>
-  preRenderActionId_LT?: InputMaybe<Scalars['Int']>
-  preRenderActionId_AVERAGE_LT?: InputMaybe<Scalars['Float']>
-  preRenderActionId_LONGEST_LT?: InputMaybe<Scalars['Int']>
-  preRenderActionId_SHORTEST_LT?: InputMaybe<Scalars['Int']>
-  preRenderActionId_LTE?: InputMaybe<Scalars['Int']>
-  preRenderActionId_AVERAGE_LTE?: InputMaybe<Scalars['Float']>
-  preRenderActionId_LONGEST_LTE?: InputMaybe<Scalars['Int']>
-  preRenderActionId_SHORTEST_LTE?: InputMaybe<Scalars['Int']>
-  postRenderActionId_EQUAL?: InputMaybe<Scalars['String']>
-  postRenderActionId_AVERAGE_EQUAL?: InputMaybe<Scalars['Float']>
-  postRenderActionId_LONGEST_EQUAL?: InputMaybe<Scalars['Int']>
-  postRenderActionId_SHORTEST_EQUAL?: InputMaybe<Scalars['Int']>
-  postRenderActionId_GT?: InputMaybe<Scalars['Int']>
-  postRenderActionId_AVERAGE_GT?: InputMaybe<Scalars['Float']>
-  postRenderActionId_LONGEST_GT?: InputMaybe<Scalars['Int']>
-  postRenderActionId_SHORTEST_GT?: InputMaybe<Scalars['Int']>
-  postRenderActionId_GTE?: InputMaybe<Scalars['Int']>
-  postRenderActionId_AVERAGE_GTE?: InputMaybe<Scalars['Float']>
-  postRenderActionId_LONGEST_GTE?: InputMaybe<Scalars['Int']>
-  postRenderActionId_SHORTEST_GTE?: InputMaybe<Scalars['Int']>
-  postRenderActionId_LT?: InputMaybe<Scalars['Int']>
-  postRenderActionId_AVERAGE_LT?: InputMaybe<Scalars['Float']>
-  postRenderActionId_LONGEST_LT?: InputMaybe<Scalars['Int']>
-  postRenderActionId_SHORTEST_LT?: InputMaybe<Scalars['Int']>
-  postRenderActionId_LTE?: InputMaybe<Scalars['Int']>
-  postRenderActionId_AVERAGE_LTE?: InputMaybe<Scalars['Float']>
-  postRenderActionId_LONGEST_LTE?: InputMaybe<Scalars['Int']>
-  postRenderActionId_SHORTEST_LTE?: InputMaybe<Scalars['Int']>
-}
-
-export type PropMapBindingElementUpdateConnectionInput = {
-  node?: InputMaybe<ElementUpdateInput>
-}
-
-export type PropMapBindingElementUpdateFieldInput = {
-  where?: InputMaybe<PropMapBindingElementConnectionWhere>
-  update?: InputMaybe<PropMapBindingElementUpdateConnectionInput>
-  connect?: InputMaybe<PropMapBindingElementConnectFieldInput>
-  disconnect?: InputMaybe<PropMapBindingElementDisconnectFieldInput>
-  create?: InputMaybe<PropMapBindingElementCreateFieldInput>
-  delete?: InputMaybe<PropMapBindingElementDeleteFieldInput>
-  connectOrCreate?: InputMaybe<PropMapBindingElementConnectOrCreateFieldInput>
-}
-
-export type PropMapBindingOnCreateInput = {
-  sourceKey: Scalars['String']
-  targetKey: Scalars['String']
-}
-
-export type PropMapBindingOptions = {
-  /** Specify one or more PropMapBindingSort objects to sort PropMapBindings by. The sorts will be applied in the order in which they are arranged in the array. */
-  sort?: InputMaybe<Array<PropMapBindingSort>>
-  limit?: InputMaybe<Scalars['Int']>
-  offset?: InputMaybe<Scalars['Int']>
-}
-
-export type PropMapBindingRelationInput = {
-  element?: InputMaybe<PropMapBindingElementCreateFieldInput>
-  targetElement?: InputMaybe<PropMapBindingTargetElementCreateFieldInput>
-}
-
-/** Fields to sort PropMapBindings by. The order in which sorts are applied is not guaranteed when specifying many fields in one PropMapBindingSort object. */
-export type PropMapBindingSort = {
-  id?: InputMaybe<SortDirection>
-  sourceKey?: InputMaybe<SortDirection>
-  targetKey?: InputMaybe<SortDirection>
-}
-
-export type PropMapBindingTargetElementAggregateInput = {
-  count?: InputMaybe<Scalars['Int']>
-  count_LT?: InputMaybe<Scalars['Int']>
-  count_LTE?: InputMaybe<Scalars['Int']>
-  count_GT?: InputMaybe<Scalars['Int']>
-  count_GTE?: InputMaybe<Scalars['Int']>
-  AND?: InputMaybe<Array<PropMapBindingTargetElementAggregateInput>>
-  OR?: InputMaybe<Array<PropMapBindingTargetElementAggregateInput>>
-  node?: InputMaybe<PropMapBindingTargetElementNodeAggregationWhereInput>
-}
-
-export type PropMapBindingTargetElementConnectFieldInput = {
-  where?: InputMaybe<ElementConnectWhere>
-  connect?: InputMaybe<ElementConnectInput>
-}
-
-export type PropMapBindingTargetElementConnectionSort = {
-  node?: InputMaybe<ElementSort>
-}
-
-export type PropMapBindingTargetElementConnectionWhere = {
-  AND?: InputMaybe<Array<PropMapBindingTargetElementConnectionWhere>>
-  OR?: InputMaybe<Array<PropMapBindingTargetElementConnectionWhere>>
-  node?: InputMaybe<ElementWhere>
-  node_NOT?: InputMaybe<ElementWhere>
-}
-
-export type PropMapBindingTargetElementConnectOrCreateFieldInput = {
-  where: ElementConnectOrCreateWhere
-  onCreate: PropMapBindingTargetElementConnectOrCreateFieldInputOnCreate
-}
-
-export type PropMapBindingTargetElementConnectOrCreateFieldInputOnCreate = {
-  node: ElementOnCreateInput
-}
-
-export type PropMapBindingTargetElementCreateFieldInput = {
-  node: ElementCreateInput
-}
-
-export type PropMapBindingTargetElementDeleteFieldInput = {
-  where?: InputMaybe<PropMapBindingTargetElementConnectionWhere>
-  delete?: InputMaybe<ElementDeleteInput>
-}
-
-export type PropMapBindingTargetElementDisconnectFieldInput = {
-  where?: InputMaybe<PropMapBindingTargetElementConnectionWhere>
-  disconnect?: InputMaybe<ElementDisconnectInput>
-}
-
-export type PropMapBindingTargetElementFieldInput = {
-  create?: InputMaybe<PropMapBindingTargetElementCreateFieldInput>
-  connect?: InputMaybe<PropMapBindingTargetElementConnectFieldInput>
-  connectOrCreate?: InputMaybe<PropMapBindingTargetElementConnectOrCreateFieldInput>
-}
-
-export type PropMapBindingTargetElementNodeAggregationWhereInput = {
-  AND?: InputMaybe<Array<PropMapBindingTargetElementNodeAggregationWhereInput>>
-  OR?: InputMaybe<Array<PropMapBindingTargetElementNodeAggregationWhereInput>>
-  id_EQUAL?: InputMaybe<Scalars['ID']>
-  slug_EQUAL?: InputMaybe<Scalars['String']>
-  slug_AVERAGE_EQUAL?: InputMaybe<Scalars['Float']>
-  slug_LONGEST_EQUAL?: InputMaybe<Scalars['Int']>
-  slug_SHORTEST_EQUAL?: InputMaybe<Scalars['Int']>
-  slug_GT?: InputMaybe<Scalars['Int']>
-  slug_AVERAGE_GT?: InputMaybe<Scalars['Float']>
-  slug_LONGEST_GT?: InputMaybe<Scalars['Int']>
-  slug_SHORTEST_GT?: InputMaybe<Scalars['Int']>
-  slug_GTE?: InputMaybe<Scalars['Int']>
-  slug_AVERAGE_GTE?: InputMaybe<Scalars['Float']>
-  slug_LONGEST_GTE?: InputMaybe<Scalars['Int']>
-  slug_SHORTEST_GTE?: InputMaybe<Scalars['Int']>
-  slug_LT?: InputMaybe<Scalars['Int']>
-  slug_AVERAGE_LT?: InputMaybe<Scalars['Float']>
-  slug_LONGEST_LT?: InputMaybe<Scalars['Int']>
-  slug_SHORTEST_LT?: InputMaybe<Scalars['Int']>
-  slug_LTE?: InputMaybe<Scalars['Int']>
-  slug_AVERAGE_LTE?: InputMaybe<Scalars['Float']>
-  slug_LONGEST_LTE?: InputMaybe<Scalars['Int']>
-  slug_SHORTEST_LTE?: InputMaybe<Scalars['Int']>
-  name_EQUAL?: InputMaybe<Scalars['String']>
-  name_AVERAGE_EQUAL?: InputMaybe<Scalars['Float']>
-  name_LONGEST_EQUAL?: InputMaybe<Scalars['Int']>
-  name_SHORTEST_EQUAL?: InputMaybe<Scalars['Int']>
-  name_GT?: InputMaybe<Scalars['Int']>
-  name_AVERAGE_GT?: InputMaybe<Scalars['Float']>
-  name_LONGEST_GT?: InputMaybe<Scalars['Int']>
-  name_SHORTEST_GT?: InputMaybe<Scalars['Int']>
-  name_GTE?: InputMaybe<Scalars['Int']>
-  name_AVERAGE_GTE?: InputMaybe<Scalars['Float']>
-  name_LONGEST_GTE?: InputMaybe<Scalars['Int']>
-  name_SHORTEST_GTE?: InputMaybe<Scalars['Int']>
-  name_LT?: InputMaybe<Scalars['Int']>
-  name_AVERAGE_LT?: InputMaybe<Scalars['Float']>
-  name_LONGEST_LT?: InputMaybe<Scalars['Int']>
-  name_SHORTEST_LT?: InputMaybe<Scalars['Int']>
-  name_LTE?: InputMaybe<Scalars['Int']>
-  name_AVERAGE_LTE?: InputMaybe<Scalars['Float']>
-  name_LONGEST_LTE?: InputMaybe<Scalars['Int']>
-  name_SHORTEST_LTE?: InputMaybe<Scalars['Int']>
-  customCss_EQUAL?: InputMaybe<Scalars['String']>
-  customCss_AVERAGE_EQUAL?: InputMaybe<Scalars['Float']>
-  customCss_LONGEST_EQUAL?: InputMaybe<Scalars['Int']>
-  customCss_SHORTEST_EQUAL?: InputMaybe<Scalars['Int']>
-  customCss_GT?: InputMaybe<Scalars['Int']>
-  customCss_AVERAGE_GT?: InputMaybe<Scalars['Float']>
-  customCss_LONGEST_GT?: InputMaybe<Scalars['Int']>
-  customCss_SHORTEST_GT?: InputMaybe<Scalars['Int']>
-  customCss_GTE?: InputMaybe<Scalars['Int']>
-  customCss_AVERAGE_GTE?: InputMaybe<Scalars['Float']>
-  customCss_LONGEST_GTE?: InputMaybe<Scalars['Int']>
-  customCss_SHORTEST_GTE?: InputMaybe<Scalars['Int']>
-  customCss_LT?: InputMaybe<Scalars['Int']>
-  customCss_AVERAGE_LT?: InputMaybe<Scalars['Float']>
-  customCss_LONGEST_LT?: InputMaybe<Scalars['Int']>
-  customCss_SHORTEST_LT?: InputMaybe<Scalars['Int']>
-  customCss_LTE?: InputMaybe<Scalars['Int']>
-  customCss_AVERAGE_LTE?: InputMaybe<Scalars['Float']>
-  customCss_LONGEST_LTE?: InputMaybe<Scalars['Int']>
-  customCss_SHORTEST_LTE?: InputMaybe<Scalars['Int']>
-  guiCss_EQUAL?: InputMaybe<Scalars['String']>
-  guiCss_AVERAGE_EQUAL?: InputMaybe<Scalars['Float']>
-  guiCss_LONGEST_EQUAL?: InputMaybe<Scalars['Int']>
-  guiCss_SHORTEST_EQUAL?: InputMaybe<Scalars['Int']>
-  guiCss_GT?: InputMaybe<Scalars['Int']>
-  guiCss_AVERAGE_GT?: InputMaybe<Scalars['Float']>
-  guiCss_LONGEST_GT?: InputMaybe<Scalars['Int']>
-  guiCss_SHORTEST_GT?: InputMaybe<Scalars['Int']>
-  guiCss_GTE?: InputMaybe<Scalars['Int']>
-  guiCss_AVERAGE_GTE?: InputMaybe<Scalars['Float']>
-  guiCss_LONGEST_GTE?: InputMaybe<Scalars['Int']>
-  guiCss_SHORTEST_GTE?: InputMaybe<Scalars['Int']>
-  guiCss_LT?: InputMaybe<Scalars['Int']>
-  guiCss_AVERAGE_LT?: InputMaybe<Scalars['Float']>
-  guiCss_LONGEST_LT?: InputMaybe<Scalars['Int']>
-  guiCss_SHORTEST_LT?: InputMaybe<Scalars['Int']>
-  guiCss_LTE?: InputMaybe<Scalars['Int']>
-  guiCss_AVERAGE_LTE?: InputMaybe<Scalars['Float']>
-  guiCss_LONGEST_LTE?: InputMaybe<Scalars['Int']>
-  guiCss_SHORTEST_LTE?: InputMaybe<Scalars['Int']>
-  propTransformationJs_EQUAL?: InputMaybe<Scalars['String']>
-  propTransformationJs_AVERAGE_EQUAL?: InputMaybe<Scalars['Float']>
-  propTransformationJs_LONGEST_EQUAL?: InputMaybe<Scalars['Int']>
-  propTransformationJs_SHORTEST_EQUAL?: InputMaybe<Scalars['Int']>
-  propTransformationJs_GT?: InputMaybe<Scalars['Int']>
-  propTransformationJs_AVERAGE_GT?: InputMaybe<Scalars['Float']>
-  propTransformationJs_LONGEST_GT?: InputMaybe<Scalars['Int']>
-  propTransformationJs_SHORTEST_GT?: InputMaybe<Scalars['Int']>
-  propTransformationJs_GTE?: InputMaybe<Scalars['Int']>
-  propTransformationJs_AVERAGE_GTE?: InputMaybe<Scalars['Float']>
-  propTransformationJs_LONGEST_GTE?: InputMaybe<Scalars['Int']>
-  propTransformationJs_SHORTEST_GTE?: InputMaybe<Scalars['Int']>
-  propTransformationJs_LT?: InputMaybe<Scalars['Int']>
-  propTransformationJs_AVERAGE_LT?: InputMaybe<Scalars['Float']>
-  propTransformationJs_LONGEST_LT?: InputMaybe<Scalars['Int']>
-  propTransformationJs_SHORTEST_LT?: InputMaybe<Scalars['Int']>
-  propTransformationJs_LTE?: InputMaybe<Scalars['Int']>
-  propTransformationJs_AVERAGE_LTE?: InputMaybe<Scalars['Float']>
-  propTransformationJs_LONGEST_LTE?: InputMaybe<Scalars['Int']>
-  propTransformationJs_SHORTEST_LTE?: InputMaybe<Scalars['Int']>
-  renderForEachPropKey_EQUAL?: InputMaybe<Scalars['String']>
-  renderForEachPropKey_AVERAGE_EQUAL?: InputMaybe<Scalars['Float']>
-  renderForEachPropKey_LONGEST_EQUAL?: InputMaybe<Scalars['Int']>
-  renderForEachPropKey_SHORTEST_EQUAL?: InputMaybe<Scalars['Int']>
-  renderForEachPropKey_GT?: InputMaybe<Scalars['Int']>
-  renderForEachPropKey_AVERAGE_GT?: InputMaybe<Scalars['Float']>
-  renderForEachPropKey_LONGEST_GT?: InputMaybe<Scalars['Int']>
-  renderForEachPropKey_SHORTEST_GT?: InputMaybe<Scalars['Int']>
-  renderForEachPropKey_GTE?: InputMaybe<Scalars['Int']>
-  renderForEachPropKey_AVERAGE_GTE?: InputMaybe<Scalars['Float']>
-  renderForEachPropKey_LONGEST_GTE?: InputMaybe<Scalars['Int']>
-  renderForEachPropKey_SHORTEST_GTE?: InputMaybe<Scalars['Int']>
-  renderForEachPropKey_LT?: InputMaybe<Scalars['Int']>
-  renderForEachPropKey_AVERAGE_LT?: InputMaybe<Scalars['Float']>
-  renderForEachPropKey_LONGEST_LT?: InputMaybe<Scalars['Int']>
-  renderForEachPropKey_SHORTEST_LT?: InputMaybe<Scalars['Int']>
-  renderForEachPropKey_LTE?: InputMaybe<Scalars['Int']>
-  renderForEachPropKey_AVERAGE_LTE?: InputMaybe<Scalars['Float']>
-  renderForEachPropKey_LONGEST_LTE?: InputMaybe<Scalars['Int']>
-  renderForEachPropKey_SHORTEST_LTE?: InputMaybe<Scalars['Int']>
-  renderIfExpression_EQUAL?: InputMaybe<Scalars['String']>
-  renderIfExpression_AVERAGE_EQUAL?: InputMaybe<Scalars['Float']>
-  renderIfExpression_LONGEST_EQUAL?: InputMaybe<Scalars['Int']>
-  renderIfExpression_SHORTEST_EQUAL?: InputMaybe<Scalars['Int']>
-  renderIfExpression_GT?: InputMaybe<Scalars['Int']>
-  renderIfExpression_AVERAGE_GT?: InputMaybe<Scalars['Float']>
-  renderIfExpression_LONGEST_GT?: InputMaybe<Scalars['Int']>
-  renderIfExpression_SHORTEST_GT?: InputMaybe<Scalars['Int']>
-  renderIfExpression_GTE?: InputMaybe<Scalars['Int']>
-  renderIfExpression_AVERAGE_GTE?: InputMaybe<Scalars['Float']>
-  renderIfExpression_LONGEST_GTE?: InputMaybe<Scalars['Int']>
-  renderIfExpression_SHORTEST_GTE?: InputMaybe<Scalars['Int']>
-  renderIfExpression_LT?: InputMaybe<Scalars['Int']>
-  renderIfExpression_AVERAGE_LT?: InputMaybe<Scalars['Float']>
-  renderIfExpression_LONGEST_LT?: InputMaybe<Scalars['Int']>
-  renderIfExpression_SHORTEST_LT?: InputMaybe<Scalars['Int']>
-  renderIfExpression_LTE?: InputMaybe<Scalars['Int']>
-  renderIfExpression_AVERAGE_LTE?: InputMaybe<Scalars['Float']>
-  renderIfExpression_LONGEST_LTE?: InputMaybe<Scalars['Int']>
-  renderIfExpression_SHORTEST_LTE?: InputMaybe<Scalars['Int']>
-  preRenderActionId_EQUAL?: InputMaybe<Scalars['String']>
-  preRenderActionId_AVERAGE_EQUAL?: InputMaybe<Scalars['Float']>
-  preRenderActionId_LONGEST_EQUAL?: InputMaybe<Scalars['Int']>
-  preRenderActionId_SHORTEST_EQUAL?: InputMaybe<Scalars['Int']>
-  preRenderActionId_GT?: InputMaybe<Scalars['Int']>
-  preRenderActionId_AVERAGE_GT?: InputMaybe<Scalars['Float']>
-  preRenderActionId_LONGEST_GT?: InputMaybe<Scalars['Int']>
-  preRenderActionId_SHORTEST_GT?: InputMaybe<Scalars['Int']>
-  preRenderActionId_GTE?: InputMaybe<Scalars['Int']>
-  preRenderActionId_AVERAGE_GTE?: InputMaybe<Scalars['Float']>
-  preRenderActionId_LONGEST_GTE?: InputMaybe<Scalars['Int']>
-  preRenderActionId_SHORTEST_GTE?: InputMaybe<Scalars['Int']>
-  preRenderActionId_LT?: InputMaybe<Scalars['Int']>
-  preRenderActionId_AVERAGE_LT?: InputMaybe<Scalars['Float']>
-  preRenderActionId_LONGEST_LT?: InputMaybe<Scalars['Int']>
-  preRenderActionId_SHORTEST_LT?: InputMaybe<Scalars['Int']>
-  preRenderActionId_LTE?: InputMaybe<Scalars['Int']>
-  preRenderActionId_AVERAGE_LTE?: InputMaybe<Scalars['Float']>
-  preRenderActionId_LONGEST_LTE?: InputMaybe<Scalars['Int']>
-  preRenderActionId_SHORTEST_LTE?: InputMaybe<Scalars['Int']>
-  postRenderActionId_EQUAL?: InputMaybe<Scalars['String']>
-  postRenderActionId_AVERAGE_EQUAL?: InputMaybe<Scalars['Float']>
-  postRenderActionId_LONGEST_EQUAL?: InputMaybe<Scalars['Int']>
-  postRenderActionId_SHORTEST_EQUAL?: InputMaybe<Scalars['Int']>
-  postRenderActionId_GT?: InputMaybe<Scalars['Int']>
-  postRenderActionId_AVERAGE_GT?: InputMaybe<Scalars['Float']>
-  postRenderActionId_LONGEST_GT?: InputMaybe<Scalars['Int']>
-  postRenderActionId_SHORTEST_GT?: InputMaybe<Scalars['Int']>
-  postRenderActionId_GTE?: InputMaybe<Scalars['Int']>
-  postRenderActionId_AVERAGE_GTE?: InputMaybe<Scalars['Float']>
-  postRenderActionId_LONGEST_GTE?: InputMaybe<Scalars['Int']>
-  postRenderActionId_SHORTEST_GTE?: InputMaybe<Scalars['Int']>
-  postRenderActionId_LT?: InputMaybe<Scalars['Int']>
-  postRenderActionId_AVERAGE_LT?: InputMaybe<Scalars['Float']>
-  postRenderActionId_LONGEST_LT?: InputMaybe<Scalars['Int']>
-  postRenderActionId_SHORTEST_LT?: InputMaybe<Scalars['Int']>
-  postRenderActionId_LTE?: InputMaybe<Scalars['Int']>
-  postRenderActionId_AVERAGE_LTE?: InputMaybe<Scalars['Float']>
-  postRenderActionId_LONGEST_LTE?: InputMaybe<Scalars['Int']>
-  postRenderActionId_SHORTEST_LTE?: InputMaybe<Scalars['Int']>
-}
-
-export type PropMapBindingTargetElementUpdateConnectionInput = {
-  node?: InputMaybe<ElementUpdateInput>
-}
-
-export type PropMapBindingTargetElementUpdateFieldInput = {
-  where?: InputMaybe<PropMapBindingTargetElementConnectionWhere>
-  update?: InputMaybe<PropMapBindingTargetElementUpdateConnectionInput>
-  connect?: InputMaybe<PropMapBindingTargetElementConnectFieldInput>
-  disconnect?: InputMaybe<PropMapBindingTargetElementDisconnectFieldInput>
-  create?: InputMaybe<PropMapBindingTargetElementCreateFieldInput>
-  delete?: InputMaybe<PropMapBindingTargetElementDeleteFieldInput>
-  connectOrCreate?: InputMaybe<PropMapBindingTargetElementConnectOrCreateFieldInput>
-}
-
-export type PropMapBindingUniqueWhere = {
-  id?: InputMaybe<Scalars['ID']>
-}
-
-export type PropMapBindingUpdateInput = {
-  sourceKey?: InputMaybe<Scalars['String']>
-  targetKey?: InputMaybe<Scalars['String']>
-  element?: InputMaybe<PropMapBindingElementUpdateFieldInput>
-  targetElement?: InputMaybe<PropMapBindingTargetElementUpdateFieldInput>
-}
-
-export type PropMapBindingWhere = {
-  OR?: InputMaybe<Array<PropMapBindingWhere>>
-  AND?: InputMaybe<Array<PropMapBindingWhere>>
-  id?: InputMaybe<Scalars['ID']>
-  id_NOT?: InputMaybe<Scalars['ID']>
-  id_IN?: InputMaybe<Array<Scalars['ID']>>
-  id_NOT_IN?: InputMaybe<Array<Scalars['ID']>>
-  id_MATCHES?: InputMaybe<Scalars['String']>
-  id_CONTAINS?: InputMaybe<Scalars['ID']>
-  id_NOT_CONTAINS?: InputMaybe<Scalars['ID']>
-  id_STARTS_WITH?: InputMaybe<Scalars['ID']>
-  id_NOT_STARTS_WITH?: InputMaybe<Scalars['ID']>
-  id_ENDS_WITH?: InputMaybe<Scalars['ID']>
-  id_NOT_ENDS_WITH?: InputMaybe<Scalars['ID']>
-  sourceKey?: InputMaybe<Scalars['String']>
-  sourceKey_NOT?: InputMaybe<Scalars['String']>
-  sourceKey_IN?: InputMaybe<Array<Scalars['String']>>
-  sourceKey_NOT_IN?: InputMaybe<Array<Scalars['String']>>
-  sourceKey_MATCHES?: InputMaybe<Scalars['String']>
-  sourceKey_CONTAINS?: InputMaybe<Scalars['String']>
-  sourceKey_NOT_CONTAINS?: InputMaybe<Scalars['String']>
-  sourceKey_STARTS_WITH?: InputMaybe<Scalars['String']>
-  sourceKey_NOT_STARTS_WITH?: InputMaybe<Scalars['String']>
-  sourceKey_ENDS_WITH?: InputMaybe<Scalars['String']>
-  sourceKey_NOT_ENDS_WITH?: InputMaybe<Scalars['String']>
-  targetKey?: InputMaybe<Scalars['String']>
-  targetKey_NOT?: InputMaybe<Scalars['String']>
-  targetKey_IN?: InputMaybe<Array<Scalars['String']>>
-  targetKey_NOT_IN?: InputMaybe<Array<Scalars['String']>>
-  targetKey_MATCHES?: InputMaybe<Scalars['String']>
-  targetKey_CONTAINS?: InputMaybe<Scalars['String']>
-  targetKey_NOT_CONTAINS?: InputMaybe<Scalars['String']>
-  targetKey_STARTS_WITH?: InputMaybe<Scalars['String']>
-  targetKey_NOT_STARTS_WITH?: InputMaybe<Scalars['String']>
-  targetKey_ENDS_WITH?: InputMaybe<Scalars['String']>
-  targetKey_NOT_ENDS_WITH?: InputMaybe<Scalars['String']>
-  element?: InputMaybe<ElementWhere>
-  element_NOT?: InputMaybe<ElementWhere>
-  elementAggregate?: InputMaybe<PropMapBindingElementAggregateInput>
-  targetElement?: InputMaybe<ElementWhere>
-  targetElement_NOT?: InputMaybe<ElementWhere>
-  targetElementAggregate?: InputMaybe<PropMapBindingTargetElementAggregateInput>
-  elementConnection?: InputMaybe<PropMapBindingElementConnectionWhere>
-  elementConnection_NOT?: InputMaybe<PropMapBindingElementConnectionWhere>
-  targetElementConnection?: InputMaybe<PropMapBindingTargetElementConnectionWhere>
-  targetElementConnection_NOT?: InputMaybe<PropMapBindingTargetElementConnectionWhere>
 }
 
 export type PropOnCreateInput = {
@@ -24400,75 +23555,6 @@ export interface IntAggregateInputNonNullable {
   average?: boolean
   sum?: boolean
 }
-export interface PropMapBindingAggregateSelectionInput {
-  count?: boolean
-  id?: IdAggregateInputNonNullable
-  sourceKey?: StringAggregateInputNonNullable
-  targetKey?: StringAggregateInputNonNullable
-}
-
-export declare class PropMapBindingModel {
-  public find(args?: {
-    where?: PropMapBindingWhere
-
-    options?: PropMapBindingOptions
-    selectionSet?: string | DocumentNode | SelectionSetNode
-    args?: any
-    context?: any
-    rootValue?: any
-  }): Promise<PropMapBinding[]>
-  public create(args: {
-    input: PropMapBindingCreateInput[]
-    selectionSet?: string | DocumentNode | SelectionSetNode
-    args?: any
-    context?: any
-    rootValue?: any
-  }): Promise<CreatePropMapBindingsMutationResponse>
-  public update(args: {
-    where?: PropMapBindingWhere
-    update?: PropMapBindingUpdateInput
-    connect?: PropMapBindingConnectInput
-    disconnect?: PropMapBindingDisconnectInput
-    create?: PropMapBindingCreateInput
-    connectOrCreate?: PropMapBindingConnectOrCreateInput
-    selectionSet?: string | DocumentNode | SelectionSetNode
-    args?: any
-    context?: any
-    rootValue?: any
-  }): Promise<UpdatePropMapBindingsMutationResponse>
-  public delete(args: {
-    where?: PropMapBindingWhere
-    delete?: PropMapBindingDeleteInput
-    context?: any
-    rootValue?: any
-  }): Promise<{ nodesDeleted: number; relationshipsDeleted: number }>
-  public aggregate(args: {
-    where?: PropMapBindingWhere
-
-    aggregate: PropMapBindingAggregateSelectionInput
-    context?: any
-    rootValue?: any
-  }): Promise<PropMapBindingAggregateSelection>
-}
-
-export interface IdAggregateInputNonNullable {
-  shortest?: boolean
-  longest?: boolean
-}
-export interface StringAggregateInputNonNullable {
-  shortest?: boolean
-  longest?: boolean
-}
-export interface StringAggregateInputNullable {
-  shortest?: boolean
-  longest?: boolean
-}
-export interface IntAggregateInputNonNullable {
-  max?: boolean
-  min?: boolean
-  average?: boolean
-  sum?: boolean
-}
 export interface HookAggregateSelectionInput {
   count?: boolean
   id?: IdAggregateInputNonNullable
@@ -25147,7 +24233,6 @@ export interface ModelMap {
   Tag: TagModel
   Element: ElementModel
   Prop: PropModel
-  PropMapBinding: PropMapBindingModel
   Hook: HookModel
   Component: ComponentModel
   Store: StoreModel

--- a/libs/shared/abstract/codegen/src/types.api.graphql.gen.ts
+++ b/libs/shared/abstract/codegen/src/types.api.graphql.gen.ts
@@ -3460,6 +3460,9 @@ export type Atom = {
   icon?: Maybe<Scalars['String']>
   id: Scalars['ID']
   name: Scalars['String']
+  requiredParent?: Maybe<Atom>
+  requiredParentAggregate?: Maybe<AtomAtomRequiredParentAggregationSelection>
+  requiredParentConnection: AtomRequiredParentConnection
   tags: Array<Tag>
   tagsAggregate?: Maybe<AtomTagTagsAggregationSelection>
   tagsConnection: AtomTagsConnection
@@ -3502,6 +3505,25 @@ export type AtomApiConnectionArgs = {
   first?: InputMaybe<Scalars['Int']>
   sort?: InputMaybe<Array<AtomApiConnectionSort>>
   where?: InputMaybe<AtomApiConnectionWhere>
+}
+
+export type AtomRequiredParentArgs = {
+  directed?: InputMaybe<Scalars['Boolean']>
+  options?: InputMaybe<AtomOptions>
+  where?: InputMaybe<AtomWhere>
+}
+
+export type AtomRequiredParentAggregateArgs = {
+  directed?: InputMaybe<Scalars['Boolean']>
+  where?: InputMaybe<AtomWhere>
+}
+
+export type AtomRequiredParentConnectionArgs = {
+  after?: InputMaybe<Scalars['String']>
+  directed?: InputMaybe<Scalars['Boolean']>
+  first?: InputMaybe<Scalars['Int']>
+  sort?: InputMaybe<Array<AtomRequiredParentConnectionSort>>
+  where?: InputMaybe<AtomRequiredParentConnectionWhere>
 }
 
 export type AtomTagsArgs = {
@@ -3786,9 +3808,23 @@ export type AtomAtomAllowedChildrenNodeAggregateSelection = {
   name: StringAggregateSelectionNonNullable
 }
 
+export type AtomAtomRequiredParentAggregationSelection = {
+  __typename?: 'AtomAtomRequiredParentAggregationSelection'
+  count: Scalars['Int']
+  node?: Maybe<AtomAtomRequiredParentNodeAggregateSelection>
+}
+
+export type AtomAtomRequiredParentNodeAggregateSelection = {
+  __typename?: 'AtomAtomRequiredParentNodeAggregateSelection'
+  icon: StringAggregateSelectionNullable
+  id: IdAggregateSelectionNonNullable
+  name: StringAggregateSelectionNonNullable
+}
+
 export type AtomConnectInput = {
   allowedChildren?: InputMaybe<Array<AtomAllowedChildrenConnectFieldInput>>
   api?: InputMaybe<AtomApiConnectFieldInput>
+  requiredParent?: InputMaybe<AtomRequiredParentConnectFieldInput>
   tags?: InputMaybe<Array<AtomTagsConnectFieldInput>>
 }
 
@@ -3797,6 +3833,7 @@ export type AtomConnectOrCreateInput = {
     Array<AtomAllowedChildrenConnectOrCreateFieldInput>
   >
   api?: InputMaybe<AtomApiConnectOrCreateFieldInput>
+  requiredParent?: InputMaybe<AtomRequiredParentConnectOrCreateFieldInput>
   tags?: InputMaybe<Array<AtomTagsConnectOrCreateFieldInput>>
 }
 
@@ -3814,6 +3851,7 @@ export type AtomCreateInput = {
   icon?: InputMaybe<Scalars['String']>
   id: Scalars['ID']
   name: Scalars['String']
+  requiredParent?: InputMaybe<AtomRequiredParentFieldInput>
   tags?: InputMaybe<AtomTagsFieldInput>
   type: AtomType
 }
@@ -3821,12 +3859,14 @@ export type AtomCreateInput = {
 export type AtomDeleteInput = {
   allowedChildren?: InputMaybe<Array<AtomAllowedChildrenDeleteFieldInput>>
   api?: InputMaybe<AtomApiDeleteFieldInput>
+  requiredParent?: InputMaybe<AtomRequiredParentDeleteFieldInput>
   tags?: InputMaybe<Array<AtomTagsDeleteFieldInput>>
 }
 
 export type AtomDisconnectInput = {
   allowedChildren?: InputMaybe<Array<AtomAllowedChildrenDisconnectFieldInput>>
   api?: InputMaybe<AtomApiDisconnectFieldInput>
+  requiredParent?: InputMaybe<AtomRequiredParentDisconnectFieldInput>
   tags?: InputMaybe<Array<AtomTagsDisconnectFieldInput>>
 }
 
@@ -3865,7 +3905,137 @@ export type AtomOptions = {
 export type AtomRelationInput = {
   allowedChildren?: InputMaybe<Array<AtomAllowedChildrenCreateFieldInput>>
   api?: InputMaybe<AtomApiCreateFieldInput>
+  requiredParent?: InputMaybe<AtomRequiredParentCreateFieldInput>
   tags?: InputMaybe<Array<AtomTagsCreateFieldInput>>
+}
+
+export type AtomRequiredParentAggregateInput = {
+  AND?: InputMaybe<Array<AtomRequiredParentAggregateInput>>
+  OR?: InputMaybe<Array<AtomRequiredParentAggregateInput>>
+  count?: InputMaybe<Scalars['Int']>
+  count_GT?: InputMaybe<Scalars['Int']>
+  count_GTE?: InputMaybe<Scalars['Int']>
+  count_LT?: InputMaybe<Scalars['Int']>
+  count_LTE?: InputMaybe<Scalars['Int']>
+  node?: InputMaybe<AtomRequiredParentNodeAggregationWhereInput>
+}
+
+export type AtomRequiredParentConnectFieldInput = {
+  connect?: InputMaybe<AtomConnectInput>
+  where?: InputMaybe<AtomConnectWhere>
+}
+
+export type AtomRequiredParentConnectOrCreateFieldInput = {
+  onCreate: AtomRequiredParentConnectOrCreateFieldInputOnCreate
+  where: AtomConnectOrCreateWhere
+}
+
+export type AtomRequiredParentConnectOrCreateFieldInputOnCreate = {
+  node: AtomOnCreateInput
+}
+
+export type AtomRequiredParentConnection = {
+  __typename?: 'AtomRequiredParentConnection'
+  edges: Array<AtomRequiredParentRelationship>
+  pageInfo: PageInfo
+  totalCount: Scalars['Int']
+}
+
+export type AtomRequiredParentConnectionSort = {
+  node?: InputMaybe<AtomSort>
+}
+
+export type AtomRequiredParentConnectionWhere = {
+  AND?: InputMaybe<Array<AtomRequiredParentConnectionWhere>>
+  OR?: InputMaybe<Array<AtomRequiredParentConnectionWhere>>
+  node?: InputMaybe<AtomWhere>
+  node_NOT?: InputMaybe<AtomWhere>
+}
+
+export type AtomRequiredParentCreateFieldInput = {
+  node: AtomCreateInput
+}
+
+export type AtomRequiredParentDeleteFieldInput = {
+  delete?: InputMaybe<AtomDeleteInput>
+  where?: InputMaybe<AtomRequiredParentConnectionWhere>
+}
+
+export type AtomRequiredParentDisconnectFieldInput = {
+  disconnect?: InputMaybe<AtomDisconnectInput>
+  where?: InputMaybe<AtomRequiredParentConnectionWhere>
+}
+
+export type AtomRequiredParentFieldInput = {
+  connect?: InputMaybe<AtomRequiredParentConnectFieldInput>
+  connectOrCreate?: InputMaybe<AtomRequiredParentConnectOrCreateFieldInput>
+  create?: InputMaybe<AtomRequiredParentCreateFieldInput>
+}
+
+export type AtomRequiredParentNodeAggregationWhereInput = {
+  AND?: InputMaybe<Array<AtomRequiredParentNodeAggregationWhereInput>>
+  OR?: InputMaybe<Array<AtomRequiredParentNodeAggregationWhereInput>>
+  icon_AVERAGE_EQUAL?: InputMaybe<Scalars['Float']>
+  icon_AVERAGE_GT?: InputMaybe<Scalars['Float']>
+  icon_AVERAGE_GTE?: InputMaybe<Scalars['Float']>
+  icon_AVERAGE_LT?: InputMaybe<Scalars['Float']>
+  icon_AVERAGE_LTE?: InputMaybe<Scalars['Float']>
+  icon_EQUAL?: InputMaybe<Scalars['String']>
+  icon_GT?: InputMaybe<Scalars['Int']>
+  icon_GTE?: InputMaybe<Scalars['Int']>
+  icon_LONGEST_EQUAL?: InputMaybe<Scalars['Int']>
+  icon_LONGEST_GT?: InputMaybe<Scalars['Int']>
+  icon_LONGEST_GTE?: InputMaybe<Scalars['Int']>
+  icon_LONGEST_LT?: InputMaybe<Scalars['Int']>
+  icon_LONGEST_LTE?: InputMaybe<Scalars['Int']>
+  icon_LT?: InputMaybe<Scalars['Int']>
+  icon_LTE?: InputMaybe<Scalars['Int']>
+  icon_SHORTEST_EQUAL?: InputMaybe<Scalars['Int']>
+  icon_SHORTEST_GT?: InputMaybe<Scalars['Int']>
+  icon_SHORTEST_GTE?: InputMaybe<Scalars['Int']>
+  icon_SHORTEST_LT?: InputMaybe<Scalars['Int']>
+  icon_SHORTEST_LTE?: InputMaybe<Scalars['Int']>
+  id_EQUAL?: InputMaybe<Scalars['ID']>
+  name_AVERAGE_EQUAL?: InputMaybe<Scalars['Float']>
+  name_AVERAGE_GT?: InputMaybe<Scalars['Float']>
+  name_AVERAGE_GTE?: InputMaybe<Scalars['Float']>
+  name_AVERAGE_LT?: InputMaybe<Scalars['Float']>
+  name_AVERAGE_LTE?: InputMaybe<Scalars['Float']>
+  name_EQUAL?: InputMaybe<Scalars['String']>
+  name_GT?: InputMaybe<Scalars['Int']>
+  name_GTE?: InputMaybe<Scalars['Int']>
+  name_LONGEST_EQUAL?: InputMaybe<Scalars['Int']>
+  name_LONGEST_GT?: InputMaybe<Scalars['Int']>
+  name_LONGEST_GTE?: InputMaybe<Scalars['Int']>
+  name_LONGEST_LT?: InputMaybe<Scalars['Int']>
+  name_LONGEST_LTE?: InputMaybe<Scalars['Int']>
+  name_LT?: InputMaybe<Scalars['Int']>
+  name_LTE?: InputMaybe<Scalars['Int']>
+  name_SHORTEST_EQUAL?: InputMaybe<Scalars['Int']>
+  name_SHORTEST_GT?: InputMaybe<Scalars['Int']>
+  name_SHORTEST_GTE?: InputMaybe<Scalars['Int']>
+  name_SHORTEST_LT?: InputMaybe<Scalars['Int']>
+  name_SHORTEST_LTE?: InputMaybe<Scalars['Int']>
+}
+
+export type AtomRequiredParentRelationship = {
+  __typename?: 'AtomRequiredParentRelationship'
+  cursor: Scalars['String']
+  node: Atom
+}
+
+export type AtomRequiredParentUpdateConnectionInput = {
+  node?: InputMaybe<AtomUpdateInput>
+}
+
+export type AtomRequiredParentUpdateFieldInput = {
+  connect?: InputMaybe<AtomRequiredParentConnectFieldInput>
+  connectOrCreate?: InputMaybe<AtomRequiredParentConnectOrCreateFieldInput>
+  create?: InputMaybe<AtomRequiredParentCreateFieldInput>
+  delete?: InputMaybe<AtomRequiredParentDeleteFieldInput>
+  disconnect?: InputMaybe<AtomRequiredParentDisconnectFieldInput>
+  update?: InputMaybe<AtomRequiredParentUpdateConnectionInput>
+  where?: InputMaybe<AtomRequiredParentConnectionWhere>
 }
 
 /** Fields to sort Atoms by. The order in which sorts are applied is not guaranteed when specifying many fields in one AtomSort object. */
@@ -4386,6 +4556,7 @@ export type AtomUpdateInput = {
   icon?: InputMaybe<Scalars['String']>
   id?: InputMaybe<Scalars['ID']>
   name?: InputMaybe<Scalars['String']>
+  requiredParent?: InputMaybe<AtomRequiredParentUpdateFieldInput>
   tags?: InputMaybe<Array<AtomTagsUpdateFieldInput>>
   type?: InputMaybe<AtomType>
 }
@@ -4444,6 +4615,11 @@ export type AtomWhere = {
   name_NOT_IN?: InputMaybe<Array<Scalars['String']>>
   name_NOT_STARTS_WITH?: InputMaybe<Scalars['String']>
   name_STARTS_WITH?: InputMaybe<Scalars['String']>
+  requiredParent?: InputMaybe<AtomWhere>
+  requiredParentAggregate?: InputMaybe<AtomRequiredParentAggregateInput>
+  requiredParentConnection?: InputMaybe<AtomRequiredParentConnectionWhere>
+  requiredParentConnection_NOT?: InputMaybe<AtomRequiredParentConnectionWhere>
+  requiredParent_NOT?: InputMaybe<AtomWhere>
   tagsAggregate?: InputMaybe<AtomTagsAggregateInput>
   tagsConnection_ALL?: InputMaybe<AtomTagsConnectionWhere>
   tagsConnection_NONE?: InputMaybe<AtomTagsConnectionWhere>
@@ -21443,6 +21619,12 @@ export type AtomFragment = {
     name: string
     type: AtomType
   }>
+  requiredParent?: {
+    __typename?: 'Atom'
+    id: string
+    name: string
+    type: AtomType
+  } | null
 }
 
 export type RenderAtomFragment = {
@@ -21459,6 +21641,12 @@ export type RenderAtomFragment = {
     name: string
     type: AtomType
   }>
+  requiredParent?: {
+    __typename?: 'Atom'
+    id: string
+    name: string
+    type: AtomType
+  } | null
 }
 
 export type RenderedComponentFragment = {

--- a/schema.api.graphql
+++ b/schema.api.graphql
@@ -3342,6 +3342,22 @@ type Atom {
   icon: String
   id: ID!
   name: String!
+  requiredParent(
+    directed: Boolean = true
+    options: AtomOptions
+    where: AtomWhere
+  ): Atom
+  requiredParentAggregate(
+    directed: Boolean = true
+    where: AtomWhere
+  ): AtomAtomRequiredParentAggregationSelection
+  requiredParentConnection(
+    after: String
+    directed: Boolean = true
+    first: Int
+    sort: [AtomRequiredParentConnectionSort!]
+    where: AtomRequiredParentConnectionWhere
+  ): AtomRequiredParentConnection!
   tags(directed: Boolean = true, options: TagOptions, where: TagWhere): [Tag!]!
   tagsAggregate(
     directed: Boolean = true
@@ -3609,15 +3625,28 @@ type AtomAtomAllowedChildrenNodeAggregateSelection {
   name: StringAggregateSelectionNonNullable!
 }
 
+type AtomAtomRequiredParentAggregationSelection {
+  count: Int!
+  node: AtomAtomRequiredParentNodeAggregateSelection
+}
+
+type AtomAtomRequiredParentNodeAggregateSelection {
+  icon: StringAggregateSelectionNullable!
+  id: IDAggregateSelectionNonNullable!
+  name: StringAggregateSelectionNonNullable!
+}
+
 input AtomConnectInput {
   allowedChildren: [AtomAllowedChildrenConnectFieldInput!]
   api: AtomApiConnectFieldInput
+  requiredParent: AtomRequiredParentConnectFieldInput
   tags: [AtomTagsConnectFieldInput!]
 }
 
 input AtomConnectOrCreateInput {
   allowedChildren: [AtomAllowedChildrenConnectOrCreateFieldInput!]
   api: AtomApiConnectOrCreateFieldInput
+  requiredParent: AtomRequiredParentConnectOrCreateFieldInput
   tags: [AtomTagsConnectOrCreateFieldInput!]
 }
 
@@ -3635,6 +3664,7 @@ input AtomCreateInput {
   icon: String
   id: ID!
   name: String!
+  requiredParent: AtomRequiredParentFieldInput
   tags: AtomTagsFieldInput
   type: AtomType!
 }
@@ -3642,12 +3672,14 @@ input AtomCreateInput {
 input AtomDeleteInput {
   allowedChildren: [AtomAllowedChildrenDeleteFieldInput!]
   api: AtomApiDeleteFieldInput
+  requiredParent: AtomRequiredParentDeleteFieldInput
   tags: [AtomTagsDeleteFieldInput!]
 }
 
 input AtomDisconnectInput {
   allowedChildren: [AtomAllowedChildrenDisconnectFieldInput!]
   api: AtomApiDisconnectFieldInput
+  requiredParent: AtomRequiredParentDisconnectFieldInput
   tags: [AtomTagsDisconnectFieldInput!]
 }
 
@@ -3686,7 +3718,135 @@ input AtomOptions {
 input AtomRelationInput {
   allowedChildren: [AtomAllowedChildrenCreateFieldInput!]
   api: AtomApiCreateFieldInput
+  requiredParent: AtomRequiredParentCreateFieldInput
   tags: [AtomTagsCreateFieldInput!]
+}
+
+input AtomRequiredParentAggregateInput {
+  AND: [AtomRequiredParentAggregateInput!]
+  OR: [AtomRequiredParentAggregateInput!]
+  count: Int
+  count_GT: Int
+  count_GTE: Int
+  count_LT: Int
+  count_LTE: Int
+  node: AtomRequiredParentNodeAggregationWhereInput
+}
+
+input AtomRequiredParentConnectFieldInput {
+  connect: AtomConnectInput
+  where: AtomConnectWhere
+}
+
+input AtomRequiredParentConnectOrCreateFieldInput {
+  onCreate: AtomRequiredParentConnectOrCreateFieldInputOnCreate!
+  where: AtomConnectOrCreateWhere!
+}
+
+input AtomRequiredParentConnectOrCreateFieldInputOnCreate {
+  node: AtomOnCreateInput!
+}
+
+type AtomRequiredParentConnection {
+  edges: [AtomRequiredParentRelationship!]!
+  pageInfo: PageInfo!
+  totalCount: Int!
+}
+
+input AtomRequiredParentConnectionSort {
+  node: AtomSort
+}
+
+input AtomRequiredParentConnectionWhere {
+  AND: [AtomRequiredParentConnectionWhere!]
+  OR: [AtomRequiredParentConnectionWhere!]
+  node: AtomWhere
+  node_NOT: AtomWhere
+}
+
+input AtomRequiredParentCreateFieldInput {
+  node: AtomCreateInput!
+}
+
+input AtomRequiredParentDeleteFieldInput {
+  delete: AtomDeleteInput
+  where: AtomRequiredParentConnectionWhere
+}
+
+input AtomRequiredParentDisconnectFieldInput {
+  disconnect: AtomDisconnectInput
+  where: AtomRequiredParentConnectionWhere
+}
+
+input AtomRequiredParentFieldInput {
+  connect: AtomRequiredParentConnectFieldInput
+  connectOrCreate: AtomRequiredParentConnectOrCreateFieldInput
+  create: AtomRequiredParentCreateFieldInput
+}
+
+input AtomRequiredParentNodeAggregationWhereInput {
+  AND: [AtomRequiredParentNodeAggregationWhereInput!]
+  OR: [AtomRequiredParentNodeAggregationWhereInput!]
+  icon_AVERAGE_EQUAL: Float
+  icon_AVERAGE_GT: Float
+  icon_AVERAGE_GTE: Float
+  icon_AVERAGE_LT: Float
+  icon_AVERAGE_LTE: Float
+  icon_EQUAL: String
+  icon_GT: Int
+  icon_GTE: Int
+  icon_LONGEST_EQUAL: Int
+  icon_LONGEST_GT: Int
+  icon_LONGEST_GTE: Int
+  icon_LONGEST_LT: Int
+  icon_LONGEST_LTE: Int
+  icon_LT: Int
+  icon_LTE: Int
+  icon_SHORTEST_EQUAL: Int
+  icon_SHORTEST_GT: Int
+  icon_SHORTEST_GTE: Int
+  icon_SHORTEST_LT: Int
+  icon_SHORTEST_LTE: Int
+  id_EQUAL: ID
+  name_AVERAGE_EQUAL: Float
+  name_AVERAGE_GT: Float
+  name_AVERAGE_GTE: Float
+  name_AVERAGE_LT: Float
+  name_AVERAGE_LTE: Float
+  name_EQUAL: String
+  name_GT: Int
+  name_GTE: Int
+  name_LONGEST_EQUAL: Int
+  name_LONGEST_GT: Int
+  name_LONGEST_GTE: Int
+  name_LONGEST_LT: Int
+  name_LONGEST_LTE: Int
+  name_LT: Int
+  name_LTE: Int
+  name_SHORTEST_EQUAL: Int
+  name_SHORTEST_GT: Int
+  name_SHORTEST_GTE: Int
+  name_SHORTEST_LT: Int
+  name_SHORTEST_LTE: Int
+}
+
+type AtomRequiredParentRelationship {
+  cursor: String!
+  node: Atom!
+}
+
+input AtomRequiredParentUpdateConnectionInput {
+  node: AtomUpdateInput
+}
+
+input AtomRequiredParentUpdateFieldInput {
+  connect: AtomRequiredParentConnectFieldInput
+  connectOrCreate: AtomRequiredParentConnectOrCreateFieldInput
+  create: AtomRequiredParentCreateFieldInput
+  delete: AtomRequiredParentDeleteFieldInput
+  disconnect: AtomRequiredParentDisconnectFieldInput
+  update: AtomRequiredParentUpdateConnectionInput
+  where: AtomRequiredParentConnectionWhere
 }
 
 """
@@ -4205,6 +4365,7 @@ input AtomUpdateInput {
   icon: String
   id: ID
   name: String
+  requiredParent: AtomRequiredParentUpdateFieldInput
   tags: [AtomTagsUpdateFieldInput!]
   type: AtomType
 }
@@ -4275,6 +4436,11 @@ input AtomWhere {
   name_NOT_IN: [String!]
   name_NOT_STARTS_WITH: String
   name_STARTS_WITH: String
+  requiredParent: AtomWhere
+  requiredParentAggregate: AtomRequiredParentAggregateInput
+  requiredParentConnection: AtomRequiredParentConnectionWhere
+  requiredParentConnection_NOT: AtomRequiredParentConnectionWhere
+  requiredParent_NOT: AtomWhere
   tagsAggregate: AtomTagsAggregateInput
   tagsConnection_ALL: AtomTagsConnectionWhere
   tagsConnection_NONE: AtomTagsConnectionWhere


### PR DESCRIPTION
<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(libs-ui-component): must begin with lowercase` -->

Some Antd atoms like AntdAnchoLink require to be nested within a certain parent atom like AntdAnchor, otherwise, an error is thrown which crashes the builder immediately.

Done:
- updated Atoms API  to handle requiredParent field.
- add requiredParent verification to the Builder and the Elements tree.

In progress:

- add requiredParent field to the seed data.
- handle the case when an atom is converted to a component and vice-versa.

<!-- This is a short description on the Pull Request -->

## Video or Image

<!-- Add video or image showing how the new feature works -->

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged -->

Fixes #
