### PR TITLE
fix: regular page elements not rendering in builder

### DIFF
--- a/libs/frontend/domain/app/src/store/api.utils.ts
+++ b/libs/frontend/domain/app/src/store/api.utils.ts
@@ -7,12 +7,14 @@ import {
 } from '@codelab/frontend/abstract/core'
 import { createUniqueName } from '@codelab/frontend/shared/utils'
 import { IPageKind } from '@codelab/shared/abstract/core'
+import { connectNodeId } from '@codelab/shared/domain/mapper'
 import { v4 } from 'uuid'
 
 export const makeBasicPagesInput = (appId: string) => {
   const providerPageId = v4()
   const notFoundPageId = v4()
   const internalServerErrorPageId = v4()
+  const providerRootId = v4()
 
   const providerPage = {
     id: providerPageId,
@@ -29,6 +31,7 @@ export const makeBasicPagesInput = (appId: string) => {
         },
       },
     },
+    pageContainerElement: connectNodeId(providerRootId),
     kind: IPageKind.Provider,
   }
 


### PR DESCRIPTION
<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(libs-ui-component): must begin with lowercase` -->

## Description

<!-- This is a short description on the Pull Request -->
restore `pageContainerElement` which allows attaching regular page elements to provider page elements. without it only provider elements will be rendered

## Video or Image

<!-- Add video or image showing how the new feature works -->

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged -->

Fixes #2301 
