### PR TITLE
fix: props are messed up when updating the element

### DIFF
--- a/libs/frontend/domain/element/src/store/element.model.ts
+++ b/libs/frontend/domain/element/src/store/element.model.ts
@@ -426,9 +426,6 @@ export class Element
       customCss: this.customCss,
       guiCss: this.guiCss,
       name: this.name,
-      props: {
-        update: { node: { data: JSON.stringify(this.props.current.data) } },
-      },
       renderAtomType,
       renderComponentType,
       renderForEachPropKey: this.renderForEachPropKey,

--- a/libs/frontend/domain/prop/src/store/prop.service.ts
+++ b/libs/frontend/domain/prop/src/store/prop.service.ts
@@ -35,13 +35,13 @@ export class PropService
   }
 
   @modelAction
-  add({ data, id }: IPropDTO) {
+  add({ api, data, id }: IPropDTO) {
     let props = this.prop(id)
 
     if (props) {
-      props.writeCache({ data })
+      props.writeCache({ api, data })
     } else {
-      props = Prop.create({ data, id })
+      props = Prop.create({ api, data, id })
       this.props.set(props.id, props)
     }
 
@@ -54,7 +54,7 @@ export class PropService
     this: PropService,
     { api, data, id }: ICreatePropData,
   ) {
-    const props = Prop.create({ api, data, id })
+    const props = this.add({ api, data, id })
 
     yield* _await(this.propRepository.add(props))
 


### PR DESCRIPTION
<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(libs-ui-component): must begin with lowercase` -->

## Description

<!-- This is a short description on the Pull Request -->
When an element is updated, its existing props gets messed up because the `props` are also included on the update input and it was incorrectly structured that its making the current props to be wrapped inside another `data` like
```
{
  "data": {
    "data": {
      "name":"Title",
      "required":false,
      "hidden":false,
      "colon":true,
      "label":"Title"
    }
  }
}
```

We actually dont need to include the props anymore when updating the element since we now update the props via `propService` when we update it on the props form or props inspector

## Video or Image

<!-- Add video or image showing how the new feature works -->

### Before

https://user-images.githubusercontent.com/27695022/228260937-58fb191c-eb8c-445b-94f0-9add6b35fd78.mp4

<br />

### After

https://user-images.githubusercontent.com/27695022/228261039-0f43b35e-63c0-4ecf-aea3-31dcb5862765.mp4



## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged -->

Fixes #
