### PR TITLE
fix: forbidden errors in e2e tests

### DIFF
--- a/apps/builder-e2e/src/e2e/admin/admin.cy.ts
+++ b/apps/builder-e2e/src/e2e/admin/admin.cy.ts
@@ -5,9 +5,6 @@ describe('Admin', () => {
   before(() => {
     cy.resetDatabase()
     loginSession()
-    // Visit so we can trigger upsert user
-    cy.visit('/apps')
-    cy.getSpinner().should('not.exist')
   })
 
   /**
@@ -50,9 +47,6 @@ describe('Admin', () => {
       cy.logout()
       cy.resetDatabase()
       loginSession()
-      // Visit so we can trigger upsert user
-      cy.visit('/apps')
-      cy.getSpinner().should('not.exist')
       importData()
 
       return exportAndAssert(createSeedDataPath(2)).then((payload) => {

--- a/apps/builder-e2e/src/e2e/apps.cy.ts
+++ b/apps/builder-e2e/src/e2e/apps.cy.ts
@@ -5,8 +5,6 @@ describe('Apps CRUD', () => {
   before(() => {
     cy.resetDatabase()
     loginSession()
-    cy.visit('/apps')
-    cy.getSpinner().should('not.exist')
   })
 
   describe('create', () => {

--- a/apps/builder-e2e/src/e2e/providers-page.cy.ts
+++ b/apps/builder-e2e/src/e2e/providers-page.cy.ts
@@ -45,9 +45,6 @@ describe('_app page', () => {
   before(() => {
     cy.resetDatabase()
     loginSession()
-    cy.visit('/apps')
-    cy.getSpinner().should('not.exist')
-
     seedData()
   })
 

--- a/apps/builder-e2e/src/support/nextjs-auth0/commands/login.ts
+++ b/apps/builder-e2e/src/support/nextjs-auth0/commands/login.ts
@@ -63,7 +63,6 @@ export const login = ({
       })
     })
   } catch (error) {
-    console.error(error)
     // throw new Error(error);
   }
 }

--- a/apps/builder-e2e/src/support/nextjs-auth0/commands/login.ts
+++ b/apps/builder-e2e/src/support/nextjs-auth0/commands/login.ts
@@ -11,10 +11,19 @@ export const loginSession = () => {
     ['auth0-session'],
     () => {
       login()
+      // Needs to visit the page where the user data will get upserted
+      // so that there will be no forbidden errors when doing mutations
+      // because the roles are needed
+      cy.visit('/apps')
+      cy.getSpinner().should('not.exist')
+      cy.intercept('GET', '/api/upsert-user').as('upsertUser')
+      cy.wait('@upsertUser')
     },
     {
       cacheAcrossSpecs: true,
-      // validate: () => {},
+      validate: () => {
+        cy.get('@upsertUser.all').should('not.have.length', 0)
+      },
     },
   )
 }
@@ -54,6 +63,7 @@ export const login = ({
       })
     })
   } catch (error) {
+    console.error(error)
     // throw new Error(error);
   }
 }


### PR DESCRIPTION
<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(libs-ui-component): must begin with lowercase` -->

## Description

<!-- This is a short description on the Pull Request -->
It seems that the user data needs to be upserted first before calling the mutations for seeding the data for testing.

I updated the [loginSession](https://github.com/codelab-app/platform/pull/2320/files#diff-36371f76c76798c489abdf2ec5b8891c261a5ab11d4ca2f756bc6e685d2e62a2R17) so that it visits the page where the [upsert of user data will happen](https://github.com/codelab-app/platform/blob/master/apps/builder/pages/apps/index.tsx#L62) before proceeding with the mutations.

## Video or Image

<!-- Add video or image showing how the new feature works -->

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged -->

Fixes #2319 
