### PR TITLE
fix: component issues and add additional e2e cases

### DIFF
--- a/apps/builder-e2e/src/e2e/component.cy.ts
+++ b/apps/builder-e2e/src/e2e/component.cy.ts
@@ -1,12 +1,21 @@
-import { IAtomType } from '@codelab/shared/abstract/core'
+import {
+  IAtomType,
+  IPrimitiveTypeKind,
+  ITypeKind,
+} from '@codelab/shared/abstract/core'
 import { connectOwner } from '@codelab/shared/data'
 import { v4 } from 'uuid'
+import { FIELD_TYPE } from '../support/antd/form'
 import { createAppInput } from '../support/database/app'
 
-const NEW_COMP_NAME = 'new component'
-const CHILD_BUTTON = 'Button'
-const CHILD_TEXT = 'Text'
-const UPDATED_COMP_NAME = 'updated component'
+const COMPONENT_NAME = 'new component'
+const COMPONENT_INSTANCE_NAME = 'component instance'
+const COMPONENT_PROP_NAME = 'component_prop'
+const COMPONENT_PROP_VALUE = 'component_prop_value'
+const COMPONENT_CHILD_SPACE = 'space'
+const COMPONENT_CHILD_TYPOGRAPHY = 'typography'
+const COMPONENT_CHILD_TEXT = `text {{this.${COMPONENT_PROP_NAME}}}`
+const COMPONENT_INSTANCE_TEXT = 'instance text'
 
 interface ComponentChildData {
   name: string
@@ -14,8 +23,8 @@ interface ComponentChildData {
 }
 
 const componentChildren: Array<ComponentChildData> = [
-  { name: CHILD_BUTTON, atom: IAtomType.AntDesignButton },
-  { name: CHILD_TEXT, atom: IAtomType.AntDesignTypographyText },
+  { name: COMPONENT_CHILD_SPACE, atom: IAtomType.AntDesignSpace },
+  { name: COMPONENT_CHILD_TYPOGRAPHY, atom: IAtomType.AntDesignTypographyText },
 ]
 
 let testApp: any
@@ -25,16 +34,28 @@ describe('Component CRUD', () => {
     cy.login()
     cy.getCurrentUserId()
       .then((userId) => {
+        cy.createType(
+          {
+            PrimitiveType: {
+              id: v4(),
+              name: IPrimitiveTypeKind.String,
+              primitiveKind: IPrimitiveTypeKind.String,
+              kind: ITypeKind.PrimitiveType,
+              owner: connectOwner(userId),
+            },
+          },
+          ITypeKind.PrimitiveType,
+        )
         cy.createAtom([
           {
-            name: IAtomType.AntDesignButton,
-            type: IAtomType.AntDesignButton,
+            name: IAtomType.AntDesignSpace,
+            type: IAtomType.AntDesignSpace,
             id: v4(),
             api: {
               create: {
                 node: {
                   id: v4(),
-                  name: `${IAtomType.AntDesignButton} API`,
+                  name: `${IAtomType.AntDesignSpace} API`,
                   owner: connectOwner(userId),
                 },
               },
@@ -72,7 +93,7 @@ describe('Component CRUD', () => {
     it('should be able to add a new component', () => {
       cy.log('my app', JSON.stringify(testApp, null, 2))
       cy.getSider().getButton({ icon: 'plus' }).eq(1).click()
-      cy.getModal().findByLabelText('Name').type(NEW_COMP_NAME)
+      cy.getModal().findByLabelText('Name').type(COMPONENT_NAME)
       cy.getModal()
         .getModalAction(/Create/)
         .click()
@@ -81,7 +102,157 @@ describe('Component CRUD', () => {
         .parent()
         .find('.ant-tree-switcher_close')
         .click()
-      cy.findByText(NEW_COMP_NAME).should('exist')
+      cy.findByText(COMPONENT_NAME).should('exist')
+    })
+
+    it('should be able to define property on component', () => {
+      cy.get(`[title="${COMPONENT_NAME}"]`).click({ force: true })
+      cy.get(`.ant-tabs [aria-label="setting"]`).click()
+      cy.get('.ant-tabs-tabpane-active').contains(/Add/).click()
+      cy.getModal().setFormFieldValue({
+        label: 'Key',
+        value: COMPONENT_PROP_NAME,
+      })
+      cy.getModal().setFormFieldValue({
+        label: 'Type',
+        value: IPrimitiveTypeKind.String,
+        type: FIELD_TYPE.SELECT,
+      })
+      cy.getModal()
+        .getModalAction(/Create/)
+        .click()
+      cy.getModal().should('not.exist', { timeout: 10000 })
+    })
+
+    it('should be able to add elements to the component', () => {
+      cy.get(`.ant-tree-node-content-wrapper[title="${COMPONENT_NAME}"]`)
+        .eq(1)
+        .click({ force: true })
+        .trigger('contextmenu')
+
+      cy.wrap(componentChildren)
+        .each((child: ComponentChildData) => {
+          cy.contains(/Add child/).click({ force: true })
+
+          cy.getModal().setFormFieldValue({
+            label: 'Render Type',
+            value: 'Atom',
+            type: FIELD_TYPE.SELECT,
+          })
+          cy.getModal().setFormFieldValue({
+            label: 'Atom',
+            value: child.atom,
+            type: FIELD_TYPE.SELECT,
+          })
+          cy.getModal().setFormFieldValue({
+            label: 'Name',
+            value: child.name,
+          })
+
+          cy.getModal()
+            .getModalAction(/Create/)
+            .click()
+          cy.getModal().should('not.exist', { timeout: 10000 })
+          cy.get(`[title="${child.name}"]`).click({ force: true })
+        })
+        .then(() => {
+          cy.get(`.ant-tabs [aria-label="setting"]`).click()
+          cy.get('.ant-tabs-tabpane-active form .ql-editor').type(
+            COMPONENT_CHILD_TEXT,
+            { parseSpecialCharSequences: false },
+          )
+
+          cy.get('#Builder').findByText('text null').should('exist')
+        })
+    })
+
+    it('should be able to specify where to render component children', () => {
+      cy.get(`.ant-tree-node-content-wrapper[title="${COMPONENT_NAME}"]`)
+        .eq(0)
+        .click({ force: true })
+      cy.get(`.ant-tabs [aria-label="node-index"]`).click()
+      cy.get('.ant-tabs-tabpane-active form').setFormFieldValue({
+        label: 'Container for component children',
+        value: COMPONENT_CHILD_SPACE,
+        type: FIELD_TYPE.SELECT,
+      })
+    })
+
+    it('should be able to create an instance of the component', () => {
+      cy.get(`[title="Body"]`).click({ force: true })
+
+      cy.getSider()
+        .find('.ant-page-header-heading')
+        .getButton({ icon: 'plus' })
+        .click()
+
+      cy.getModal().setFormFieldValue({
+        label: 'Render Type',
+        value: 'Component',
+        type: FIELD_TYPE.SELECT,
+      })
+      cy.getModal().setFormFieldValue({
+        label: 'Component',
+        value: COMPONENT_NAME,
+        type: FIELD_TYPE.SELECT,
+      })
+      cy.getModal().setFormFieldValue({
+        label: 'Name',
+        value: COMPONENT_INSTANCE_NAME,
+      })
+
+      cy.getModal()
+        .getModalAction(/Create/)
+        .click()
+      cy.getModal().should('not.exist', { timeout: 10000 })
+    })
+
+    it('should be able to set props on an instance of the component', () => {
+      cy.get(`[title="${COMPONENT_INSTANCE_NAME}"]`).click({ force: true })
+      cy.get(`.ant-tabs [aria-label="setting"]`).click()
+      cy.getSpinner().should('not.exist')
+      cy.get('.ant-tabs-tabpane-active form').setFormFieldValue({
+        label: 'Component_prop',
+        value: COMPONENT_PROP_VALUE,
+        type: FIELD_TYPE.CODE_MIRROR,
+      })
+    })
+
+    it('should be able to add children to component instance', () => {
+      cy.getSider()
+        .find('.ant-page-header-heading')
+        .getButton({ icon: 'plus' })
+        .click()
+
+      cy.getModal().setFormFieldValue({
+        label: 'Render Type',
+        value: 'Atom',
+        type: FIELD_TYPE.SELECT,
+      })
+      cy.getModal().setFormFieldValue({
+        label: 'Atom',
+        value: IAtomType.AntDesignTypographyText,
+        type: FIELD_TYPE.SELECT,
+      })
+      cy.getModal().setFormFieldValue({
+        label: 'Name',
+        value: COMPONENT_INSTANCE_TEXT,
+      })
+
+      cy.getModal()
+        .getModalAction(/Create/)
+        .click()
+      cy.getModal().should('not.exist', { timeout: 10000 })
+      cy.get(`[title="${COMPONENT_INSTANCE_TEXT}"]`).click({ force: true })
+      cy.get(`.ant-tabs [aria-label="setting"]`).click()
+      cy.get('.ant-tabs-tabpane-active form .ql-editor').type(
+        COMPONENT_INSTANCE_TEXT,
+      )
+
+      cy.get('#Builder')
+        .findByText(`text ${COMPONENT_PROP_VALUE}`)
+        .should('exist')
+      cy.get('#Builder').findByText(COMPONENT_INSTANCE_TEXT).should('exist')
     })
   })
 })

--- a/libs/backend/infra/adapter/neo4j/src/schema/model/component.schema.ts
+++ b/libs/backend/infra/adapter/neo4j/src/schema/model/component.schema.ts
@@ -9,6 +9,8 @@ export const componentSchema = gql`
     api: InterfaceType! @relationship(type: "COMPONENT_API", direction: OUT)
     owner: User!
     props: Prop @relationship(type: "PROPS_OF_COMPONENT", direction: OUT)
+    # This is the element inside the component that is going to be
+    # the container for component instance children
     childrenContainerElement: Element! @relationship(type: "CHILDREN_CONTAINER_ELEMENT", direction: OUT)
     # This is used to prevent components from referencing each other in a
     # circular way. In another words, if component A references component B,

--- a/libs/frontend/domain/component/src/store/component.service.ts
+++ b/libs/frontend/domain/component/src/store/component.service.ts
@@ -258,7 +258,17 @@ export class ComponentService
   writeClonesCache(componentFragment: IComponentDTO) {
     return [...this.clonedComponents.values()]
       .filter((c) => c.sourceComponentId === componentFragment.id)
-      .map((c) => c.writeCache(componentFragment))
+      .map((c) => {
+        const clonedChildrenContainer = c.elementTree?.elementsList.find(
+          ({ sourceElementId }) =>
+            sourceElementId === componentFragment.childrenContainerElement.id,
+        )
+
+        const childrenContainerElement =
+          clonedChildrenContainer ?? componentFragment.childrenContainerElement
+
+        return c.writeCache({ ...componentFragment, childrenContainerElement })
+      })
   }
 
   @modelAction

--- a/libs/frontend/domain/renderer/src/renderer.model.ts
+++ b/libs/frontend/domain/renderer/src/renderer.model.ts
@@ -336,7 +336,7 @@ export class Renderer
   }
 
   getComponentInstanceChildren(element: IElement) {
-    const parentComponent = element.parentComponent?.current
+    const parentComponent = element.rootElement.parentComponent?.current
 
     const isContainer =
       element.id === parentComponent?.childrenContainerElementId


### PR DESCRIPTION
<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(libs-ui-component): must begin with lowercase` -->

## Description
Fixed 2 issues:
- issue when the component instance was updated and childrenContainerElement property was reset to the original element instead of the cloned one and no children rendered again.
- issue when component instance children were impossible to render inside of the non-root component element

Update e2e test cases for components:
- case for handling component children rendering
- case for component props passing

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged -->

Fixes #2258 
