### PR TITLE
refactor: remove "getServerSideProps" and revert system page names

### DIFF
--- a/apps/builder-e2e/src/support/database/page.ts
+++ b/apps/builder-e2e/src/support/database/page.ts
@@ -1,7 +1,4 @@
-import {
-  DEFAULT_GET_SERVER_SIDE_PROPS,
-  ROOT_ELEMENT_NAME,
-} from '@codelab/frontend/abstract/core'
+import { ROOT_ELEMENT_NAME } from '@codelab/frontend/abstract/core'
 import type { PageCreateInput } from '@codelab/shared/abstract/codegen'
 import { IPageKind } from '@codelab/shared/abstract/core'
 import { createUniqueName } from '@codelab/shared/utils'
@@ -22,7 +19,6 @@ export const createPageInput = (
       app: {
         connect: { where: { node: { id: appId } } },
       },
-      getServerSideProps: DEFAULT_GET_SERVER_SIDE_PROPS,
       id: pageId,
       kind: IPageKind.Regular,
       pageContentContainer: {

--- a/apps/builder/pages/apps/[appId]/pages/[pageId]/index.tsx
+++ b/apps/builder/pages/apps/[appId]/pages/[pageId]/index.tsx
@@ -1,7 +1,7 @@
 import type { IPageProps } from '@codelab/frontend/abstract/core'
 import { RendererType } from '@codelab/frontend/abstract/core'
 import type { CodelabPage } from '@codelab/frontend/abstract/types'
-import { Page, PageDetailHeader } from '@codelab/frontend/domain/page'
+import { PageDetailHeader } from '@codelab/frontend/domain/page'
 import { Renderer } from '@codelab/frontend/domain/renderer'
 import {
   useCurrentAppId,
@@ -15,49 +15,43 @@ import { auth0Instance } from '@codelab/shared/adapter/auth0'
 import { Alert, Spin } from 'antd'
 import { observer } from 'mobx-react-lite'
 import Head from 'next/head'
-import React, { useEffect } from 'react'
+import React from 'react'
 
-const PageRenderer: CodelabPage<IPageProps> = observer(
-  ({ getServerSidePropsData }) => {
-    const { appRenderService } = useStore()
-    const appId = useCurrentAppId()
-    const pageId = useCurrentPageId()
+const PageRenderer: CodelabPage<IPageProps> = observer(() => {
+  const { appRenderService } = useStore()
+  const appId = useCurrentAppId()
+  const pageId = useCurrentPageId()
 
-    const { value, error, loading } = useRenderedPage({
-      appId,
-      pageId,
-      rendererType: RendererType.Preview,
-      renderService: appRenderService,
-    })
+  const { value, error, loading } = useRenderedPage({
+    appId,
+    pageId,
+    rendererType: RendererType.Preview,
+    renderService: appRenderService,
+  })
 
-    useEffect(() => {
-      if (value?.appStore && getServerSidePropsData) {
-        value.appStore.state.setMany(getServerSidePropsData)
-      }
-    }, [loading])
+  // useEffect(() => {
+  //   if (value?.appStore && getServerSidePropsData) {
+  //     value.appStore.state.setMany(getServerSidePropsData)
+  //   }
+  // }, [loading])
 
-    return (
-      <>
-        <Head>
-          <title>{value?.page.name}</title>
-        </Head>
-        {error && <Alert message={extractErrorMessage(error)} type="error" />}
-        {loading && <Spin />}
-        {!loading && value?.elementTree && (
-          <Renderer
-            renderRoot={value.renderer.renderRoot.bind(value.renderer)}
-          />
-        )}
-      </>
-    )
-  },
-)
+  return (
+    <>
+      <Head>
+        <title>{value?.page.name}</title>
+      </Head>
+      {error && <Alert message={extractErrorMessage(error)} type="error" />}
+      {loading && <Spin />}
+      {!loading && value?.elementTree && (
+        <Renderer renderRoot={value.renderer.renderRoot.bind(value.renderer)} />
+      )}
+    </>
+  )
+})
 
 export default PageRenderer
 
-export const getServerSideProps = auth0Instance.withPageAuthRequired({
-  getServerSideProps: Page.getServerSideProps,
-})
+export const getServerSideProps = auth0Instance.withPageAuthRequired()
 
 PageRenderer.Layout = observer((page) => {
   const { pageService } = useStore()

--- a/libs/backend/infra/adapter/neo4j/src/schema/model/page.schema.ts
+++ b/libs/backend/infra/adapter/neo4j/src/schema/model/page.schema.ts
@@ -18,7 +18,7 @@ export const pageSchema = gql`
     rootElement: Element!
       @relationship(type: "ROOT_PAGE_ELEMENT", direction: OUT)
     app: App! @relationship(type: "PAGES", direction: IN)
-    getServerSideProps: String
+    #getServerSideProps: String
     # this is an element on _app page tree inside of which child pages content is rendered
     # default is root "Body" element, but can be changed using dropdown on Page Inspector tab
     pageContentContainer: Element

--- a/libs/frontend/abstract/core/src/constant.ts
+++ b/libs/frontend/abstract/core/src/constant.ts
@@ -39,10 +39,10 @@ export const NOT_FOUND_PAGE_NAME = '404'
 
 export const INTERNAL_SERVER_ERROR_PAGE_NAME = '500'
 
-export const DEFAULT_GET_SERVER_SIDE_PROPS = `async function (context) {
-  return {
-    props: {},
-    redirect: undefined,
-    notFound: false,
-  }
-}`
+// export const DEFAULT_GET_SERVER_SIDE_PROPS = `async function (context) {
+//     return {
+//       props: {},
+//       redirect: undefined,
+//       notFound: false,
+//     }
+//   }`

--- a/libs/frontend/abstract/core/src/domain/page/page.dto.interface.ts
+++ b/libs/frontend/abstract/core/src/domain/page/page.dto.interface.ts
@@ -9,17 +9,14 @@ export interface IPageDTO {
   app: IEntity
   rootElement: IEntity
   descendentElements?: Array<IEntity>
-  getServerSideProps?: Nullish<string>
+  // getServerSideProps?: Nullish<string>
   // The container element of the page
   pageContentContainer?: Nullish<IEntity>
 }
 
-export type ICreatePageData = Pick<
-  IPageDTO,
-  'id' | 'name' | 'app' | 'getServerSideProps'
->
+export type ICreatePageData = Pick<IPageDTO, 'id' | 'name' | 'app'>
 
 export type IUpdatePageData = Pick<
   IPageDTO,
-  'id' | 'getServerSideProps' | 'name' | 'pageContentContainer' | 'app'
+  'id' | 'name' | 'pageContentContainer' | 'app'
 >

--- a/libs/frontend/abstract/core/src/domain/page/page.fragment.graphql
+++ b/libs/frontend/abstract/core/src/domain/page/page.fragment.graphql
@@ -2,7 +2,6 @@ fragment Page on Page {
   id
   name
   slug
-  getServerSideProps
   app {
     id
   }
@@ -22,7 +21,6 @@ fragment BuilderPage on Page {
   id
   name
   slug
-  getServerSideProps
   rootElement {
     ...Element
     descendantElements {

--- a/libs/frontend/abstract/core/src/domain/page/page.fragment.graphql.gen.ts
+++ b/libs/frontend/abstract/core/src/domain/page/page.fragment.graphql.gen.ts
@@ -11,7 +11,6 @@ export type PageFragment = {
   id: string
   name: string
   slug: string
-  getServerSideProps?: string | null
   kind: Types.PageKind
   app: { id: string }
   rootElement: { descendantElements: Array<ElementFragment> } & ElementFragment
@@ -22,7 +21,6 @@ export type BuilderPageFragment = {
   id: string
   name: string
   slug: string
-  getServerSideProps?: string | null
   kind: Types.PageKind
   rootElement: { descendantElements: Array<ElementFragment> } & ElementFragment
   app: { id: string; owner: OwnerFragment }
@@ -34,7 +32,6 @@ export const PageFragmentDoc = gql`
     id
     name
     slug
-    getServerSideProps
     app {
       id
     }
@@ -56,7 +53,6 @@ export const BuilderPageFragmentDoc = gql`
     id
     name
     slug
-    getServerSideProps
     rootElement {
       ...Element
       descendantElements {

--- a/libs/frontend/abstract/core/src/domain/page/page.model.interface.ts
+++ b/libs/frontend/abstract/core/src/domain/page/page.model.interface.ts
@@ -19,7 +19,7 @@ export interface IPage
   descendentElements: Array<Ref<IElement>>
   // Helper getter to get all elements
   elements: Array<IElement>
-  getServerSideProps: Nullish<string>
+  // getServerSideProps: Nullish<string>
   /**
    * A pointer to tell us where to render from app
    */

--- a/libs/frontend/abstract/core/src/ui/nextjs.interface.ts
+++ b/libs/frontend/abstract/core/src/ui/nextjs.interface.ts
@@ -1,7 +1,6 @@
 import type { Auth0SessionUser } from '@codelab/shared/abstract/core'
 import type { AppProps } from 'next/app'
 import type { Overwrite } from 'utility-types'
-import type { IPropData } from '../domain'
 
 /**
  * Used by `_app.tsx`
@@ -20,7 +19,7 @@ export interface IPageProps {
   // storeSnapshot?: SnapshotOutOfModel<any>
   user?: Auth0SessionUser
   // data returned by user after running code inside getServerSideProps
-  getServerSidePropsData?: IPropData
+  // getServerSidePropsData?: IPropData
   // snapshot?: {
   // rootStore: SnapshotOutOfModel<any>
   // appService: SnapshotOutOfModel<any>

--- a/libs/frontend/domain/builder/src/sections/content/BuilderTabs.tsx
+++ b/libs/frontend/domain/builder/src/sections/content/BuilderTabs.tsx
@@ -24,6 +24,17 @@ export const BuilderTabs = observer<BuilderTabsProps>(
     const elementTree = page?.elementTree
     const appStore = app?.store.current
 
+    const tabItems = [
+      {
+        key: RendererTab.Page,
+        label: 'Page',
+      },
+      {
+        key: RendererTab.Component,
+        label: 'Component',
+      },
+    ]
+
     return (
       <Layout style={{ height: '100%' }}>
         {error && <Alert message={extractErrorMessage(error)} type="error" />}
@@ -31,12 +42,10 @@ export const BuilderTabs = observer<BuilderTabsProps>(
           <Tabs
             activeKey={builderService.activeTree}
             defaultActiveKey={RendererTab.Page}
+            items={tabItems}
             onChange={(key) => console.log(key)}
             type="card"
-          >
-            <Tabs.TabPane key={RendererTab.Page} tab="Page" />
-            <Tabs.TabPane key={RendererTab.Component} tab="Component" />
-          </Tabs>
+          />
         </Header>
         {isLoading && <Spin />}
         <Content>

--- a/libs/frontend/domain/page/src/services/page.factory.ts
+++ b/libs/frontend/domain/page/src/services/page.factory.ts
@@ -1,7 +1,10 @@
 import type { IApp, IPage, IPageFactory } from '@codelab/frontend/abstract/core'
 import {
+  APP_PAGE_NAME,
   DEFAULT_GET_SERVER_SIDE_PROPS,
   getElementService,
+  INTERNAL_SERVER_ERROR_PAGE_NAME,
+  NOT_FOUND_PAGE_NAME,
   ROOT_ELEMENT_NAME,
 } from '@codelab/frontend/abstract/core'
 import { getPropService } from '@codelab/frontend/domain/prop'
@@ -42,6 +45,7 @@ export class PageFactory extends Model({}) implements IPageFactory {
     return this.addDefaultPage({
       app,
       kind: IPageKind.Provider,
+      name: APP_PAGE_NAME,
     })
   }
 
@@ -50,6 +54,7 @@ export class PageFactory extends Model({}) implements IPageFactory {
     return this.addDefaultPage({
       app,
       kind: IPageKind.NotFound,
+      name: NOT_FOUND_PAGE_NAME,
     })
   }
 
@@ -58,11 +63,16 @@ export class PageFactory extends Model({}) implements IPageFactory {
     return this.addDefaultPage({
       app,
       kind: IPageKind.InternalServerError,
+      name: INTERNAL_SERVER_ERROR_PAGE_NAME,
     })
   }
 
   @modelAction
-  private addDefaultPage({ kind, app }: Pick<IPage, 'app' | 'kind'>) {
+  private addDefaultPage({
+    kind,
+    app,
+    name,
+  }: Pick<IPage, 'app' | 'kind' | 'name'>) {
     const rootElementProps = this.propService.add({
       id: v4(),
     })
@@ -78,7 +88,7 @@ export class PageFactory extends Model({}) implements IPageFactory {
       getServerSideProps: DEFAULT_GET_SERVER_SIDE_PROPS,
       id: v4(),
       kind,
-      name: kind,
+      name,
       rootElement,
     })
   }

--- a/libs/frontend/domain/page/src/services/page.factory.ts
+++ b/libs/frontend/domain/page/src/services/page.factory.ts
@@ -1,7 +1,6 @@
 import type { IApp, IPage, IPageFactory } from '@codelab/frontend/abstract/core'
 import {
   APP_PAGE_NAME,
-  DEFAULT_GET_SERVER_SIDE_PROPS,
   getElementService,
   INTERNAL_SERVER_ERROR_PAGE_NAME,
   NOT_FOUND_PAGE_NAME,
@@ -85,7 +84,6 @@ export class PageFactory extends Model({}) implements IPageFactory {
 
     return this.pageService.add({
       app,
-      getServerSideProps: DEFAULT_GET_SERVER_SIDE_PROPS,
       id: v4(),
       kind,
       name,

--- a/libs/frontend/domain/page/src/store/page.model.ts
+++ b/libs/frontend/domain/page/src/store/page.model.ts
@@ -1,20 +1,14 @@
-import type {
-  IElement,
-  IPage,
-  IPageDTO,
-  IPropData,
-} from '@codelab/frontend/abstract/core'
+import type { IElement, IPage, IPageDTO } from '@codelab/frontend/abstract/core'
 import { elementRef } from '@codelab/frontend/abstract/core'
 import { ElementTreeService } from '@codelab/frontend/domain/element'
 import type { PageCreateInput } from '@codelab/shared/abstract/codegen'
 import type { IPageKind } from '@codelab/shared/abstract/core'
-import type { IEntity, Maybe, Nullish } from '@codelab/shared/abstract/types'
+import type { IEntity, Maybe } from '@codelab/shared/abstract/types'
 import { createUniqueName } from '@codelab/shared/utils'
 import { computed } from 'mobx'
 import type { Ref } from 'mobx-keystone'
 import { ExtendedModel, idProp, model, modelAction, prop } from 'mobx-keystone'
 import slugify from 'voca/slugify'
-import { pageApi } from './page.api'
 
 const create = ({
   id,
@@ -22,7 +16,6 @@ const create = ({
   app,
   kind,
   rootElement,
-  getServerSideProps,
   pageContentContainer,
   descendentElements,
 }: IPageDTO): IPage => {
@@ -31,7 +24,6 @@ const create = ({
     descendentElements: descendentElements?.map((element) =>
       elementRef(element.id),
     ),
-    getServerSideProps,
     id,
     kind,
     name,
@@ -42,31 +34,31 @@ const create = ({
   })
 }
 
-const getPageServerSideProps = async (context: IPropData) => {
-  const id = context.params?.pageId as string
+// const getPageServerSideProps = async (context: IPropData) => {
+//   const id = context.params?.pageId as string
 
-  const {
-    pages: [page],
-  } = await pageApi.GetPages({ where: { id } })
+//   const {
+//     pages: [page],
+//   } = await pageApi.GetPages({ where: { id } })
 
-  if (!page || !page.getServerSideProps) {
-    return { props: {} }
-  }
+//   if (!page || !page.getServerSideProps) {
+//     return { props: {} }
+//   }
 
-  const {
-    props = {},
-    notFound = false,
-    redirect = undefined,
-  } = await eval(`(${page.getServerSideProps})`)(context)
+//   const {
+//     props = {},
+//     notFound = false,
+//     redirect = undefined,
+//   } = await eval(`(${page.getServerSideProps})`)(context)
 
-  return {
-    notFound,
-    props: {
-      getServerSidePropsData: props,
-    },
-    redirect,
-  }
-}
+//   return {
+//     notFound,
+//     props: {
+//       getServerSidePropsData: props,
+//     },
+//     redirect,
+//   }
+// }
 
 @model('@codelab/Page')
 export class Page
@@ -76,7 +68,7 @@ export class Page
      * Descendants of the rootElement, does not contain rootElement itself
      */
     descendentElements: prop<Array<Ref<IElement>>>(() => []),
-    getServerSideProps: prop<Nullish<string>>(),
+    // getServerSideProps: prop<Nullish<string>>(),
     id: idProp,
     kind: prop<IPageKind>(),
     name: prop<string>().withSetter(),
@@ -116,7 +108,6 @@ export class Page
   toCreateInput(): PageCreateInput {
     return {
       _compoundName: createUniqueName(this.name, this.app.id),
-      getServerSideProps: this.getServerSideProps,
       id: this.id,
       kind: this.kind,
       pageContentContainer: {
@@ -139,7 +130,6 @@ export class Page
     app,
     name,
     rootElement,
-    getServerSideProps,
     pageContentContainer,
     kind,
   }: Partial<IPageDTO>) {
@@ -148,9 +138,6 @@ export class Page
       ? elementRef(rootElement.id)
       : this.rootElement
     this.app = app ? app : this.app
-    this.getServerSideProps = getServerSideProps
-      ? getServerSideProps
-      : this.getServerSideProps
     this.pageContentContainer = pageContentContainer
       ? elementRef(pageContentContainer.id)
       : this.pageContentContainer
@@ -160,6 +147,4 @@ export class Page
   }
 
   static create = create
-
-  static getServerSideProps = getPageServerSideProps
 }

--- a/libs/frontend/domain/page/src/store/page.repository.ts
+++ b/libs/frontend/domain/page/src/store/page.repository.ts
@@ -11,7 +11,7 @@ export class PageRepository extends Model({}) implements IPageRepository {
   @modelFlow
   add = _async(function* (
     this: PageRepository,
-    { id, name, app, rootElement, getServerSideProps }: IPage,
+    { id, name, app, rootElement }: IPage,
   ) {
     const {
       createPages: { pages },
@@ -20,7 +20,6 @@ export class PageRepository extends Model({}) implements IPageRepository {
         input: {
           _compoundName: createUniqueName(name, app.id),
           app: connectNodeId(app.id),
-          getServerSideProps,
           id,
           kind: IPageKind.Regular,
           rootElement: {
@@ -38,7 +37,7 @@ export class PageRepository extends Model({}) implements IPageRepository {
   @modelFlow
   update = _async(function* (
     this: PageRepository,
-    { name, id, app, getServerSideProps, pageContentContainer }: IPage,
+    { name, id, app, pageContentContainer }: IPage,
   ) {
     const {
       updatePages: { pages },
@@ -47,7 +46,6 @@ export class PageRepository extends Model({}) implements IPageRepository {
         update: {
           _compoundName: createUniqueName(name, app.id),
           app: connectNodeId(app.id),
-          getServerSideProps,
           pageContentContainer: reconnectNodeId(pageContentContainer?.id),
         },
         where: { id },

--- a/libs/frontend/domain/page/src/store/page.service.ts
+++ b/libs/frontend/domain/page/src/store/page.service.ts
@@ -81,19 +81,12 @@ export class PageService
   @transaction
   update = _async(function* (
     this: PageService,
-    {
-      id,
-      name,
-      getServerSideProps,
-      app,
-      pageContentContainer,
-    }: IUpdatePageData,
+    { id, name, app, pageContentContainer }: IUpdatePageData,
   ) {
     const page = this.pages.get(id)!
 
     page.writeCache({
       app,
-      getServerSideProps,
       name,
       pageContentContainer,
     })
@@ -123,7 +116,7 @@ export class PageService
   @transaction
   create = _async(function* (
     this: PageService,
-    { id, name, app, getServerSideProps }: ICreatePageData,
+    { id, name, app }: ICreatePageData,
   ) {
     const rootElementProps = this.propService.add({
       data: '{}',
@@ -138,7 +131,6 @@ export class PageService
 
     const page = this.add({
       app,
-      getServerSideProps,
       id,
       kind: IPageKind.Regular,
       name,

--- a/libs/frontend/domain/page/src/use-cases/create-page/CreatePageModal.tsx
+++ b/libs/frontend/domain/page/src/use-cases/create-page/CreatePageModal.tsx
@@ -3,7 +3,6 @@ import type {
   IPageService,
   IUserService,
 } from '@codelab/frontend/abstract/core'
-import { DEFAULT_GET_SERVER_SIDE_PROPS } from '@codelab/frontend/abstract/core'
 import { useCurrentAppId } from '@codelab/frontend/presenter/container'
 import { createNotificationHandler } from '@codelab/frontend/shared/utils'
 import { ModalForm } from '@codelab/frontend/view/components'
@@ -22,7 +21,6 @@ export const CreatePageModal = observer<{
 
   const model = {
     app: { id: currentAppId },
-    getServerSideProps: DEFAULT_GET_SERVER_SIDE_PROPS,
     id: v4(),
     owner: {
       auth0Id: userService.auth0Id,

--- a/libs/frontend/domain/page/src/use-cases/create-page/create-page.schema.ts
+++ b/libs/frontend/domain/page/src/use-cases/create-page/create-page.schema.ts
@@ -1,13 +1,11 @@
 import type { ICreatePageData } from '@codelab/frontend/abstract/core'
 import {
-  CodeMirrorField,
   idSchema,
   nonEmptyString,
   ownerSchema,
   showFieldOnDev,
   titleCaseValidation,
 } from '@codelab/frontend/view/components'
-import { CodeMirrorLanguage } from '@codelab/shared/abstract/codegen'
 import type { JSONSchemaType } from 'ajv'
 
 export const createPageSchema: JSONSchemaType<ICreatePageData> = {
@@ -24,13 +22,6 @@ export const createPageSchema: JSONSchemaType<ICreatePageData> = {
       },
       required: ['id'],
       type: 'object',
-    },
-    getServerSideProps: {
-      nullable: true,
-      type: 'string',
-      uniforms: {
-        component: CodeMirrorField({ language: CodeMirrorLanguage.Typescript }),
-      },
     },
     name: {
       autoFocus: true,

--- a/libs/frontend/domain/page/src/use-cases/update-page-tab/UpdatePageTabForm.tsx
+++ b/libs/frontend/domain/page/src/use-cases/update-page-tab/UpdatePageTabForm.tsx
@@ -29,7 +29,6 @@ export const UpdatePageTabForm = observer<{ pageService: IPageService }>(
 
     const model = {
       appId: page.app.id,
-      getServerSideProps: page.getServerSideProps,
       name: page.name,
       pageContainerElementId: page.pageContentContainer?.id,
     }

--- a/libs/frontend/domain/page/src/use-cases/update-page-tab/update-page-tab.schema.ts
+++ b/libs/frontend/domain/page/src/use-cases/update-page-tab/update-page-tab.schema.ts
@@ -2,15 +2,8 @@ import type { IUpdatePageData } from '@codelab/frontend/abstract/core'
 import { getSelectElementComponent } from '@codelab/frontend/domain/type'
 // import { idSchema } from '@codelab/frontend/shared/domain'
 // import { showFieldOnDev } from '@codelab/frontend/shared/utils'
-import {
-  CodeMirrorField,
-  idSchema,
-  showFieldOnDev,
-} from '@codelab/frontend/view/components'
-import {
-  CodeMirrorLanguage,
-  ElementTypeKind,
-} from '@codelab/shared/abstract/codegen'
+import { idSchema, showFieldOnDev } from '@codelab/frontend/view/components'
+import { ElementTypeKind } from '@codelab/shared/abstract/codegen'
 import { IPageKind } from '@codelab/shared/abstract/core'
 import type { JSONSchemaType } from 'ajv'
 
@@ -29,15 +22,6 @@ export const schema = (kind: IPageKind): JSONSchemaType<IUpdatePageData> =>
         ...showFieldOnDev(),
         disabled: true,
         required: ['id'],
-      },
-      getServerSideProps: {
-        nullable: true,
-        type: 'string',
-        uniforms: {
-          component: CodeMirrorField({
-            language: CodeMirrorLanguage.Typescript,
-          }),
-        },
       },
       name: { disabled: kind !== IPageKind.Regular, type: 'string' },
       pageContentContainer: {

--- a/libs/frontend/domain/page/src/use-cases/update-page/UpdatePageModal.tsx
+++ b/libs/frontend/domain/page/src/use-cases/update-page/UpdatePageModal.tsx
@@ -22,7 +22,6 @@ export const UpdatePageModal = observer<{ pageService: IPageService }>(
 
     const model = {
       app: page?.app,
-      getServerSideProps: page?.getServerSideProps,
       id: page?.id,
       name: page?.name,
     }

--- a/libs/frontend/domain/page/src/use-cases/update-page/update-page.schema.ts
+++ b/libs/frontend/domain/page/src/use-cases/update-page/update-page.schema.ts
@@ -1,12 +1,10 @@
 import type { IUpdatePageData } from '@codelab/frontend/abstract/core'
 import {
-  CodeMirrorField,
   idSchema,
   nonEmptyString,
   showFieldOnDev,
   titleCaseValidation,
 } from '@codelab/frontend/view/components'
-import { CodeMirrorLanguage } from '@codelab/shared/abstract/codegen'
 import type { JSONSchemaType } from 'ajv'
 
 export type UpdatePageSchema = Omit<IUpdatePageData, 'pageContentContainer'>
@@ -24,13 +22,6 @@ export const updatePageSchema: JSONSchemaType<UpdatePageSchema> = {
       type: 'object',
       ...showFieldOnDev(),
       required: ['id'],
-    },
-    getServerSideProps: {
-      nullable: true,
-      type: 'string',
-      uniforms: {
-        component: CodeMirrorField({ language: CodeMirrorLanguage.Typescript }),
-      },
     },
     name: {
       autoFocus: true,

--- a/libs/shared/abstract/codegen/src/ogm-types.gen.ts
+++ b/libs/shared/abstract/codegen/src/ogm-types.gen.ts
@@ -2545,7 +2545,6 @@ export type AppPagePagesNodeAggregateSelection = {
   __typename?: 'AppPagePagesNodeAggregateSelection'
   id: IdAggregateSelectionNonNullable
   _compoundName: StringAggregateSelectionNonNullable
-  getServerSideProps: StringAggregateSelectionNullable
 }
 
 export type AppPagesConnection = {
@@ -4234,7 +4233,6 @@ export type ElementPagePageNodeAggregateSelection = {
   __typename?: 'ElementPagePageNodeAggregateSelection'
   id: IdAggregateSelectionNonNullable
   _compoundName: StringAggregateSelectionNonNullable
-  getServerSideProps: StringAggregateSelectionNullable
 }
 
 export type ElementPageRelationship = {
@@ -5223,7 +5221,6 @@ export type Page = {
   __typename?: 'Page'
   id: Scalars['ID']
   _compoundName: Scalars['String']
-  getServerSideProps?: Maybe<Scalars['String']>
   kind: PageKind
   name: Scalars['String']
   slug: Scalars['String']
@@ -5300,7 +5297,6 @@ export type PageAggregateSelection = {
   count: Scalars['Int']
   id: IdAggregateSelectionNonNullable
   _compoundName: StringAggregateSelectionNonNullable
-  getServerSideProps: StringAggregateSelectionNullable
 }
 
 export type PageAppAppAggregationSelection = {
@@ -9637,61 +9633,6 @@ export type AppPagesNodeAggregationWhereInput = {
   _compoundName_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars['Float']>
   _compoundName_LONGEST_LENGTH_LTE?: InputMaybe<Scalars['Int']>
   _compoundName_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars['Int']>
-  /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
-  getServerSideProps_EQUAL?: InputMaybe<Scalars['String']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  getServerSideProps_AVERAGE_EQUAL?: InputMaybe<Scalars['Float']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  getServerSideProps_LONGEST_EQUAL?: InputMaybe<Scalars['Int']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  getServerSideProps_SHORTEST_EQUAL?: InputMaybe<Scalars['Int']>
-  getServerSideProps_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars['Float']>
-  getServerSideProps_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars['Int']>
-  getServerSideProps_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars['Int']>
-  /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
-  getServerSideProps_GT?: InputMaybe<Scalars['Int']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  getServerSideProps_AVERAGE_GT?: InputMaybe<Scalars['Float']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  getServerSideProps_LONGEST_GT?: InputMaybe<Scalars['Int']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  getServerSideProps_SHORTEST_GT?: InputMaybe<Scalars['Int']>
-  getServerSideProps_AVERAGE_LENGTH_GT?: InputMaybe<Scalars['Float']>
-  getServerSideProps_LONGEST_LENGTH_GT?: InputMaybe<Scalars['Int']>
-  getServerSideProps_SHORTEST_LENGTH_GT?: InputMaybe<Scalars['Int']>
-  /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
-  getServerSideProps_GTE?: InputMaybe<Scalars['Int']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  getServerSideProps_AVERAGE_GTE?: InputMaybe<Scalars['Float']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  getServerSideProps_LONGEST_GTE?: InputMaybe<Scalars['Int']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  getServerSideProps_SHORTEST_GTE?: InputMaybe<Scalars['Int']>
-  getServerSideProps_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars['Float']>
-  getServerSideProps_LONGEST_LENGTH_GTE?: InputMaybe<Scalars['Int']>
-  getServerSideProps_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars['Int']>
-  /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
-  getServerSideProps_LT?: InputMaybe<Scalars['Int']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  getServerSideProps_AVERAGE_LT?: InputMaybe<Scalars['Float']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  getServerSideProps_LONGEST_LT?: InputMaybe<Scalars['Int']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  getServerSideProps_SHORTEST_LT?: InputMaybe<Scalars['Int']>
-  getServerSideProps_AVERAGE_LENGTH_LT?: InputMaybe<Scalars['Float']>
-  getServerSideProps_LONGEST_LENGTH_LT?: InputMaybe<Scalars['Int']>
-  getServerSideProps_SHORTEST_LENGTH_LT?: InputMaybe<Scalars['Int']>
-  /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
-  getServerSideProps_LTE?: InputMaybe<Scalars['Int']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  getServerSideProps_AVERAGE_LTE?: InputMaybe<Scalars['Float']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  getServerSideProps_LONGEST_LTE?: InputMaybe<Scalars['Int']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  getServerSideProps_SHORTEST_LTE?: InputMaybe<Scalars['Int']>
-  getServerSideProps_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars['Float']>
-  getServerSideProps_LONGEST_LENGTH_LTE?: InputMaybe<Scalars['Int']>
-  getServerSideProps_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars['Int']>
 }
 
 export type AppPagesUpdateConnectionInput = {
@@ -16321,61 +16262,6 @@ export type ElementPageNodeAggregationWhereInput = {
   _compoundName_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars['Float']>
   _compoundName_LONGEST_LENGTH_LTE?: InputMaybe<Scalars['Int']>
   _compoundName_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars['Int']>
-  /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
-  getServerSideProps_EQUAL?: InputMaybe<Scalars['String']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  getServerSideProps_AVERAGE_EQUAL?: InputMaybe<Scalars['Float']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  getServerSideProps_LONGEST_EQUAL?: InputMaybe<Scalars['Int']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  getServerSideProps_SHORTEST_EQUAL?: InputMaybe<Scalars['Int']>
-  getServerSideProps_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars['Float']>
-  getServerSideProps_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars['Int']>
-  getServerSideProps_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars['Int']>
-  /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
-  getServerSideProps_GT?: InputMaybe<Scalars['Int']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  getServerSideProps_AVERAGE_GT?: InputMaybe<Scalars['Float']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  getServerSideProps_LONGEST_GT?: InputMaybe<Scalars['Int']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  getServerSideProps_SHORTEST_GT?: InputMaybe<Scalars['Int']>
-  getServerSideProps_AVERAGE_LENGTH_GT?: InputMaybe<Scalars['Float']>
-  getServerSideProps_LONGEST_LENGTH_GT?: InputMaybe<Scalars['Int']>
-  getServerSideProps_SHORTEST_LENGTH_GT?: InputMaybe<Scalars['Int']>
-  /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
-  getServerSideProps_GTE?: InputMaybe<Scalars['Int']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  getServerSideProps_AVERAGE_GTE?: InputMaybe<Scalars['Float']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  getServerSideProps_LONGEST_GTE?: InputMaybe<Scalars['Int']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  getServerSideProps_SHORTEST_GTE?: InputMaybe<Scalars['Int']>
-  getServerSideProps_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars['Float']>
-  getServerSideProps_LONGEST_LENGTH_GTE?: InputMaybe<Scalars['Int']>
-  getServerSideProps_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars['Int']>
-  /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
-  getServerSideProps_LT?: InputMaybe<Scalars['Int']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  getServerSideProps_AVERAGE_LT?: InputMaybe<Scalars['Float']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  getServerSideProps_LONGEST_LT?: InputMaybe<Scalars['Int']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  getServerSideProps_SHORTEST_LT?: InputMaybe<Scalars['Int']>
-  getServerSideProps_AVERAGE_LENGTH_LT?: InputMaybe<Scalars['Float']>
-  getServerSideProps_LONGEST_LENGTH_LT?: InputMaybe<Scalars['Int']>
-  getServerSideProps_SHORTEST_LENGTH_LT?: InputMaybe<Scalars['Int']>
-  /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
-  getServerSideProps_LTE?: InputMaybe<Scalars['Int']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  getServerSideProps_AVERAGE_LTE?: InputMaybe<Scalars['Float']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  getServerSideProps_LONGEST_LTE?: InputMaybe<Scalars['Int']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  getServerSideProps_SHORTEST_LTE?: InputMaybe<Scalars['Int']>
-  getServerSideProps_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars['Float']>
-  getServerSideProps_LONGEST_LENGTH_LTE?: InputMaybe<Scalars['Int']>
-  getServerSideProps_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars['Int']>
 }
 
 export type ElementPageUpdateConnectionInput = {
@@ -22057,7 +21943,6 @@ export type PageConnectWhere = {
 export type PageCreateInput = {
   id: Scalars['ID']
   _compoundName: Scalars['String']
-  getServerSideProps?: InputMaybe<Scalars['String']>
   kind: PageKind
   rootElement?: InputMaybe<PageRootElementFieldInput>
   app?: InputMaybe<PageAppFieldInput>
@@ -22079,7 +21964,6 @@ export type PageDisconnectInput = {
 export type PageOnCreateInput = {
   id: Scalars['ID']
   _compoundName: Scalars['String']
-  getServerSideProps?: InputMaybe<Scalars['String']>
   kind: PageKind
 }
 
@@ -22926,7 +22810,6 @@ export type PageRootElementUpdateFieldInput = {
 export type PageSort = {
   id?: InputMaybe<SortDirection>
   _compoundName?: InputMaybe<SortDirection>
-  getServerSideProps?: InputMaybe<SortDirection>
   kind?: InputMaybe<SortDirection>
 }
 
@@ -23238,7 +23121,6 @@ export type PageUniqueWhere = {
 export type PageUpdateInput = {
   id?: InputMaybe<Scalars['ID']>
   _compoundName?: InputMaybe<Scalars['String']>
-  getServerSideProps?: InputMaybe<Scalars['String']>
   kind?: InputMaybe<PageKind>
   rootElement?: InputMaybe<PageRootElementUpdateFieldInput>
   app?: InputMaybe<PageAppUpdateFieldInput>
@@ -23281,22 +23163,6 @@ export type PageWhere = {
   _compoundName_NOT_STARTS_WITH?: InputMaybe<Scalars['String']>
   /** @deprecated Negation filters will be deprecated, use the NOT operator to achieve the same behavior */
   _compoundName_NOT_ENDS_WITH?: InputMaybe<Scalars['String']>
-  getServerSideProps?: InputMaybe<Scalars['String']>
-  /** @deprecated Negation filters will be deprecated, use the NOT operator to achieve the same behavior */
-  getServerSideProps_NOT?: InputMaybe<Scalars['String']>
-  getServerSideProps_IN?: InputMaybe<Array<InputMaybe<Scalars['String']>>>
-  /** @deprecated Negation filters will be deprecated, use the NOT operator to achieve the same behavior */
-  getServerSideProps_NOT_IN?: InputMaybe<Array<InputMaybe<Scalars['String']>>>
-  getServerSideProps_MATCHES?: InputMaybe<Scalars['String']>
-  getServerSideProps_CONTAINS?: InputMaybe<Scalars['String']>
-  getServerSideProps_STARTS_WITH?: InputMaybe<Scalars['String']>
-  getServerSideProps_ENDS_WITH?: InputMaybe<Scalars['String']>
-  /** @deprecated Negation filters will be deprecated, use the NOT operator to achieve the same behavior */
-  getServerSideProps_NOT_CONTAINS?: InputMaybe<Scalars['String']>
-  /** @deprecated Negation filters will be deprecated, use the NOT operator to achieve the same behavior */
-  getServerSideProps_NOT_STARTS_WITH?: InputMaybe<Scalars['String']>
-  /** @deprecated Negation filters will be deprecated, use the NOT operator to achieve the same behavior */
-  getServerSideProps_NOT_ENDS_WITH?: InputMaybe<Scalars['String']>
   kind?: InputMaybe<PageKind>
   /** @deprecated Negation filters will be deprecated, use the NOT operator to achieve the same behavior */
   kind_NOT?: InputMaybe<PageKind>
@@ -29383,7 +29249,6 @@ export interface PageAggregateSelectionInput {
   count?: boolean
   id?: IdAggregateInputNonNullable
   _compoundName?: StringAggregateInputNonNullable
-  getServerSideProps?: StringAggregateInputNullable
 }
 
 export declare class PageModel {

--- a/libs/shared/abstract/codegen/src/types.api.graphql.gen.ts
+++ b/libs/shared/abstract/codegen/src/types.api.graphql.gen.ts
@@ -2094,7 +2094,6 @@ export type AppPagePagesAggregationSelection = {
 export type AppPagePagesNodeAggregateSelection = {
   __typename?: 'AppPagePagesNodeAggregateSelection'
   _compoundName: StringAggregateSelectionNonNullable
-  getServerSideProps: StringAggregateSelectionNullable
   id: IdAggregateSelectionNonNullable
 }
 
@@ -2183,21 +2182,6 @@ export type AppPagesNodeAggregationWhereInput = {
   _compoundName_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars['Int']>
   _compoundName_SHORTEST_LENGTH_LT?: InputMaybe<Scalars['Int']>
   _compoundName_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars['Int']>
-  getServerSideProps_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars['Float']>
-  getServerSideProps_AVERAGE_LENGTH_GT?: InputMaybe<Scalars['Float']>
-  getServerSideProps_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars['Float']>
-  getServerSideProps_AVERAGE_LENGTH_LT?: InputMaybe<Scalars['Float']>
-  getServerSideProps_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars['Float']>
-  getServerSideProps_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars['Int']>
-  getServerSideProps_LONGEST_LENGTH_GT?: InputMaybe<Scalars['Int']>
-  getServerSideProps_LONGEST_LENGTH_GTE?: InputMaybe<Scalars['Int']>
-  getServerSideProps_LONGEST_LENGTH_LT?: InputMaybe<Scalars['Int']>
-  getServerSideProps_LONGEST_LENGTH_LTE?: InputMaybe<Scalars['Int']>
-  getServerSideProps_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars['Int']>
-  getServerSideProps_SHORTEST_LENGTH_GT?: InputMaybe<Scalars['Int']>
-  getServerSideProps_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars['Int']>
-  getServerSideProps_SHORTEST_LENGTH_LT?: InputMaybe<Scalars['Int']>
-  getServerSideProps_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars['Int']>
 }
 
 export type AppPagesRelationship = {
@@ -8054,21 +8038,6 @@ export type ElementPageNodeAggregationWhereInput = {
   _compoundName_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars['Int']>
   _compoundName_SHORTEST_LENGTH_LT?: InputMaybe<Scalars['Int']>
   _compoundName_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars['Int']>
-  getServerSideProps_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars['Float']>
-  getServerSideProps_AVERAGE_LENGTH_GT?: InputMaybe<Scalars['Float']>
-  getServerSideProps_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars['Float']>
-  getServerSideProps_AVERAGE_LENGTH_LT?: InputMaybe<Scalars['Float']>
-  getServerSideProps_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars['Float']>
-  getServerSideProps_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars['Int']>
-  getServerSideProps_LONGEST_LENGTH_GT?: InputMaybe<Scalars['Int']>
-  getServerSideProps_LONGEST_LENGTH_GTE?: InputMaybe<Scalars['Int']>
-  getServerSideProps_LONGEST_LENGTH_LT?: InputMaybe<Scalars['Int']>
-  getServerSideProps_LONGEST_LENGTH_LTE?: InputMaybe<Scalars['Int']>
-  getServerSideProps_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars['Int']>
-  getServerSideProps_SHORTEST_LENGTH_GT?: InputMaybe<Scalars['Int']>
-  getServerSideProps_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars['Int']>
-  getServerSideProps_SHORTEST_LENGTH_LT?: InputMaybe<Scalars['Int']>
-  getServerSideProps_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars['Int']>
 }
 
 export type ElementPagePageAggregationSelection = {
@@ -8080,7 +8049,6 @@ export type ElementPagePageAggregationSelection = {
 export type ElementPagePageNodeAggregateSelection = {
   __typename?: 'ElementPagePageNodeAggregateSelection'
   _compoundName: StringAggregateSelectionNonNullable
-  getServerSideProps: StringAggregateSelectionNullable
   id: IdAggregateSelectionNonNullable
 }
 
@@ -12882,7 +12850,6 @@ export type Page = {
   app: App
   appAggregate?: Maybe<PageAppAppAggregationSelection>
   appConnection: PageAppConnection
-  getServerSideProps?: Maybe<Scalars['String']>
   id: Scalars['ID']
   kind: PageKind
   name: Scalars['String']
@@ -12956,7 +12923,6 @@ export type PageAggregateSelection = {
   __typename?: 'PageAggregateSelection'
   _compoundName: StringAggregateSelectionNonNullable
   count: Scalars['Int']
-  getServerSideProps: StringAggregateSelectionNullable
   id: IdAggregateSelectionNonNullable
 }
 
@@ -13102,7 +13068,6 @@ export type PageConnectWhere = {
 export type PageCreateInput = {
   _compoundName: Scalars['String']
   app?: InputMaybe<PageAppFieldInput>
-  getServerSideProps?: InputMaybe<Scalars['String']>
   id: Scalars['ID']
   kind: PageKind
   pageContentContainer?: InputMaybe<PagePageContentContainerFieldInput>
@@ -13179,7 +13144,6 @@ export enum PageKind {
 
 export type PageOnCreateInput = {
   _compoundName: Scalars['String']
-  getServerSideProps?: InputMaybe<Scalars['String']>
   id: Scalars['ID']
   kind: PageKind
 }
@@ -13564,7 +13528,6 @@ export type PageRootElementUpdateFieldInput = {
 /** Fields to sort Pages by. The order in which sorts are applied is not guaranteed when specifying many fields in one PageSort object. */
 export type PageSort = {
   _compoundName?: InputMaybe<SortDirection>
-  getServerSideProps?: InputMaybe<SortDirection>
   id?: InputMaybe<SortDirection>
   kind?: InputMaybe<SortDirection>
 }
@@ -13797,7 +13760,6 @@ export type PageUniqueWhere = {
 export type PageUpdateInput = {
   _compoundName?: InputMaybe<Scalars['String']>
   app?: InputMaybe<PageAppUpdateFieldInput>
-  getServerSideProps?: InputMaybe<Scalars['String']>
   id?: InputMaybe<Scalars['ID']>
   kind?: InputMaybe<PageKind>
   pageContentContainer?: InputMaybe<PagePageContentContainerUpdateFieldInput>
@@ -13819,12 +13781,6 @@ export type PageWhere = {
   appConnection?: InputMaybe<PageAppConnectionWhere>
   appConnection_NOT?: InputMaybe<PageAppConnectionWhere>
   app_NOT?: InputMaybe<AppWhere>
-  getServerSideProps?: InputMaybe<Scalars['String']>
-  getServerSideProps_CONTAINS?: InputMaybe<Scalars['String']>
-  getServerSideProps_ENDS_WITH?: InputMaybe<Scalars['String']>
-  getServerSideProps_IN?: InputMaybe<Array<InputMaybe<Scalars['String']>>>
-  getServerSideProps_MATCHES?: InputMaybe<Scalars['String']>
-  getServerSideProps_STARTS_WITH?: InputMaybe<Scalars['String']>
   id?: InputMaybe<Scalars['ID']>
   id_CONTAINS?: InputMaybe<Scalars['ID']>
   id_ENDS_WITH?: InputMaybe<Scalars['ID']>
@@ -19959,7 +19915,6 @@ export type PageFragment = {
   id: string
   name: string
   slug: string
-  getServerSideProps?: string | null
   kind: PageKind
   app: { __typename?: 'App'; id: string }
   rootElement: {
@@ -19974,7 +19929,6 @@ export type BuilderPageFragment = {
   id: string
   name: string
   slug: string
-  getServerSideProps?: string | null
   kind: PageKind
   rootElement: {
     __typename?: 'Element'

--- a/schema.api.graphql
+++ b/schema.api.graphql
@@ -1996,7 +1996,6 @@ type AppPagePagesAggregationSelection {
 
 type AppPagePagesNodeAggregateSelection {
   _compoundName: StringAggregateSelectionNonNullable!
-  getServerSideProps: StringAggregateSelectionNullable!
   id: IDAggregateSelectionNonNullable!
 }
 
@@ -2087,21 +2086,6 @@ input AppPagesNodeAggregationWhereInput {
   _compoundName_SHORTEST_LENGTH_GTE: Int
   _compoundName_SHORTEST_LENGTH_LT: Int
   _compoundName_SHORTEST_LENGTH_LTE: Int
-  getServerSideProps_AVERAGE_LENGTH_EQUAL: Float
-  getServerSideProps_AVERAGE_LENGTH_GT: Float
-  getServerSideProps_AVERAGE_LENGTH_GTE: Float
-  getServerSideProps_AVERAGE_LENGTH_LT: Float
-  getServerSideProps_AVERAGE_LENGTH_LTE: Float
-  getServerSideProps_LONGEST_LENGTH_EQUAL: Int
-  getServerSideProps_LONGEST_LENGTH_GT: Int
-  getServerSideProps_LONGEST_LENGTH_GTE: Int
-  getServerSideProps_LONGEST_LENGTH_LT: Int
-  getServerSideProps_LONGEST_LENGTH_LTE: Int
-  getServerSideProps_SHORTEST_LENGTH_EQUAL: Int
-  getServerSideProps_SHORTEST_LENGTH_GT: Int
-  getServerSideProps_SHORTEST_LENGTH_GTE: Int
-  getServerSideProps_SHORTEST_LENGTH_LT: Int
-  getServerSideProps_SHORTEST_LENGTH_LTE: Int
 }
 
 type AppPagesRelationship {
@@ -7743,21 +7727,6 @@ input ElementPageNodeAggregationWhereInput {
   _compoundName_SHORTEST_LENGTH_GTE: Int
   _compoundName_SHORTEST_LENGTH_LT: Int
   _compoundName_SHORTEST_LENGTH_LTE: Int
-  getServerSideProps_AVERAGE_LENGTH_EQUAL: Float
-  getServerSideProps_AVERAGE_LENGTH_GT: Float
-  getServerSideProps_AVERAGE_LENGTH_GTE: Float
-  getServerSideProps_AVERAGE_LENGTH_LT: Float
-  getServerSideProps_AVERAGE_LENGTH_LTE: Float
-  getServerSideProps_LONGEST_LENGTH_EQUAL: Int
-  getServerSideProps_LONGEST_LENGTH_GT: Int
-  getServerSideProps_LONGEST_LENGTH_GTE: Int
-  getServerSideProps_LONGEST_LENGTH_LT: Int
-  getServerSideProps_LONGEST_LENGTH_LTE: Int
-  getServerSideProps_SHORTEST_LENGTH_EQUAL: Int
-  getServerSideProps_SHORTEST_LENGTH_GT: Int
-  getServerSideProps_SHORTEST_LENGTH_GTE: Int
-  getServerSideProps_SHORTEST_LENGTH_LT: Int
-  getServerSideProps_SHORTEST_LENGTH_LTE: Int
 }
 
 type ElementPagePageAggregationSelection {
@@ -7767,7 +7736,6 @@ type ElementPagePageAggregationSelection {
 
 type ElementPagePageNodeAggregateSelection {
   _compoundName: StringAggregateSelectionNonNullable!
-  getServerSideProps: StringAggregateSelectionNullable!
   id: IDAggregateSelectionNonNullable!
 }
 
@@ -12227,7 +12195,6 @@ type Page {
     sort: [PageAppConnectionSort!]
     where: PageAppConnectionWhere
   ): PageAppConnection!
-  getServerSideProps: String
   id: ID!
   kind: PageKind!
   name: String!
@@ -12269,7 +12236,6 @@ type Page {
 type PageAggregateSelection {
   _compoundName: StringAggregateSelectionNonNullable!
   count: Int!
-  getServerSideProps: StringAggregateSelectionNullable!
   id: IDAggregateSelectionNonNullable!
 }
 
@@ -12414,7 +12380,6 @@ input PageConnectWhere {
 input PageCreateInput {
   _compoundName: String!
   app: PageAppFieldInput
-  getServerSideProps: String
   id: ID!
   kind: PageKind!
   pageContentContainer: PagePageContentContainerFieldInput
@@ -12487,7 +12452,6 @@ enum PageKind {
 
 input PageOnCreateInput {
   _compoundName: String!
-  getServerSideProps: String
   id: ID!
   kind: PageKind!
 }
@@ -12879,7 +12843,6 @@ Fields to sort Pages by. The order in which sorts are applied is not guaranteed 
 """
 input PageSort {
   _compoundName: SortDirection
-  getServerSideProps: SortDirection
   id: SortDirection
   kind: SortDirection
 }
@@ -13100,7 +13063,6 @@ input PageUniqueWhere {
 input PageUpdateInput {
   _compoundName: String
   app: PageAppUpdateFieldInput
-  getServerSideProps: String
   id: ID
   kind: PageKind
   pageContentContainer: PagePageContentContainerUpdateFieldInput
@@ -13122,12 +13084,6 @@ input PageWhere {
   appConnection: PageAppConnectionWhere
   appConnection_NOT: PageAppConnectionWhere
   app_NOT: AppWhere
-  getServerSideProps: String
-  getServerSideProps_CONTAINS: String
-  getServerSideProps_ENDS_WITH: String
-  getServerSideProps_IN: [String]
-  getServerSideProps_MATCHES: String
-  getServerSideProps_STARTS_WITH: String
   id: ID
   id_CONTAINS: ID
   id_ENDS_WITH: ID


### PR DESCRIPTION
<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(libs-ui-component): must begin with lowercase` -->

## Description
- remove `getServerSideProps` from pages since in production we use Static Site Generation, which is completely serverless and no server props are supported
- return system pages names (from "Provider", "NotFound", "ServerError" to "_app", "404", "500")
- fix console error about deprecated `Tabs.Tabpane` usage

<!-- This is a short description on the Pull Request -->

## Video or Image

<!-- Add video or image showing how the new feature works -->

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged -->

Fixes #
