### PR TITLE
fix: styles passed through css prop not working

### DIFF
--- a/libs/frontend/domain/renderer/src/renderer.model.ts
+++ b/libs/frontend/domain/renderer/src/renderer.model.ts
@@ -23,6 +23,7 @@ import {
 import { IPageKind, ITypeKind } from '@codelab/shared/abstract/core'
 import { Nullable } from '@codelab/shared/abstract/types'
 import { mapDeep, mergeProps } from '@codelab/shared/utils'
+import { jsx } from '@emotion/react'
 import { computed } from 'mobx'
 import type { Ref } from 'mobx-keystone'
 import {
@@ -221,7 +222,9 @@ export class Renderer
           return makeCustomTextContainer(injectedText)
         }
 
-        return React.createElement(Component, props, children)
+        // jsx from @emotion is a must use here.
+        // React.createElement must not be used, because css prop is not supported out of the box by React.
+        return jsx(Component, props, children)
       })
     }
 


### PR DESCRIPTION
<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(libs-ui-component): must begin with lowercase` -->

## Description
Fixes styles of elements of the `_app` page that are rendered inside other pages are not working.

<!-- This is a short description on the Pull Request -->

## Video or Image

<!-- Add video or image showing how the new feature works -->

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged -->

Fixes #2236
