### PR TITLE
Fix atomsTable infinite rendering loop

### DIFF
--- a/libs/frontend/domain/atom/src/use-cases/get-atoms/useAtomTable.tsx
+++ b/libs/frontend/domain/atom/src/use-cases/get-atoms/useAtomTable.tsx
@@ -15,7 +15,7 @@ import type {
 import debounce from 'lodash/debounce'
 import isEqual from 'lodash/isEqual'
 import { arraySet } from 'mobx-keystone'
-import React, { useCallback, useState } from 'react'
+import React, { useCallback, useMemo, useState } from 'react'
 import { ActionColumn, LibraryColumn, PropsColumn, TagsColumn } from './columns'
 import { AllowedChildrenColumn } from './columns/AllowedChildrenColumn'
 import type { AtomRecord } from './columns/types'
@@ -138,24 +138,27 @@ export const useAtomTable = ({
     type: 'checkbox',
   }
 
-  const pagination: TablePaginationConfig = {
-    defaultPageSize: 25,
-    onChange: async (page: number, pageSize: number) => {
-      const options = {
-        limit: pageSize,
-        offset: (page - 1) * pageSize,
-      }
-
-      if (!isEqual(options, atomOptions)) {
-        debouncedSetAtomOptions({
+  const pagination: TablePaginationConfig = useMemo(
+    () => ({
+      defaultPageSize: 25,
+      onChange: async (page: number, pageSize: number) => {
+        const options = {
           limit: pageSize,
           offset: (page - 1) * pageSize,
-        })
-      }
-    },
-    position: ['bottomCenter'],
-    total: atomService.count,
-  }
+        }
+
+        if (!isEqual(options, atomOptions)) {
+          debouncedSetAtomOptions({
+            limit: pageSize,
+            offset: (page - 1) * pageSize,
+          })
+        }
+      },
+      position: ['bottomCenter'],
+      total: atomService.count,
+    }),
+    [],
+  )
 
   return { atomOptions, atomWhere, columns, pagination, rowSelection }
 }


### PR DESCRIPTION
<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(libs-ui-component): must begin with lowercase` -->

## Description
this pr fixes an infinite loop in `atomsTable` that was caused by calling `getAllAtoms.execute()` which triggers re-rendering which in turns updates the `pagination` object that leads to firing `useEffect` and so on 

<!-- This is a short description on the Pull Request -->

## Video or Image

<!-- Add video or image showing how the new feature works -->

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged -->

Fixes #
