### PR TITLE
fix: components instance issues

### DIFF
--- a/libs/frontend/abstract/core/src/domain/builder/renderer.model.interface.ts
+++ b/libs/frontend/abstract/core/src/domain/builder/renderer.model.interface.ts
@@ -28,6 +28,7 @@ export interface IRenderer {
   logRendered(element: IElement, rendered: ArrayOrSingle<IRenderOutput>): void
   renderChildren(input: {
     parentOutput: IRenderOutput
+    extraProps?: IPropData
   }): ArrayOrSingle<ReactNode>
   renderElement(element: IElement, extraProps?: IPropData): ReactElement
   renderIntermediateElement(

--- a/libs/frontend/domain/builder/src/store/builder.service.ts
+++ b/libs/frontend/domain/builder/src/store/builder.service.ts
@@ -187,7 +187,16 @@ export class BuilderService
 
       return [...elementRefs.values()].reduce((prev, node) => {
         const component = findParent(node, (parent) => {
-          return (parent as AnyModel)[modelTypeKey] === '@codelab/Component'
+          // could be any model so we have to typecast here just for checking if it has `sourceComponent` field
+          // and we want to get the original component model without the `sourceComponent`
+          const parentModel = parent as AnyModel & {
+            sourceComponent?: IComponent['sourceComponent']
+          }
+
+          return (
+            parentModel[modelTypeKey] === '@codelab/Component' &&
+            !parentModel.sourceComponent
+          )
         })
 
         return component ? component : prev

--- a/libs/frontend/domain/component/src/store/component.service.ts
+++ b/libs/frontend/domain/component/src/store/component.service.ts
@@ -148,8 +148,6 @@ export class ComponentService
       rootElement,
     })
 
-    this.components.set(component.id, component)
-
     const newComponent = yield* _await(this.componentRepository.add(component))
 
     const { hydratedElements, rootElement: loadedRootElement } =
@@ -172,7 +170,7 @@ export class ComponentService
 
     yield* _await(this.componentRepository.update(component))
 
-    return component!
+    return component
   })
 
   @modelFlow

--- a/libs/frontend/domain/element/src/store/element.service.ts
+++ b/libs/frontend/domain/element/src/store/element.service.ts
@@ -2,6 +2,7 @@ import type {
   IAuth0Owner,
   ICreateElementData,
   IElement,
+  IElementDTO,
   IElementService,
   IUpdateElementData,
   RenderType,
@@ -9,7 +10,6 @@ import type {
 import {
   getBuilderService,
   getComponentService,
-  IElementDTO,
   IRenderTypeKind,
   isComponentInstance,
 } from '@codelab/frontend/abstract/core'
@@ -733,24 +733,6 @@ export class ElementService
       }),
     )
   })
-
-  @modelAction
-  writeClonesCache(elementFragment: IElementDTO) {
-    return [...this.clonedElements.values()]
-      .filter((element) => element.sourceElement?.id === elementFragment.id)
-      .map((element) =>
-        Element.create({
-          ...elementFragment,
-          // keep the cloned element's id
-          id: element.id,
-          parentComponent: element.parentComponent
-            ? ({
-                id: element.parentComponent.current.id,
-              } as IElementDTO['parentComponent'])
-            : undefined,
-        }),
-      )
-  }
 
   @modelAction
   removeClones(elementId: string) {

--- a/libs/frontend/domain/renderer/src/element/ElementWrapper.ts
+++ b/libs/frontend/domain/renderer/src/element/ElementWrapper.ts
@@ -72,7 +72,10 @@ export const ElementWrapper = observer<ElementWrapperProps>(
         element,
         mergeProps(renderOutput.props, store.state.values),
       )
-        ? renderService.renderChildren({ parentOutput: renderOutput })
+        ? renderService.renderChildren({
+            extraProps,
+            parentOutput: renderOutput,
+          })
         : undefined
 
       if (renderOutput.props) {


### PR DESCRIPTION
<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(libs-ui-component): must begin with lowercase` -->

## Description

<!-- This is a short description on the Pull Request -->
This PR fixes two issues:
1. When adding a component to the builder page then selecting the component node, it crashes because the wrong ref was being used (the clone instead of the original)
2. Changing the props in the component instance is not taking effect on the component descendant elements because the component instance props is not being passed down

## Video or Image

<!-- Add video or image showing how the new feature works -->

Tested selecting the component nodes and updating the component instance props

https://user-images.githubusercontent.com/27695022/226685940-92cc208b-05e9-4f75-a298-c86aeb0171b9.mp4



## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged -->

Fixes #
