### PR TITLE
fix: element creation shows error and resets fields while processing

### DIFF
--- a/libs/frontend/abstract/core/src/domain/element/element.service.interface.ts
+++ b/libs/frontend/abstract/core/src/domain/element/element.service.interface.ts
@@ -20,6 +20,11 @@ import type { IElementTree } from './element-tree.interface.model'
  * Used for modal input
  */
 export interface CreateElementData {
+  elementOptions: Array<{
+    childrenIds?: Array<string>
+    label: string
+    value: string
+  }>
   elementTree: Ref<IElementTree>
   selectedElement?: Maybe<Ref<IElement>>
 }

--- a/libs/frontend/domain/builder/src/sections/explorer-pane/BuilderExplorerPane-Header.tsx
+++ b/libs/frontend/domain/builder/src/sections/explorer-pane/BuilderExplorerPane-Header.tsx
@@ -30,7 +30,7 @@ export const BuilderExplorerPaneHeader = observer(
     return (
       <CreateElementButton
         createModal={elementService.createModal}
-        elementTreeId={elementTree.id}
+        elementTree={elementTree}
         key={0}
         selectedElementId={builderService.selectedNode?.id}
         title="Element"

--- a/libs/frontend/domain/builder/src/sections/explorer-pane/ElementContextMenu.tsx
+++ b/libs/frontend/domain/builder/src/sections/explorer-pane/ElementContextMenu.tsx
@@ -9,7 +9,10 @@ import {
   isComponentInstance,
   RendererTab,
 } from '@codelab/frontend/abstract/core'
-import { elementTreeRef } from '@codelab/frontend/domain/element'
+import {
+  elementTreeRef,
+  mapElementOption,
+} from '@codelab/frontend/domain/element'
 import { useStore } from '@codelab/frontend/presenter/container'
 import { Key } from '@codelab/frontend/view/components'
 import { Menu } from 'antd'
@@ -55,6 +58,7 @@ export const ElementContextMenu = observer<ElementContextMenuProps>(
       }
 
       return createModal.open({
+        elementOptions: elementTree.elements.map(mapElementOption),
         elementTree: elementTreeRef(elementTree.id),
         selectedElement: elementRef(element.id),
       })

--- a/libs/frontend/domain/builder/src/sections/explorer-pane/builder-tree/BuilderTreeItem-ComponentTitle.tsx
+++ b/libs/frontend/domain/builder/src/sections/explorer-pane/builder-tree/BuilderTreeItem-ComponentTitle.tsx
@@ -31,7 +31,7 @@ export const BuilderTreeItemComponentTitle = observer(
         <Col css={tw`px-2`}>
           <CreateElementButton
             createModal={elementService.createModal}
-            elementTreeId={component.elementTree.id || ''}
+            elementTree={component.elementTree}
             key={0}
             selectedElementId={selectedNodeId || component.rootElement.id}
             type="text"

--- a/libs/frontend/domain/element/src/use-cases/element/create-element/CreateElementButton.tsx
+++ b/libs/frontend/domain/element/src/use-cases/element/create-element/CreateElementButton.tsx
@@ -1,20 +1,24 @@
 import { PlusOutlined } from '@ant-design/icons'
-import type { IElementService } from '@codelab/frontend/abstract/core'
+import type {
+  IElementService,
+  IElementTree,
+} from '@codelab/frontend/abstract/core'
 import { elementRef } from '@codelab/frontend/abstract/core'
 import type { Maybe } from '@codelab/shared/abstract/types'
 import { Button } from 'antd'
 import { observer } from 'mobx-react-lite'
 import React from 'react'
 import { elementTreeRef } from '../../../store'
+import { mapElementOption } from '../../../utils'
 
-export type CreateElementButtonProps = {
-  selectedElementId: Maybe<string>
-  elementTreeId: string
-} & Pick<IElementService, 'createModal'> &
-  React.ComponentProps<typeof Button>
+export type CreateElementButtonProps = Pick<IElementService, 'createModal'> &
+  React.ComponentProps<typeof Button> & {
+    selectedElementId: Maybe<string>
+    elementTree: IElementTree
+  }
 
 export const CreateElementButton = observer<CreateElementButtonProps>(
-  ({ selectedElementId, elementTreeId, createModal, type, title }) => {
+  ({ createModal, elementTree, selectedElementId, title, type }) => {
     const selectedElement = selectedElementId
       ? elementRef(selectedElementId)
       : undefined
@@ -27,7 +31,8 @@ export const CreateElementButton = observer<CreateElementButtonProps>(
           event.preventDefault()
 
           return createModal.open({
-            elementTree: elementTreeRef(elementTreeId),
+            elementOptions: elementTree.elements.map(mapElementOption),
+            elementTree: elementTreeRef(elementTree.id),
             selectedElement,
           })
         }}

--- a/libs/frontend/domain/element/src/use-cases/element/create-element/CreateElementModal.tsx
+++ b/libs/frontend/domain/element/src/use-cases/element/create-element/CreateElementModal.tsx
@@ -16,18 +16,18 @@ import { v4 } from 'uuid'
 import { AutoComputedElementNameField } from '../../../components/auto-computed-element-name'
 import RenderTypeCompositeField from '../../../components/RenderTypeCompositeField'
 import { SelectLinkElement } from '../../../components/SelectLinkElement'
-import { mapElementOption } from '../../../utils'
 import { createElementSchema } from './create-element.schema'
 
 interface CreateElementModalProps {
   elementService: IElementService
-  userService: IUserService
   storeId: string
+  userService: IUserService
 }
 
 export const CreateElementModal = observer<CreateElementModalProps>(
   ({ elementService, userService }) => {
-    const { parentElement, elementTree } = elementService.createModal
+    const { elementTree, metadata, parentElement } = elementService.createModal
+    const elementOptions = metadata?.elementOptions
 
     if (!parentElement || !elementTree) {
       return null
@@ -63,12 +63,6 @@ export const CreateElementModal = observer<CreateElementModalProps>(
       renderType: null,
     }
 
-    const selectParentElementOptions =
-      elementTree.elements.map(mapElementOption)
-
-    const selectChildrenElementOptions =
-      elementTree.elements.map(mapElementOption)
-
     return (
       <ModalForm.Modal
         okText="Create"
@@ -101,14 +95,14 @@ export const CreateElementModal = observer<CreateElementModalProps>(
               <SelectAnyElement
                 // eslint-disable-next-line react/jsx-props-no-spreading
                 {...props}
-                allElementOptions={selectParentElementOptions}
+                allElementOptions={elementOptions}
               />
             )}
             help={`only elements from \`${elementTree.name}\` are visible in this list`}
             name="parentElement.id"
           />
           <SelectLinkElement
-            allElementOptions={selectChildrenElementOptions}
+            allElementOptions={elementOptions}
             name="prevSibling.id"
             required={false}
           />


### PR DESCRIPTION
<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(libs-ui-component): must begin with lowercase` -->

## Description

<!-- This is a short description on the Pull Request -->
This fixes the issue where when creating an element, the form fields get reset while still processing and this is due to updating the cache first before the actual save and is causing the CreateElementModal to re-render because the [element options](https://github.com/codelab-app/platform/pull/2373/files#diff-1e051f74cebcc472394998ff540f6d5e0788a178f1b5d90e79abff5581e44887L67) got updated.

This PR is for supplying the create modal with the element options upon opening so that the options does not change while the modal is open.

## Video or Image

<!-- Add video or image showing how the new feature works -->

### Before

https://user-images.githubusercontent.com/27695022/225651739-0cce78e0-323b-4128-bee9-fa536d91ef3d.mp4


<br />

### After


https://user-images.githubusercontent.com/27695022/225651930-8c792def-717b-4d13-bab2-0ffc8d2cee7d.mp4



## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged -->

Fixes #
