### PR TITLE
Fix builder scrolling issues

### DIFF
--- a/libs/frontend/domain/builder/src/sections/config-pane/ConfigPane.tsx
+++ b/libs/frontend/domain/builder/src/sections/config-pane/ConfigPane.tsx
@@ -18,6 +18,7 @@ import { observer } from 'mobx-react-lite'
 import React from 'react'
 import tw from 'twin.macro'
 import { usePropCompletion } from '../../hooks'
+import { renderStickyTabBar } from '../stickyTabBarRenderer'
 import { ConfigPaneComponentTabContainer } from './ConfigPane-ComponentTabContainer'
 import { ConfigPaneInspectorTabContainer } from './ConfigPane-InspectorTabContainer'
 import { TabContainer } from './ConfigPane-InspectorTabContainer/ConfigPane-InspectorTabContainerStyle'
@@ -110,6 +111,7 @@ export const ConfigPane = observer<MetaPaneProps>(
         <Tabs
           defaultActiveKey={selectedNode?.id + '_tab2'}
           items={tabItems}
+          renderTabBar={renderStickyTabBar}
           size="small"
         />
       </TabContainer>

--- a/libs/frontend/domain/builder/src/sections/explorer-pane/BuilderExplorerPane.tsx
+++ b/libs/frontend/domain/builder/src/sections/explorer-pane/BuilderExplorerPane.tsx
@@ -44,6 +44,7 @@ import { observer } from 'mobx-react-lite'
 import type { PropsWithChildren, ReactNode } from 'react'
 import React from 'react'
 import tw from 'twin.macro'
+import { renderStickyTabBar } from '../stickyTabBarRenderer'
 import { BuilderTree } from './builder-tree'
 import { BuilderExplorerPaneHeader } from './BuilderExplorerPane-Header'
 
@@ -251,6 +252,7 @@ export const BuilderExplorerPane = observer<BuilderMainPaneProps>(
           `}
           defaultActiveKey="1"
           items={tabItems}
+          renderTabBar={renderStickyTabBar}
           size="small"
         />
         {pageTree && (

--- a/libs/frontend/domain/builder/src/sections/stickyTabBarRenderer.tsx
+++ b/libs/frontend/domain/builder/src/sections/stickyTabBarRenderer.tsx
@@ -1,0 +1,13 @@
+import type { TabsProps } from 'antd'
+import React from 'react'
+import StickyBox from 'react-sticky-box'
+
+export const renderStickyTabBar: TabsProps['renderTabBar'] = (
+  props,
+  DefaultTabBar,
+) => (
+  <StickyBox style={{ zIndex: 1 }}>
+    {/* eslint-disable-next-line react/jsx-props-no-spreading */}
+    <DefaultTabBar {...props} style={{ background: 'white' }} />
+  </StickyBox>
+)

--- a/libs/frontend/view/templates/Dashboard/DashboardTemplate-ExplorerPane.tsx
+++ b/libs/frontend/view/templates/Dashboard/DashboardTemplate-ExplorerPane.tsx
@@ -13,7 +13,7 @@ export const DashboardTemplateExplorerPane = ({
   return (
     <div css={tw`w-full`}>
       <Sider
-        css={tw`w-auto border-r border-gray-200 max-h-full h-full overflow-x-hidden overflow-y-auto`}
+        css={tw`w-auto border-r border-gray-200 max-h-full h-full overflow-x-hidden overflow-y-auto overscroll-contain`}
         theme="light"
         width="auto"
       >

--- a/libs/frontend/view/templates/Dashboard/DashboardTemplate-ExplorerPane.tsx
+++ b/libs/frontend/view/templates/Dashboard/DashboardTemplate-ExplorerPane.tsx
@@ -11,7 +11,7 @@ export const DashboardTemplateExplorerPane = ({
   ExplorerPane,
 }: ExplorerPaneProps) => {
   return (
-    <div css={tw`h-full w-full`}>
+    <div css={tw`w-full`}>
       <Sider
         css={tw`w-auto border-r border-gray-200 max-h-full h-full overflow-x-hidden overflow-y-auto`}
         theme="light"

--- a/libs/frontend/view/templates/Dashboard/DashboardTemplate-ExplorerPane.tsx
+++ b/libs/frontend/view/templates/Dashboard/DashboardTemplate-ExplorerPane.tsx
@@ -11,7 +11,7 @@ export const DashboardTemplateExplorerPane = ({
   ExplorerPane,
 }: ExplorerPaneProps) => {
   return (
-    <div css={tw`w-full`}>
+    <div css={tw`w-full h-full`}>
       <Sider
         css={tw`w-auto border-r border-gray-200 max-h-full h-full overflow-x-hidden overflow-y-auto overscroll-contain`}
         theme="light"

--- a/package.json
+++ b/package.json
@@ -129,6 +129,7 @@
     "react-resizable-panels": "^0.0.36",
     "react-responsive": "9.0.0-beta.10",
     "react-slick": "0.29.0",
+    "react-sticky-box": "^2.0.0",
     "react-stickynode": "4.1.0",
     "react-syntax-highlighter": "15.5.0",
     "react-use": "17.4.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -14695,6 +14695,7 @@ __metadata:
     react-resizable-panels: ^0.0.36
     react-responsive: 9.0.0-beta.10
     react-slick: 0.29.0
+    react-sticky-box: ^2.0.0
     react-stickynode: 4.1.0
     react-syntax-highlighter: 15.5.0
     react-use: 17.4.0
@@ -29130,6 +29131,15 @@ __metadata:
     react: ^0.14.0 || ^15.0.1 || ^16.0.0 || ^17.0.0 || ^18.0.0
     react-dom: ^0.14.0 || ^15.0.1 || ^16.0.0 || ^17.0.0 || ^18.0.0
   checksum: 67ce4981914da8a76c6efb4bc8ee7ab69e04c33bd4b3517419ab2165679a3c701dae781556149713fe2c542f84188b7ca101ea58883537be5c05756408f48c8b
+  languageName: node
+  linkType: hard
+
+"react-sticky-box@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "react-sticky-box@npm:2.0.0"
+  peerDependencies:
+    react: ">=16.8.0"
+  checksum: cfe20bdbadb7ca12af0eee3746eb2880ef44b0f92f4d2a35814b6f0558ebe9b27733102d284caa1c8d13d5db3410780afb68009a38c1f533f9a156776ed82192
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(libs-ui-component): must begin with lowercase` -->

## Description
This PR fixes scrolling issues in the builder.

- [x] Make ConfigPane and ExplorePane tab bars sticky
- [x] Fix content moves out of view when scrolling in ExplorePane
- [x] Fix scrolling in ExplorePane and ConfigPane causes scroll in the Builder 

<!-- This is a short description on the Pull Request -->

## Video or Image

<!-- Add video or image showing how the new feature works -->

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged -->

Fixes #2244
