### PR TITLE
refactor: some cleanups and attempt to fix crashes

### DIFF
--- a/libs/backend/infra/adapter/neo4j/src/selectionSet/actionSelectionSet.ts
+++ b/libs/backend/infra/adapter/neo4j/src/selectionSet/actionSelectionSet.ts
@@ -18,10 +18,12 @@ const edgeSelectionProperties = `
 
 export const apiActionSelectionSet = `
   ${baseActionSelectionSet}
-  successAction 
+  successAction {
     ${edgeSelectionProperties}
-  errorAction 
+  }
+  errorAction {
     ${edgeSelectionProperties}
+  }
   resource {
     id
   }
@@ -31,19 +33,19 @@ export const apiActionSelectionSet = `
   }
 `
 
-export const codeActionSelectionSet = `{
+export const codeActionSelectionSet = `
   ${baseActionSelectionSet}
   code
-}`
+`
 
 export const actionSelectionSet = `
   {
     ... on CodeAction {
         ${codeActionSelectionSet}
-      }
+    }
     ... on ApiAction {
         ${apiActionSelectionSet}
-      }
+    }
   }
 `
 

--- a/libs/backend/infra/adapter/neo4j/src/selectionSet/componentSelectionSet.ts
+++ b/libs/backend/infra/adapter/neo4j/src/selectionSet/componentSelectionSet.ts
@@ -1,3 +1,5 @@
+import { propSelectionSet } from './propSelectionSet'
+import { storeSelectionSet } from './storeSelectionSet'
 import { interfaceTypeSelectionSet } from './typeSelectionSet'
 
 export const componentSelectionSet = `{
@@ -10,6 +12,11 @@ export const componentSelectionSet = `{
   owner {
     id
     auth0Id
+  }
+  props
+    ${propSelectionSet}
+  store {
+    ${storeSelectionSet}
   }
   api
     ${interfaceTypeSelectionSet}

--- a/libs/backend/infra/adapter/neo4j/src/selectionSet/storeSelectionSet.ts
+++ b/libs/backend/infra/adapter/neo4j/src/selectionSet/storeSelectionSet.ts
@@ -1,5 +1,11 @@
+import { actionSelectionSet } from './actionSelectionSet'
+import { interfaceTypeSelectionSet } from './typeSelectionSet'
+
 export const storeSelectionSet = `
   id
   name
-  api { id }
+  api
+    ${interfaceTypeSelectionSet}
+  actions
+    ${actionSelectionSet}
 `

--- a/libs/frontend/domain/app/src/store/app.service.ts
+++ b/libs/frontend/domain/app/src/store/app.service.ts
@@ -122,6 +122,10 @@ export class AppService
   loadPages = ({ appData, components, pageId }: IPageBuilderAppProps) => {
     const app = this.add(appData)
 
+    components.forEach((componentData) => {
+      this.propService.add(componentData.props)
+    })
+
     // Sorting the components here so that they will be sorted when referenced in the
     // explorer builder tree, or in other areas
     // Would be nice if this can be sorted in the backend instead

--- a/libs/frontend/domain/renderer/src/element/wrapper.utils.ts
+++ b/libs/frontend/domain/renderer/src/element/wrapper.utils.ts
@@ -1,16 +1,11 @@
-import type { IPropData, IRenderOutput } from '@codelab/frontend/abstract/core'
+import type { IRenderOutput } from '@codelab/frontend/abstract/core'
 import { DATA_COMPONENT_ID } from '@codelab/frontend/abstract/core'
 import { IAtomType } from '@codelab/shared/abstract/core'
-import { pick } from 'ramda'
 import type { ReactElement } from 'react'
 import React, { Fragment } from 'react'
 import { getAtom } from '../atoms'
 import type { DraggableElementProps } from './DraggableElement'
 import { DraggableElementWrapper } from './DraggableElementWrapper'
-
-const getComponentProp = (props: IPropData = {}) => {
-  return pick([DATA_COMPONENT_ID], props)
-}
 
 /**
  * Fragments can only have the `key` prop


### PR DESCRIPTION
<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(libs-ui-component): must begin with lowercase` -->

## Description

<!-- This is a short description on the Pull Request -->
- cleanup the ElementWrapper a bit by removing the DnD wrapper since its not currently working properly and might [need some re-works](https://github.com/codelab-app/platform/issues/2248)
- add component props references upon loading the page to fix ref error when a component instance references it
- fixed BE crashes when theres a component instance in the builder due to some missing fields in the selection set

**Still crashing in FE due to some cyclic logic issue. Maybe this will be fixed along with the other [PR](https://github.com/codelab-app/platform/pull/2416)**

![image](https://user-images.githubusercontent.com/27695022/228608036-1e3aef38-bc85-417b-8c5d-dd7e54b95c98.png)


## Video or Image

<!-- Add video or image showing how the new feature works -->

This shows too many rendering happening when hovering on the builder section, which should be temporarily fixed by removing DnD wrapper for now

https://user-images.githubusercontent.com/27695022/228608467-8a03409e-8437-4431-8a18-870ebbb756b0.mp4



## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged -->

Fixes #
