### PR TITLE
fix: bug in reconnectNodeIds

### DIFF
--- a/libs/shared/domain/mapper/src/orm/reconnect.ts
+++ b/libs/shared/domain/mapper/src/orm/reconnect.ts
@@ -14,8 +14,10 @@ export const reconnectNode = (key: string, id: string | null | undefined) => ({
   ...disconnectAll(),
 })
 
-export const reconnectNodeIds = (ids: Array<string> | undefined) =>
-  ids?.map((id) => ({
+export const reconnectNodeIds = (ids: Array<string> | undefined) => {
+  const connects = ids?.map((id) => ({
     ...connectNodeIds([id]),
-    ...disconnectManyAll(),
   }))
+
+  return [disconnectManyAll(), ...(connects ?? [])]
+}


### PR DESCRIPTION
<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(libs-ui-component): must begin with lowercase` -->

## Description
Fixes bug in `reconnectNodeIds`, which causes only one node to be connected.

<!-- This is a short description on the Pull Request -->

## Video or Image

<!-- Add video or image showing how the new feature works -->

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged -->

Fixes #2333
