### PR TITLE
fix: Parent Element should show name instead of ID

### DIFF
--- a/libs/frontend/abstract/core/src/domain/element/element-tree.interface.model.ts
+++ b/libs/frontend/abstract/core/src/domain/element/element-tree.interface.model.ts
@@ -12,6 +12,7 @@ import type { IElement } from './element.model.interface'
  */
 export interface IElementTree {
   id: string
+  name: string
   _root: Nullable<Ref<IElement>>
   root: Maybe<IElement>
   elementsList: Array<IElement>

--- a/libs/frontend/abstract/core/src/domain/element/element.service.interface.ts
+++ b/libs/frontend/abstract/core/src/domain/element/element.service.interface.ts
@@ -20,16 +20,19 @@ import type {
   IUpdateElementDTO,
 } from './element.dto.interface'
 import type { IElement, IElementRef } from './element.model.interface'
+import type { IElementTree } from './element-tree.interface.model'
 
 /**
  * Used for modal input
  */
 export interface CreateElementData {
-  parentElement: Ref<IElement>
+  selectedElement?: Maybe<Ref<IElement>>
+  elementTree: Ref<IElementTree>
 }
 
 export interface CreateElementProperties {
   parentElement: IElement
+  elementTree: IElementTree
 }
 
 export interface UpdateElementProperties {

--- a/libs/frontend/domain/builder/src/sections/explorer-pane/BuilderExplorerPane-Header.tsx
+++ b/libs/frontend/domain/builder/src/sections/explorer-pane/BuilderExplorerPane-Header.tsx
@@ -2,29 +2,37 @@ import type {
   IBuilderService,
   IElement,
   IElementService,
+  IElementTree,
 } from '@codelab/frontend/abstract/core'
 import { CreateElementButton } from '@codelab/frontend/domain/element'
-import type { Nullable } from '@codelab/shared/abstract/types'
+import type { Maybe, Nullable } from '@codelab/shared/abstract/types'
 import { observer } from 'mobx-react-lite'
 import React from 'react'
 
 interface BuilderMainPaneHeaderProps {
   elementService: IElementService
   builderService: IBuilderService
+  elementTree: Maybe<IElementTree>
   root: Nullable<IElement>
 }
 
 export const BuilderExplorerPaneHeader = observer(
-  ({ root, elementService, builderService }: BuilderMainPaneHeaderProps) => {
-    if (!root) {
+  ({
+    root,
+    elementService,
+    builderService,
+    elementTree,
+  }: BuilderMainPaneHeaderProps) => {
+    if (!root || !elementTree) {
       return null
     }
 
     return (
       <CreateElementButton
         createModal={elementService.createModal}
+        elementTreeId={elementTree.id}
         key={0}
-        parentElementId={builderService.selectedNode?.id || root.id}
+        selectedElementId={builderService.selectedNode?.id}
         title="Element"
       />
     )

--- a/libs/frontend/domain/builder/src/sections/explorer-pane/BuilderExplorerPane-Header.tsx
+++ b/libs/frontend/domain/builder/src/sections/explorer-pane/BuilderExplorerPane-Header.tsx
@@ -25,6 +25,7 @@ export const BuilderExplorerPaneHeader = observer(
         createModal={elementService.createModal}
         key={0}
         parentElementId={builderService.selectedNode?.id || root.id}
+        title="Element"
       />
     )
   },

--- a/libs/frontend/domain/builder/src/sections/explorer-pane/BuilderExplorerPane.tsx
+++ b/libs/frontend/domain/builder/src/sections/explorer-pane/BuilderExplorerPane.tsx
@@ -100,6 +100,7 @@ export const BuilderExplorerPane = observer<BuilderMainPaneProps>(
       ? renderService.renderers.get(componentId)?.pageTree?.current
       : null
 
+    const activeElementTree = componentTree || pageTree
     const antdTree = root?.antdNode
     const componentsAntdTree = componentService.componentAntdNode
     const isPageTree = antdTree && pageTree
@@ -255,13 +256,13 @@ export const BuilderExplorerPane = observer<BuilderMainPaneProps>(
           renderTabBar={renderStickyTabBar}
           size="small"
         />
-        {pageTree && (
+        {activeElementTree && (
           <CreateElementModal
             actionService={actionService}
+            activeElementTree={activeElementTree}
             builderService={builderService}
             componentService={componentService}
             elementService={elementService}
-            pageTree={pageTree}
             renderService={renderService}
             storeId={storeId}
             userService={userService}

--- a/libs/frontend/domain/builder/src/sections/explorer-pane/BuilderExplorerPane.tsx
+++ b/libs/frontend/domain/builder/src/sections/explorer-pane/BuilderExplorerPane.tsx
@@ -166,7 +166,10 @@ export const BuilderExplorerPane = observer<BuilderMainPaneProps>(
               <>
                 <Divider />
                 <div css={tw`flex justify-end`}>
-                  <CreateComponentButton componentService={componentService} />
+                  <CreateComponentButton
+                    componentService={componentService}
+                    title="Component"
+                  />
                 </div>
               </>
             )}

--- a/libs/frontend/domain/builder/src/sections/explorer-pane/BuilderExplorerPane.tsx
+++ b/libs/frontend/domain/builder/src/sections/explorer-pane/BuilderExplorerPane.tsx
@@ -100,7 +100,6 @@ export const BuilderExplorerPane = observer<BuilderMainPaneProps>(
       ? renderService.renderers.get(componentId)?.pageTree?.current
       : null
 
-    const activeElementTree = componentTree || pageTree
     const antdTree = root?.antdNode
     const componentsAntdTree = componentService.componentAntdNode
     const isPageTree = antdTree && pageTree
@@ -136,6 +135,7 @@ export const BuilderExplorerPane = observer<BuilderMainPaneProps>(
               <BuilderExplorerPaneHeader
                 builderService={builderService}
                 elementService={elementService}
+                elementTree={pageTree}
                 root={root ?? null}
               />
             }
@@ -259,18 +259,15 @@ export const BuilderExplorerPane = observer<BuilderMainPaneProps>(
           renderTabBar={renderStickyTabBar}
           size="small"
         />
-        {activeElementTree && (
-          <CreateElementModal
-            actionService={actionService}
-            activeElementTree={activeElementTree}
-            builderService={builderService}
-            componentService={componentService}
-            elementService={elementService}
-            renderService={renderService}
-            storeId={storeId}
-            userService={userService}
-          />
-        )}
+        <CreateElementModal
+          actionService={actionService}
+          builderService={builderService}
+          componentService={componentService}
+          elementService={elementService}
+          renderService={renderService}
+          storeId={storeId}
+          userService={userService}
+        />
         <CreateComponentModal
           componentService={componentService}
           userService={userService}

--- a/libs/frontend/domain/builder/src/sections/explorer-pane/ElementContextMenu.tsx
+++ b/libs/frontend/domain/builder/src/sections/explorer-pane/ElementContextMenu.tsx
@@ -5,7 +5,7 @@ import type {
   IElementTree,
 } from '@codelab/frontend/abstract/core'
 import { RendererTab } from '@codelab/frontend/abstract/core'
-import { elementRef } from '@codelab/frontend/domain/element'
+import { elementRef, elementTreeRef } from '@codelab/frontend/domain/element'
 import { componentRef, useStore } from '@codelab/frontend/presenter/container'
 import { Key } from '@codelab/frontend/view/components'
 import { Menu } from 'antd'
@@ -46,8 +46,13 @@ export const ElementContextMenu = observer<ElementContextMenuProps>(
     const isComponentInstance = Boolean(element.renderComponentType)
 
     const onAddChild = () => {
+      if (!elementTree) {
+        return
+      }
+
       return createModal.open({
-        parentElement: elementRef(element.id),
+        selectedElement: elementRef(element.id),
+        elementTree: elementTreeRef(elementTree.id),
       })
     }
 

--- a/libs/frontend/domain/builder/src/sections/explorer-pane/builder-tree/BuilderTree.tsx
+++ b/libs/frontend/domain/builder/src/sections/explorer-pane/builder-tree/BuilderTree.tsx
@@ -153,6 +153,7 @@ export const BuilderTree = observer<BuilderTreeProps>(
               componentContextMenuProps={componentContextMenuProps}
               data={data}
               elementContextMenuProps={elementContextMenuProps}
+              elementService={elementService}
               node={node}
             />
           )

--- a/libs/frontend/domain/builder/src/sections/explorer-pane/builder-tree/BuilderTree.tsx
+++ b/libs/frontend/domain/builder/src/sections/explorer-pane/builder-tree/BuilderTree.tsx
@@ -150,6 +150,7 @@ export const BuilderTree = observer<BuilderTreeProps>(
 
           return (
             <BuilderTreeItemTitle
+              builderService={builderService}
               componentContextMenuProps={componentContextMenuProps}
               data={data}
               elementContextMenuProps={elementContextMenuProps}

--- a/libs/frontend/domain/builder/src/sections/explorer-pane/builder-tree/BuilderTreeItem-ComponentTitle.tsx
+++ b/libs/frontend/domain/builder/src/sections/explorer-pane/builder-tree/BuilderTreeItem-ComponentTitle.tsx
@@ -1,0 +1,43 @@
+import type {
+  IBuilderService,
+  IComponent,
+  IElementService,
+} from '@codelab/frontend/abstract/core'
+import { isElement } from '@codelab/frontend/abstract/core'
+import { CreateElementButton } from '@codelab/frontend/domain/element'
+import { Col, Row } from 'antd'
+import { observer } from 'mobx-react-lite'
+import React from 'react'
+import tw from 'twin.macro'
+
+interface BuilderTreeItemComponentTitleProps {
+  component: IComponent
+  elementService: IElementService
+  builderService: IBuilderService
+}
+
+export const BuilderTreeItemComponentTitle = observer(
+  ({
+    builderService,
+    component,
+    elementService,
+  }: BuilderTreeItemComponentTitleProps) => {
+    const { selectedNode } = builderService
+    const selectedNodeId = isElement(selectedNode) && selectedNode.id
+
+    return (
+      <Row justify="space-between">
+        <Col css={tw`px-2`}>{component.name}</Col>
+        <Col css={tw`px-2`}>
+          <CreateElementButton
+            createModal={elementService.createModal}
+            elementTreeId={component.elementTree?.id || ''}
+            key={0}
+            selectedElementId={selectedNodeId || component.rootElementId}
+            type="text"
+          />
+        </Col>
+      </Row>
+    )
+  },
+)

--- a/libs/frontend/domain/builder/src/sections/explorer-pane/builder-tree/BuilderTreeItem-ElementTitle.tsx
+++ b/libs/frontend/domain/builder/src/sections/explorer-pane/builder-tree/BuilderTreeItem-ElementTitle.tsx
@@ -1,0 +1,55 @@
+import { ExclamationCircleOutlined } from '@ant-design/icons'
+import type { IElement } from '@codelab/frontend/abstract/core'
+import { Col, Row, Tooltip } from 'antd'
+import { observer } from 'mobx-react-lite'
+import React from 'react'
+import tw from 'twin.macro'
+
+interface BuilderTreeItemElementTitleProps {
+  element: IElement
+}
+
+export const BuilderTreeItemElementTitle = observer(
+  ({ element }: BuilderTreeItemElementTitleProps) => {
+    const atomName = element.atomName
+
+    const componentInstanceName =
+      element.renderComponentType?.maybeCurrent?.name
+
+    const isComponentInstance = Boolean(element.renderComponentType)
+
+    const componentMeta = componentInstanceName
+      ? `(instance of ${componentInstanceName || 'a Component'})`
+      : undefined
+
+    const atomMeta = atomName ? `(${atomName})` : undefined
+    const meta = componentMeta || atomMeta || ''
+
+    const errorMessage = element.renderingMetadata?.error
+      ? `Error: ${element.renderingMetadata.error.message}`
+      : element.ancestorError
+      ? `Something went wrong in a parent element`
+      : undefined
+
+    return (
+      <Row>
+        <Col span={18}>
+          <div css={isComponentInstance ? tw`text-blue-400` : `text-gray-400`}>
+            {element.label} <span css={tw`text-xs`}>{meta}</span>
+          </div>
+        </Col>
+        <Col span={6}>
+          <Row justify="end">
+            <Col>
+              {errorMessage && (
+                <Tooltip placement="right" title={errorMessage}>
+                  <ExclamationCircleOutlined style={{ color: 'red' }} />
+                </Tooltip>
+              )}
+            </Col>
+          </Row>
+        </Col>
+      </Row>
+    )
+  },
+)

--- a/libs/frontend/domain/builder/src/sections/explorer-pane/builder-tree/BuilderTreeItem-Title.tsx
+++ b/libs/frontend/domain/builder/src/sections/explorer-pane/builder-tree/BuilderTreeItem-Title.tsx
@@ -1,9 +1,10 @@
 import { ExclamationCircleOutlined } from '@ant-design/icons'
-import type { INode } from '@codelab/frontend/abstract/core'
+import type { IElementService, INode } from '@codelab/frontend/abstract/core'
 import {
   COMPONENT_NODE_TYPE,
   ELEMENT_NODE_TYPE,
 } from '@codelab/frontend/abstract/core'
+import { CreateElementButton } from '@codelab/frontend/domain/element'
 import type { Nullable } from '@codelab/shared/abstract/types'
 import { Col, Dropdown, Row, Tooltip } from 'antd'
 import type { DataNode } from 'antd/lib/tree'
@@ -23,10 +24,17 @@ interface BuilderTreeItemTitleProps {
   data: DataNode
   elementContextMenuProps: Omit<ElementContextMenuProps, 'element'>
   componentContextMenuProps: Omit<ComponentContextMenuProps, 'component'>
+  elementService: IElementService
 }
 
 export const BuilderTreeItemTitle = observer<BuilderTreeItemTitleProps>(
-  ({ node, data, elementContextMenuProps, componentContextMenuProps }) => {
+  ({
+    node,
+    data,
+    elementContextMenuProps,
+    componentContextMenuProps,
+    elementService,
+  }) => {
     const [contextMenuItemId, setContextMenuNodeId] =
       useState<Nullable<string>>(null)
 
@@ -125,7 +133,17 @@ export const BuilderTreeItemTitle = observer<BuilderTreeItemTitleProps>(
             }
             trigger={['contextMenu']}
           >
-            <div>{component.name}</div>
+            <Row justify="space-between">
+              <Col css={tw`px-2`}>{component.name}</Col>
+              <Col css={tw`px-2`}>
+                <CreateElementButton
+                  createModal={elementService.createModal}
+                  key={0}
+                  parentElementId={node.id}
+                  type="text"
+                />
+              </Col>
+            </Row>
           </Dropdown>
         </ItemTitleStyle>
       )

--- a/libs/frontend/domain/builder/src/sections/explorer-pane/builder-tree/BuilderTreeItem-Title.tsx
+++ b/libs/frontend/domain/builder/src/sections/explorer-pane/builder-tree/BuilderTreeItem-Title.tsx
@@ -1,8 +1,13 @@
 import { ExclamationCircleOutlined } from '@ant-design/icons'
-import type { IElementService, INode } from '@codelab/frontend/abstract/core'
+import type {
+  IBuilderService,
+  IElementService,
+  INode,
+} from '@codelab/frontend/abstract/core'
 import {
   COMPONENT_NODE_TYPE,
   ELEMENT_NODE_TYPE,
+  isElement,
 } from '@codelab/frontend/abstract/core'
 import { CreateElementButton } from '@codelab/frontend/domain/element'
 import type { Nullable } from '@codelab/shared/abstract/types'
@@ -25,6 +30,7 @@ interface BuilderTreeItemTitleProps {
   elementContextMenuProps: Omit<ElementContextMenuProps, 'element'>
   componentContextMenuProps: Omit<ComponentContextMenuProps, 'component'>
   elementService: IElementService
+  builderService: IBuilderService
 }
 
 export const BuilderTreeItemTitle = observer<BuilderTreeItemTitleProps>(
@@ -34,9 +40,13 @@ export const BuilderTreeItemTitle = observer<BuilderTreeItemTitleProps>(
     elementContextMenuProps,
     componentContextMenuProps,
     elementService,
+    builderService,
   }) => {
     const [contextMenuItemId, setContextMenuNodeId] =
       useState<Nullable<string>>(null)
+
+    const { selectedNode } = builderService
+    const selectedNodeId = isElement(selectedNode) && selectedNode.id
 
     // Add CSS to disable hover if node is unselectable
     if (node?.__nodeType === ELEMENT_NODE_TYPE) {
@@ -138,8 +148,9 @@ export const BuilderTreeItemTitle = observer<BuilderTreeItemTitleProps>(
               <Col css={tw`px-2`}>
                 <CreateElementButton
                   createModal={elementService.createModal}
+                  elementTreeId={component.elementTree?.id || ''}
                   key={0}
-                  parentElementId={node.id}
+                  selectedElementId={selectedNodeId || component.rootElementId}
                   type="text"
                 />
               </Col>

--- a/libs/frontend/domain/builder/src/sections/explorer-pane/builder-tree/BuilderTreeItem-Title.tsx
+++ b/libs/frontend/domain/builder/src/sections/explorer-pane/builder-tree/BuilderTreeItem-Title.tsx
@@ -1,4 +1,3 @@
-import { ExclamationCircleOutlined } from '@ant-design/icons'
 import type {
   IBuilderService,
   IElementService,
@@ -7,20 +6,19 @@ import type {
 import {
   COMPONENT_NODE_TYPE,
   ELEMENT_NODE_TYPE,
-  isElement,
 } from '@codelab/frontend/abstract/core'
-import { CreateElementButton } from '@codelab/frontend/domain/element'
 import type { Nullable } from '@codelab/shared/abstract/types'
-import { Col, Dropdown, Row, Tooltip } from 'antd'
+import { Dropdown } from 'antd'
 import type { DataNode } from 'antd/lib/tree'
 import { observer } from 'mobx-react-lite'
 import React, { useState } from 'react'
-import tw from 'twin.macro'
 import { BuilderDropHandler } from '../../../dnd/BuilderDropHandler'
 import type { ComponentContextMenuProps } from '../ComponentContextMenu'
 import { ComponentContextMenu } from '../ComponentContextMenu'
 import type { ElementContextMenuProps } from '../ElementContextMenu'
 import { ElementContextMenu } from '../ElementContextMenu'
+import { BuilderTreeItemComponentTitle } from './BuilderTreeItem-ComponentTitle'
+import { BuilderTreeItemElementTitle } from './BuilderTreeItem-ElementTitle'
 import { BuilderTreeItemOverlay } from './BuilderTreeItem-Overlay'
 import { ItemTitleStyle } from './ItemTitleStyle'
 
@@ -45,31 +43,9 @@ export const BuilderTreeItemTitle = observer<BuilderTreeItemTitleProps>(
     const [contextMenuItemId, setContextMenuNodeId] =
       useState<Nullable<string>>(null)
 
-    const { selectedNode } = builderService
-    const selectedNodeId = isElement(selectedNode) && selectedNode.id
-
     // Add CSS to disable hover if node is unselectable
     if (node?.__nodeType === ELEMENT_NODE_TYPE) {
       const element = node
-      const atomName = element.atomName
-
-      const componentInstanceName =
-        element.renderComponentType?.maybeCurrent?.name
-
-      const isComponentInstance = Boolean(element.renderComponentType)
-
-      const componentMeta = componentInstanceName
-        ? `(instance of ${componentInstanceName || 'a Component'})`
-        : undefined
-
-      const atomMeta = atomName ? `(${atomName})` : undefined
-      const meta = componentMeta || atomMeta || ''
-
-      const errorMessage = element.renderingMetadata?.error
-        ? `Error: ${element.renderingMetadata.error.message}`
-        : element.ancestorError
-        ? `Something went wrong in a parent element`
-        : undefined
 
       return (
         <BuilderDropHandler element={element}>
@@ -92,28 +68,9 @@ export const BuilderTreeItemTitle = observer<BuilderTreeItemTitleProps>(
               }
               trigger={['contextMenu']}
             >
-              <Row>
-                <Col span={18}>
-                  <div
-                    css={
-                      isComponentInstance ? tw`text-blue-400` : `text-gray-400`
-                    }
-                  >
-                    {element.label} <span css={tw`text-xs`}>{meta}</span>
-                  </div>
-                </Col>
-                <Col span={6}>
-                  <Row justify="end">
-                    <Col>
-                      {errorMessage && (
-                        <Tooltip placement="right" title={errorMessage}>
-                          <ExclamationCircleOutlined style={{ color: 'red' }} />
-                        </Tooltip>
-                      )}
-                    </Col>
-                  </Row>
-                </Col>
-              </Row>
+              <div>
+                <BuilderTreeItemElementTitle element={element} />
+              </div>
             </Dropdown>
           </ItemTitleStyle>
         </BuilderDropHandler>
@@ -143,18 +100,13 @@ export const BuilderTreeItemTitle = observer<BuilderTreeItemTitleProps>(
             }
             trigger={['contextMenu']}
           >
-            <Row justify="space-between">
-              <Col css={tw`px-2`}>{component.name}</Col>
-              <Col css={tw`px-2`}>
-                <CreateElementButton
-                  createModal={elementService.createModal}
-                  elementTreeId={component.elementTree?.id || ''}
-                  key={0}
-                  selectedElementId={selectedNodeId || component.rootElementId}
-                  type="text"
-                />
-              </Col>
-            </Row>
+            <div>
+              <BuilderTreeItemComponentTitle
+                builderService={builderService}
+                component={component}
+                elementService={elementService}
+              />
+            </div>
           </Dropdown>
         </ItemTitleStyle>
       )

--- a/libs/frontend/domain/component/src/use-cases/create-component/CreateComponentButton.tsx
+++ b/libs/frontend/domain/component/src/use-cases/create-component/CreateComponentButton.tsx
@@ -4,17 +4,23 @@ import { Button } from 'antd'
 import { observer } from 'mobx-react-lite'
 import React from 'react'
 
-export const CreateComponentButton = observer<{
+export type CreateComponentButtonProps = {
   className?: string
   componentService: IComponentService
-}>(({ componentService, className }) => {
-  return (
-    <Button
-      className={className}
-      icon={<PlusOutlined />}
-      key={0}
-      onClick={() => componentService.createModal.open()}
-      size="small"
-    />
-  )
-})
+} & React.ComponentProps<typeof Button>
+
+export const CreateComponentButton = observer<CreateComponentButtonProps>(
+  ({ componentService, className, title }) => {
+    return (
+      <Button
+        className={className}
+        icon={<PlusOutlined />}
+        key={0}
+        onClick={() => componentService.createModal.open()}
+        size="small"
+      >
+        {title || ''}
+      </Button>
+    )
+  },
+)

--- a/libs/frontend/domain/element/src/store/element-modal.service.ts
+++ b/libs/frontend/domain/element/src/store/element-modal.service.ts
@@ -18,9 +18,31 @@ export class CreateElementModalService
   )
   implements IEntityModalService<CreateElementData, CreateElementProperties>
 {
+  /**
+   * The default parent element for the element to be created.
+   * The parent element is the selected node in the explorer tree
+   * if it belongs to the element tree. Otherwise, it's the root
+   * of the tree.
+   */
   @computed
   get parentElement() {
-    return this.metadata?.parentElement.current
+    const elementTree = this.metadata?.elementTree.current
+    const selectedElement = this.metadata?.selectedElement?.current
+
+    if (!elementTree) {
+      return undefined
+    }
+
+    if (selectedElement && elementTree.elementsList.includes(selectedElement)) {
+      return selectedElement
+    }
+
+    return elementTree.root
+  }
+
+  @computed
+  get elementTree() {
+    return this.metadata?.elementTree.current
   }
 }
 

--- a/libs/frontend/domain/element/src/store/element-tree.model.ts
+++ b/libs/frontend/domain/element/src/store/element-tree.model.ts
@@ -64,6 +64,13 @@ export class ElementTree
   }
 
   @computed
+  get name() {
+    const parentComponent = this.root?.parentComponent?.current
+
+    return parentComponent ? parentComponent.name : 'Page'
+  }
+
+  @computed
   get root() {
     return this._root?.current
   }

--- a/libs/frontend/domain/element/src/use-cases/element/create-element/CreateElementButton.tsx
+++ b/libs/frontend/domain/element/src/use-cases/element/create-element/CreateElementButton.tsx
@@ -11,7 +11,7 @@ export type CreateElementButtonProps = {
   React.ComponentProps<typeof Button>
 
 export const CreateElementButton = observer<CreateElementButtonProps>(
-  ({ parentElementId, createModal, type }) => {
+  ({ parentElementId, createModal, type, title }) => {
     return (
       <Button
         icon={<PlusOutlined data-testid="create-page-element-button" />}
@@ -22,7 +22,9 @@ export const CreateElementButton = observer<CreateElementButtonProps>(
         }}
         size="small"
         type={type}
-      />
+      >
+        {title || ''}
+      </Button>
     )
   },
 )

--- a/libs/frontend/domain/element/src/use-cases/element/create-element/CreateElementButton.tsx
+++ b/libs/frontend/domain/element/src/use-cases/element/create-element/CreateElementButton.tsx
@@ -1,23 +1,33 @@
 import { PlusOutlined } from '@ant-design/icons'
 import type { IElementService } from '@codelab/frontend/abstract/core'
+import type { Maybe } from '@codelab/shared/abstract/types'
 import { Button } from 'antd'
 import { observer } from 'mobx-react-lite'
 import React from 'react'
-import { elementRef } from '../../../store'
+import { elementRef, elementTreeRef } from '../../../store'
 
 export type CreateElementButtonProps = {
-  parentElementId: string
+  selectedElementId: Maybe<string>
+  elementTreeId: string
 } & Pick<IElementService, 'createModal'> &
   React.ComponentProps<typeof Button>
 
 export const CreateElementButton = observer<CreateElementButtonProps>(
-  ({ parentElementId, createModal, type, title }) => {
+  ({ selectedElementId, elementTreeId, createModal, type, title }) => {
+    const selectedElement = selectedElementId
+      ? elementRef(selectedElementId)
+      : undefined
+
     return (
       <Button
         icon={<PlusOutlined data-testid="create-page-element-button" />}
-        onClick={() => {
+        onClick={(event) => {
+          event.stopPropagation()
+          event.preventDefault()
+
           return createModal.open({
-            parentElement: elementRef(parentElementId),
+            selectedElement,
+            elementTree: elementTreeRef(elementTreeId),
           })
         }}
         size="small"

--- a/libs/frontend/domain/element/src/use-cases/element/create-element/CreateElementModal.tsx
+++ b/libs/frontend/domain/element/src/use-cases/element/create-element/CreateElementModal.tsx
@@ -110,6 +110,7 @@ export const CreateElementModal = observer<CreateElementModalProps>(
                 allElementOptions={selectParentElementOptions}
               />
             )}
+            help={`only elements from \`${activeElementTree.name}\` are visible in this list`}
             name="parentElementId"
           />
           <SelectLinkElement

--- a/libs/frontend/domain/element/src/use-cases/element/create-element/CreateElementModal.tsx
+++ b/libs/frontend/domain/element/src/use-cases/element/create-element/CreateElementModal.tsx
@@ -24,7 +24,7 @@ import { mapElementOption } from '../../../utils'
 import { createElementSchema } from './createElementSchema'
 
 interface CreateElementModalProps {
-  pageTree: IElementTree
+  activeElementTree: IElementTree
   renderService: IRenderService
   actionService: IActionService
   builderService: IBuilderService
@@ -35,13 +35,7 @@ interface CreateElementModalProps {
 }
 
 export const CreateElementModal = observer<CreateElementModalProps>(
-  ({
-    elementService,
-    builderService,
-    userService,
-    pageTree,
-    renderService,
-  }) => {
+  ({ elementService, userService, activeElementTree }) => {
     const onSubmit = async (data: ICreateElementDTO) => {
       const { prevSiblingId } = data
 
@@ -50,17 +44,7 @@ export const CreateElementModal = observer<CreateElementModalProps>(
         : elementService.createElementAsFirstChild(data))
 
       // Build tree for page
-      pageTree.addElements([element])
-
-      // Get the component tree for the current element, so we can update the component tree
-      const componentId = builderService.activeComponent?.id
-
-      if (componentId) {
-        const componentTree =
-          renderService.renderers.get(componentId)?.pageTree?.current
-
-        componentTree?.addElements([element])
-      }
+      activeElementTree.addElements([element])
 
       return Promise.resolve([element])
     }
@@ -86,10 +70,10 @@ export const CreateElementModal = observer<CreateElementModalProps>(
     const closeModal = () => elementService.createModal.close()
 
     const selectParentElementOptions =
-      pageTree.elementsList.map(mapElementOption)
+      activeElementTree.elementsList.map(mapElementOption)
 
     const selectChildrenElementOptions =
-      pageTree.elementsList.map(mapElementOption)
+      activeElementTree.elementsList.map(mapElementOption)
 
     return (
       <ModalForm.Modal

--- a/libs/frontend/domain/element/src/use-cases/element/create-element/CreateElementModal.tsx
+++ b/libs/frontend/domain/element/src/use-cases/element/create-element/CreateElementModal.tsx
@@ -4,7 +4,6 @@ import type {
   IComponentService,
   ICreateElementDTO,
   IElementService,
-  IElementTree,
   IRenderService,
   IUserService,
 } from '@codelab/frontend/abstract/core'
@@ -24,7 +23,6 @@ import { mapElementOption } from '../../../utils'
 import { createElementSchema } from './createElementSchema'
 
 interface CreateElementModalProps {
-  activeElementTree: IElementTree
   renderService: IRenderService
   actionService: IActionService
   builderService: IBuilderService
@@ -35,7 +33,13 @@ interface CreateElementModalProps {
 }
 
 export const CreateElementModal = observer<CreateElementModalProps>(
-  ({ elementService, userService, activeElementTree }) => {
+  ({ elementService, userService }) => {
+    const { parentElement, elementTree } = elementService.createModal
+
+    if (!parentElement || !elementTree) {
+      return null
+    }
+
     const onSubmit = async (data: ICreateElementDTO) => {
       const { prevSiblingId } = data
 
@@ -44,7 +48,7 @@ export const CreateElementModal = observer<CreateElementModalProps>(
         : elementService.createElementAsFirstChild(data))
 
       // Build tree for page
-      activeElementTree.addElements([element])
+      elementTree.addElements([element])
 
       return Promise.resolve([element])
     }
@@ -53,11 +57,7 @@ export const CreateElementModal = observer<CreateElementModalProps>(
       title: 'Error while creating element',
     })
 
-    const parentElement = elementService.createModal.parentElement
-
-    if (!parentElement) {
-      return null
-    }
+    const closeModal = () => elementService.createModal.close()
 
     const model = {
       parentElementId: parentElement.id,
@@ -67,13 +67,11 @@ export const CreateElementModal = observer<CreateElementModalProps>(
       renderType: null,
     }
 
-    const closeModal = () => elementService.createModal.close()
-
     const selectParentElementOptions =
-      activeElementTree.elementsList.map(mapElementOption)
+      elementTree.elementsList.map(mapElementOption)
 
     const selectChildrenElementOptions =
-      activeElementTree.elementsList.map(mapElementOption)
+      elementTree.elementsList.map(mapElementOption)
 
     return (
       <ModalForm.Modal
@@ -110,7 +108,7 @@ export const CreateElementModal = observer<CreateElementModalProps>(
                 allElementOptions={selectParentElementOptions}
               />
             )}
-            help={`only elements from \`${activeElementTree.name}\` are visible in this list`}
+            help={`only elements from \`${elementTree.name}\` are visible in this list`}
             name="parentElementId"
           />
           <SelectLinkElement


### PR DESCRIPTION
## Description

This PR implements the following:

1. Adds `+` button for each component.
2. changes the style of create element and create component buttons by adding a descriptive text to it.
3. limits the parent element options to the scope of the create element button
4. if selected builder tree node is outside the scope of the element modal the root element of the element tree will be used as the parent element.

## Video or Image

https://user-images.githubusercontent.com/51242349/221829889-ca87a6b3-efaf-4369-b1f4-7bd9c5475a38.mp4

## Related Issue(s)

Fixes #2308 
Fixes #2256
