### PR TITLE
fix: not authenticated error on page regeneration

### DIFF
--- a/apps/websites/pages/[domain]/[page].tsx
+++ b/apps/websites/pages/[domain]/[page].tsx
@@ -1,3 +1,5 @@
+// eslint-disable-next-line @nrwl/nx/enforce-module-boundaries
+import { pageSlug as getPageSlug } from '@codelab/backend/graphql'
 import { RendererType } from '@codelab/frontend/abstract/core'
 import type { AppPagePageProps } from '@codelab/frontend/abstract/types'
 import { Renderer } from '@codelab/frontend/domain/renderer'
@@ -70,7 +72,9 @@ export const getStaticProps: GetStaticProps<AppPagePageProps> = async (
     throw new Error(`No apps found for "${domain}" domain`)
   }
 
-  const page = app.pages.find((appPage) => appPage.current.slug === pageSlug)
+  const page = app.pages.find(
+    (appPage) => getPageSlug({ name: appPage.current.name }) === pageSlug,
+  )
 
   if (!page) {
     throw new Error(`Page ${pageSlug} on "${domain}" domain Not found`)

--- a/apps/websites/pages/api/regenerate.ts
+++ b/apps/websites/pages/api/regenerate.ts
@@ -1,3 +1,5 @@
+// eslint-disable-next-line @nrwl/nx/enforce-module-boundaries
+import { pageSlug } from '@codelab/backend/graphql'
 import { auth0Instance } from '@codelab/shared/adapter/auth0'
 import type { NextApiHandler } from 'next'
 
@@ -23,8 +25,8 @@ const regenerate: NextApiHandler = async (req, res) => {
     const revalidatedPages: Array<string> = []
     const failedPages: Array<string> = []
 
-    const revalidationPromises = pages.map(async (pageSlug) => {
-      const path = `/${domain}/${pageSlug}`
+    const revalidationPromises = pages.map(async (pageName) => {
+      const path = `/${domain}/${pageSlug({ name: pageName })}`
 
       try {
         await res.revalidate(path)

--- a/libs/backend/graphql/src/resolvers/index.ts
+++ b/libs/backend/graphql/src/resolvers/index.ts
@@ -1,2 +1,3 @@
 export * from './element'
+export * from './page'
 export * from './resolvers'

--- a/libs/backend/graphql/src/resolvers/page/index.ts
+++ b/libs/backend/graphql/src/resolvers/page/index.ts
@@ -1,6 +1,8 @@
 import type { IResolvers } from '@graphql-tools/utils'
 import { pageSlug } from './page.resolver'
 
+export * from './page.resolver'
+
 export const pageResolver: IResolvers = {
   Mutation: {},
   Query: {},

--- a/libs/frontend/domain/app/src/use-cases/build-app/BuildAppModal.tsx
+++ b/libs/frontend/domain/app/src/use-cases/build-app/BuildAppModal.tsx
@@ -21,7 +21,7 @@ export const BuildAppModal = observer<{
         (_domain) => _domain.appId === app.id,
       )
 
-      const pages = app.pages.map((page) => page.id)
+      const pages = app.pages.map((page) => page.current.name)
 
       if (domain) {
         await regeneratePages(pages, domain.name)

--- a/libs/frontend/domain/domain/src/staticRegeneration.ts
+++ b/libs/frontend/domain/domain/src/staticRegeneration.ts
@@ -1,3 +1,11 @@
+const baseUrl = process.env['NEXT_PUBLIC_BUILDER_HOST']
+
+// makes a call to the builder backend where session is checked
+// and request will be redirected to appropriate user domain
 export const regeneratePages = (pages: Array<string>, domain: string) => {
-  return fetch(`https://${domain}/api/regenerate?pages=${pages.join(',')}`)
+  const pagesParam = pages.join(',')
+
+  return fetch(
+    `https://${baseUrl}/api/regenerate?domain=${domain}&pages=${pagesParam}`,
+  )
 }

--- a/libs/frontend/domain/page/src/use-cases/get-pages/GetPagesItem.tsx
+++ b/libs/frontend/domain/page/src/use-cases/get-pages/GetPagesItem.tsx
@@ -41,7 +41,7 @@ export const GetPagesItem = observer<GetPagesItemProps>(
 
       if (pageDomain?.name) {
         setRebuildButtonLoading(true)
-        await regeneratePages([page.slug], pageDomain.name)
+        await regeneratePages([page.name], pageDomain.name)
         setRebuildButtonLoading(false)
       }
     }


### PR DESCRIPTION
<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(libs-ui-component): must begin with lowercase` -->

## Description
- fixed auth0 403 error when requested to regenerate app pages.
Now the flow is the following:
user clicks the "rebuild" button on UI -> request to the builder backend is sent (admin.codelab.app) -> builder backend redirects the request to the appropriate domain of the websites project (for example to codelab-demo.online/api/regenerate). Each backend endpoint is protected by auth0 so an unauthenticated user will not be able to trigger the regeneration of any page.

- fixed website page routing after automatic slugs were implemented
after automatic slugs were implemented it became hard to navigate to user pages since they started to look like this: `https://codelab-demo.online/3-fe-3-e-3-b-3-0852-4056-9625-d-7-ba-490-a-125-a-home`. Used slugified page name to navigate to pages instead

## Related Issue(s)

Fixes #2232 
