### PR TITLE
fix: type table search not working

### DIFF
--- a/libs/frontend/domain/type/src/use-cases/types/get-types/GetTypesTable.tsx
+++ b/libs/frontend/domain/type/src/use-cases/types/get-types/GetTypesTable.tsx
@@ -52,16 +52,20 @@ export const GetTypesTable = observer<{
     [router],
   )
 
-  const loadAllBaseTypes = async () => {
-    await getBaseTypes({
-      offset: 0,
-      limit: curPageSize,
-    })
-    await getBaseTypes({
-      offset: 0,
-      limit: typeService.count,
-    })
-  }
+  const loadAllBaseTypes = useCallback(
+    async (pagesize: number) => {
+      let callCounter = 0
+
+      while (callCounter < 2) {
+        await getBaseTypes({
+          offset: 0,
+          limit: callCounter === 0 ? pagesize : typeService.count,
+        })
+        callCounter++
+      }
+    },
+    [curPageSize],
+  )
 
   /**
    * Change page
@@ -73,8 +77,8 @@ export const GetTypesTable = observer<{
   }, [curPage, pageSize, pagination])
 
   useEffect(() => {
-    void loadAllBaseTypes()
-  }, [])
+    void loadAllBaseTypes(curPageSize)
+  }, [curPageSize])
 
   return (
     <Table<IAnyType>

--- a/libs/frontend/domain/type/src/use-cases/types/get-types/GetTypesTable.tsx
+++ b/libs/frontend/domain/type/src/use-cases/types/get-types/GetTypesTable.tsx
@@ -29,7 +29,6 @@ export const GetTypesTable = observer<{
   const {
     isLoadingAllTypes,
     getBaseTypes,
-    fetchedBaseTypes,
     isLoadingTypeDescendants,
     getTypeDescendants,
   } = useTypesTableData(typeService)
@@ -53,6 +52,17 @@ export const GetTypesTable = observer<{
     [router],
   )
 
+  const loadAllBaseTypes = async () => {
+    await getBaseTypes({
+      offset: 0,
+      limit: curPageSize,
+    })
+    await getBaseTypes({
+      offset: 0,
+      limit: typeService.count,
+    })
+  }
+
   /**
    * Change page
    */
@@ -63,24 +73,13 @@ export const GetTypesTable = observer<{
   }, [curPage, pageSize, pagination])
 
   useEffect(() => {
-    const offset = (curPage - 1) * curPageSize
-    void getBaseTypes({
-      offset,
-      limit: curPageSize,
-    })
-  }, [curPage, curPageSize, getBaseTypes])
-
-  const curPageDataStartIndex = typesList.findIndex(
-    (t) => t.id === fetchedBaseTypes?.[0]?.id,
-  )
+    void loadAllBaseTypes()
+  }, [])
 
   return (
     <Table<IAnyType>
       columns={columns}
-      dataSource={typesList.slice(
-        curPageDataStartIndex >= 0 ? curPageDataStartIndex : 0,
-        (curPageDataStartIndex >= 0 ? curPageDataStartIndex : 0) + curPageSize,
-      )}
+      dataSource={typesList}
       expandable={{
         onExpand: async (expanded, record) => {
           if (expanded) {

--- a/libs/frontend/domain/type/src/use-cases/types/get-types/useTypesTable.tsx
+++ b/libs/frontend/domain/type/src/use-cases/types/get-types/useTypesTable.tsx
@@ -110,7 +110,6 @@ export const useTypesTable = ({
   const pagination: TablePaginationConfig = {
     position: ['bottomCenter'],
     defaultPageSize: 25,
-    total: typeService.count,
     onChange: async (page: number, pageSize: number) => {
       const options = {
         offset: (page - 1) * pageSize,


### PR DESCRIPTION
<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(libs-ui-component): must begin with lowercase` -->

## Description

<!-- This is a short description on the Pull Request -->
Fixed Closes #2276 
GetTypesTable component loads only pagesize count of types, so result is not good when user search types.
If Ant Design Table doesn't contain full types, it is difficult to search types.
Modified section loads BaseTypes in GetTypesTable component.

## Video or Image

<!-- Add video or image showing how the new feature works -->

https://user-images.githubusercontent.com/87414033/220055785-8a0c9d12-aba1-48d4-8a5c-3c171193303b.mp4

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged -->

Fixes #2276 
