### PR TITLE
fix: cyclic error when there is a component element

### DIFF
--- a/libs/backend/domain/element/src/model/element.model.ts
+++ b/libs/backend/domain/element/src/model/element.model.ts
@@ -18,7 +18,7 @@ export class Element implements IElementDTO {
 
   parent?: IEntity | null | undefined
 
-  component?: IEntity | null | undefined
+  parentComponent?: IEntity | null | undefined
 
   postRenderAction?: IEntity | null | undefined
 

--- a/libs/frontend/abstract/core/src/domain/element/element.dto.interface.ts
+++ b/libs/frontend/abstract/core/src/domain/element/element.dto.interface.ts
@@ -62,7 +62,6 @@ export type IUpdateBaseElementData = Pick<
  */
 export interface IElementDTO {
   // slug: string
-  component?: IEntity | null
   customCss?: Nullable<string>
   firstChild?: IEntity | null
   guiCss?: Nullable<string>
@@ -71,6 +70,7 @@ export interface IElementDTO {
   nextSibling?: IEntity | null
   page?: IEntity | null
   parent?: IEntity | null
+  parentComponent?: IEntity | null
   postRenderAction?: IEntity | null
   preRenderAction?: IEntity | null
   // renderComponentType?: IComponentDTO | null

--- a/libs/frontend/abstract/core/src/domain/element/element.model.interface.ts
+++ b/libs/frontend/abstract/core/src/domain/element/element.model.interface.ts
@@ -61,8 +61,6 @@ export interface IElement
   closestContainerNode: IComponent | IPage
   // the closest rootElement of node (page/component) that element belongs to
   closestRootElement: IElement
-  // component that this element belongs to
-  component?: Nullable<Ref<IComponent>>
   customCss?: Nullable<string>
   // This is a computed property, so we can use model instead of ref
   descendantElements: Array<IElement>
@@ -78,6 +76,8 @@ export interface IElement
   // page that this element belongs to
   page: Nullable<Ref<IPage>>
   parent?: Nullable<Ref<IElement>>
+  // component that this element belongs to
+  parentComponent?: Nullable<Ref<IComponent>>
   prevSibling?: Nullable<Ref<IElement>>
   propTransformationJs: Nullable<string>
   props: Ref<IProp>
@@ -105,12 +105,12 @@ export interface IElement
   detachAsFirstChild(): void
   detachFromParent(): void
   executePropTransformJs(props: IPropData): IPropData
-  setComponent(component: Ref<IComponent>): void
   setFirstChild(firstChild: Ref<IElement>): void
   setName(name: string): void
   setNextSibling(nextSibling: Ref<IElement>): void
   setOrderInParent(order: number | null): void
   setParent(parent: Ref<IElement>): void
+  setParentComponent(component: Ref<IComponent>): void
   setPrevSibling(prevSibling: Ref<IElement>): void
   setPropTransformationJs(props: string): void
   setProps(props: Nullable<Ref<IProp>>): void

--- a/libs/frontend/domain/builder/src/store/builder.service.ts
+++ b/libs/frontend/domain/builder/src/store/builder.service.ts
@@ -162,7 +162,7 @@ export class BuilderService
     }
 
     if (isElementPageNodeRef(selectedNode)) {
-      return selectedNode.current.component ?? null
+      return selectedNode.current.parentComponent ?? null
     }
 
     return null

--- a/libs/frontend/domain/component/src/store/component.model.ts
+++ b/libs/frontend/domain/component/src/store/component.model.ts
@@ -138,12 +138,12 @@ export class Component
 
       if (firstChild) {
         const firstChildId = elementMap.get(firstChild.current.id)
-        element.setParent(elementRef(firstChildId!))
+        element.setFirstChild(elementRef(firstChildId!))
       }
 
       if (nextSibling) {
         const nextSiblingId = elementMap.get(nextSibling.current.id)
-        element.setParent(elementRef(nextSiblingId!))
+        element.setNextSibling(elementRef(nextSiblingId!))
       }
 
       if (prevSibling) {
@@ -153,7 +153,7 @@ export class Component
     })
 
     const rootElement = elements.find((element) => element.id === rootElementId)
-    rootElement?.setComponent(componentRef(clonedComponent.id))
+    rootElement?.setParentComponent(componentRef(clonedComponent.id))
 
     if (!rootElement) {
       throw new Error('rootElement not found')

--- a/libs/frontend/domain/component/src/store/component.service.ts
+++ b/libs/frontend/domain/component/src/store/component.service.ts
@@ -112,8 +112,8 @@ export class ComponentService
 
     const rootElement = this.elementService.add({
       ...data.rootElement,
-      component: { id: data.id },
       name,
+      parentComponent: { id: data.id },
       props: rootElementProps,
     })
 

--- a/libs/frontend/domain/element/src/use-cases/element/create-element/CreateElementModal.tsx
+++ b/libs/frontend/domain/element/src/use-cases/element/create-element/CreateElementModal.tsx
@@ -67,7 +67,7 @@ export const CreateElementModal = observer(() => {
     ? parentElement.renderType.current
     : undefined
 
-  const parentComponent = parentElement.component?.current
+  const parentComponent = parentElement.parentComponent?.current
 
   return (
     <ModalForm.Modal

--- a/libs/frontend/domain/renderer/src/renderer.model.ts
+++ b/libs/frontend/domain/renderer/src/renderer.model.ts
@@ -132,12 +132,6 @@ export class Renderer
   })
   implements IRenderer
 {
-  // @modelAction
-  // initForce(elementTree: IElementTree, providerTree?: Nullable<IElementTree>) {
-  //   this.elementTree = elementTreeRef(elementTree)
-  //   this.providerTree = providerTree ? elementTreeRef(providerTree) : null
-  // }
-
   renderRoot() {
     const root = this.elementTree.maybeCurrent?.rootElement.current
 
@@ -208,31 +202,6 @@ export class Renderer
       : result
   }
 
-  /*
-  computePropsForComponentElements(element: IElement) {
-    const component = (element.renderComponentType ?? element.parentComponent)
-      ?.maybeCurrent
-
-    const componentProps = element.parentComponent
-      ? component?.props?.values
-      : element.props?.values
-
-    if (!component || !componentProps) {
-      return
-    }
-
-
-    const props = this.processPropsForRender(
-      {
-        ...componentProps,
-        ...propsForCurrentElement,
-        [COMPONENT_INSTANCE_ID]: element.id,
-      },
-      element,
-    )
-  }
-  */
-
   /**
    * Renders a single Element using the provided RenderAdapter
    */
@@ -256,7 +225,7 @@ export class Renderer
     element: IElement,
     extraProps?: IPropData,
   ): ArrayOrSingle<IRenderOutput> => {
-    const component = element.component?.current
+    const component = element.parentComponent?.current
     const componentInstance = component?.instanceElement?.current
     const componentApi = component?.api.maybeCurrent
 
@@ -275,7 +244,7 @@ export class Renderer
   }
 
   getComponentInstanceChildren(element: IElement) {
-    const parentComponent = element.component?.current
+    const parentComponent = element.parentComponent?.current
 
     const isContainer =
       element.id === parentComponent?.childrenContainerElement.id
@@ -304,8 +273,8 @@ export class Renderer
 
       // This will pass down the props from the component instance to the descendants
       const componentInstanceProps = {
-        ...parentOutput.element.component?.current.instanceElement?.current
-          .props.current.values,
+        ...parentOutput.element.parentComponent?.current.instanceElement
+          ?.current.props.current.values,
         ...extraProps,
       }
 

--- a/libs/frontend/domain/renderer/src/test/setup/setup-test.ts
+++ b/libs/frontend/domain/renderer/src/test/setup/setup-test.ts
@@ -125,7 +125,7 @@ export const setupTestForRenderer = (pipes: Array<RenderPipeClass> = []) => {
     })
 
     data.componentRootElement = new Element({
-      _component: componentRef(data.componentToRender.id),
+      _parentComponent: componentRef(data.componentToRender.id),
       customCss: '',
       guiCss: '',
       id: compRootElementId,
@@ -177,7 +177,7 @@ export const setupTestForRenderer = (pipes: Array<RenderPipeClass> = []) => {
     })
 
     data.componentInstanceElementToRender = new Element({
-      _component: componentRef(data.componentToRender.id),
+      _parentComponent: componentRef(data.componentToRender.id),
       id: v4(),
       name: '01',
       props: propRef(data.componentInstanceElementToRenderProps.id),


### PR DESCRIPTION
<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(libs-ui-component): must begin with lowercase` -->

## Description

<!-- This is a short description on the Pull Request -->
- fixed cyclic traversal issue due to [bug on the logic of setting the element parent](https://github.com/codelab-app/platform/pull/2425/files#diff-1df306a8c4d34d1d731fcf135c78d3b94949bcc3ac5ce3975ad940a3ccbda0e4L141)
- re-renamed the `element.component` to `element.parentComponent` to make it the same with the BE response which also fixes the reference issue on the component builder
- 
## Video or Image

<!-- Add video or image showing how the new feature works -->

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged -->

Fixes #
