### PR TITLE
fix: can't set props on component root element

### DIFF
--- a/libs/frontend/domain/component/src/store/api.utils.ts
+++ b/libs/frontend/domain/component/src/store/api.utils.ts
@@ -14,12 +14,17 @@ export const mapCreateInput = (
   const { id = v4(), name, auth0Id, rootElementId } = input
   const newRootElementId = v4()
 
+  const props: ComponentCreateInput['props'] = {
+    create: { node: { data: JSON.stringify({}) } },
+  }
+
   const createRootElement: ComponentCreateInput['rootElement'] = {
     create: {
       node: {
         id: newRootElementId,
         name,
         slug: createSlug(name, id),
+        props,
       },
     },
   }
@@ -42,10 +47,6 @@ export const mapCreateInput = (
         owner: connectOwner(auth0Id),
       },
     },
-  }
-
-  const props: ComponentCreateInput['props'] = {
-    create: { node: { data: JSON.stringify({}) } },
   }
 
   return {


### PR DESCRIPTION
<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(libs-ui-component): must begin with lowercase` -->

## Description
When the component was created, the root element was created as well, but no "props" were created for it.
This results in inability to set any props for this root element in the future since the "update" mutation was used and it does nothing if "props" does not exist

## Video or Image

Before 

https://user-images.githubusercontent.com/74900868/219870083-ed823ebb-f8d7-44a6-af2a-4b8186a4d2e3.mov

After

https://user-images.githubusercontent.com/74900868/219870089-399bbfb0-05c7-4142-b9cb-7c4ed8d0d415.mov



## Related Issue(s)

Fixes #2239
