### PR TITLE
fix: cypher query to get only direct descendants (#2328)

### DIFF
--- a/libs/backend/infra/adapter/neo4j/src/cypher/element/getDescendants.cypher
+++ b/libs/backend/infra/adapter/neo4j/src/cypher/element/getDescendants.cypher
@@ -4,7 +4,7 @@ OPTIONAL MATCH (firstChild: Element)-[:TREE_FIRST_CHILD]->(rootElement)
 // For root Element, we get all descendants
 CALL apoc.path.subgraphAll(
   firstChild,
-  { relationshipFilter: '<TREE_FIRST_CHILD|<NODE_SIBLING|RENDER_COMPONENT_TYPE' }
+  { relationshipFilter: '<TREE_FIRST_CHILD|<NODE_SIBLING|RENDER_COMPONENT_TYPE>' }
 ) YIELD nodes AS descendants
 
 // Get isRoot by checking if parent exists


### PR DESCRIPTION
<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(libs-ui-component): must begin with lowercase` -->

## Description
When there are several pages exist in the application, for example like this:
<img width="424" alt="Screenshot 2023-03-24 at 10 18 29" src="https://user-images.githubusercontent.com/74900868/227481492-fd647c20-9f57-41ef-ae51-95b292acbb25.png">

And each of this pages has a component instance with descendants, like this:
Page 1             |  Page 2 | Page 3
:-------------------------:|:-------------------------:|:-------------------------:
<img width="339" alt="Screenshot 2023-03-24 at 10 18 58" src="https://user-images.githubusercontent.com/74900868/227481782-cc714ca0-5861-4211-9436-f8b10a7c7174.png">|<img width="337" alt="Screenshot 2023-03-24 at 10 19 13" src="https://user-images.githubusercontent.com/74900868/227481821-fb49ec39-3cf0-44df-84b8-bdf605bcaacb.png">|<img width="338" alt="Screenshot 2023-03-24 at 10 19 27" src="https://user-images.githubusercontent.com/74900868/227481846-16b05a96-4bc0-4074-ac50-748f274daa63.png">

Then when any of those pages is opened - the resolver for `descendantElements` returns all the elements from all the pages. In this example - it returns all 6 elements (3 component instances and 3 children of the component instances), instead of only 2 components (1 component instance and one child):

Before             |  After
:-------------------------:|:-------------------------:
<img width="916" alt="Screenshot 2023-03-24 at 10 23 37" src="https://user-images.githubusercontent.com/74900868/227482244-ad3b6e12-17f0-47b4-a233-6ef6308e57e6.png">|<img width="903" alt="Screenshot 2023-03-24 at 10 25 57" src="https://user-images.githubusercontent.com/74900868/227482291-be75f88f-b642-4f60-9f46-4911fe96aa02.png">


## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged -->

Fixes #2328 
