### PR TITLE
fix: component.cy spec

### DIFF
--- a/libs/frontend/domain/component/src/store/component.service.ts
+++ b/libs/frontend/domain/component/src/store/component.service.ts
@@ -9,7 +9,6 @@ import {
   getElementService,
   IBuilderDataNode,
   IComponentDTO,
-  ROOT_ELEMENT_NAME,
 } from '@codelab/frontend/abstract/core'
 import { getPropService } from '@codelab/frontend/domain/prop'
 import { getTypeService, InterfaceType } from '@codelab/frontend/domain/type'
@@ -115,7 +114,8 @@ export class ComponentService
 
     const rootElement = this.elementService.add({
       ...createComponentData.rootElement,
-      name: ROOT_ELEMENT_NAME,
+      name: createComponentData.name,
+      parentComponent: { id: createComponentData.id },
       props,
     })
 


### PR DESCRIPTION
<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(libs-ui-component): must begin with lowercase` -->

## Description
- Root element was missing reference to a parent component when new component is created. This cause script error
- Invalid name was set to root component element, and e2e test failed ("Body" was set instead of the same name as component)
<!-- This is a short description on the Pull Request -->

## Video or Image

<!-- Add video or image showing how the new feature works -->

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged -->

Fixes #
