### PR TITLE
fix: apps loading issue, multiple field labels

### DIFF
--- a/apps/builder-e2e/src/e2e/providers-page.cy.ts
+++ b/apps/builder-e2e/src/e2e/providers-page.cy.ts
@@ -64,7 +64,7 @@ describe('_app page', () => {
     cy.get(`.ant-tabs [aria-label="file"]`).click()
     cy.get(`.ant-tabs [aria-label="file"]`).click()
     cy.get('.ant-tabs-tabpane-active form').setFormFieldValue({
-      label: 'Id',
+      label: 'Page Content Container',
       type: FIELD_TYPE.SELECT,
       value: CARD_COMPONENT_NAME,
     })

--- a/apps/builder/pages/apps/index.tsx
+++ b/apps/builder/pages/apps/index.tsx
@@ -23,12 +23,12 @@ import {
   sidebarNavigation,
 } from '@codelab/frontend/view/templates'
 import { auth0Instance } from '@codelab/shared/adapter/auth0'
-import { useAsync, useMountEffect } from '@react-hookz/web'
+import { useAsync } from '@react-hookz/web'
 import type { MenuProps } from 'antd'
 import { Button, Dropdown, Menu, PageHeader, Spin } from 'antd'
 import { observer } from 'mobx-react-lite'
 import Head from 'next/head'
-import React from 'react'
+import React, { useEffect } from 'react'
 
 const items: MenuProps['items'] = [
   {
@@ -61,17 +61,17 @@ const AppsPage: CodelabPage<DashboardTemplateProps> = (props) => {
     appService.loadAppsWithNestedPreviews({ owner }),
   )
 
-  useMountEffect(() => {
+  useEffect(() => {
     if (user?.sub) {
       void loadApp.execute({ auth0Id: user.sub })
     }
 
     // in development need to execute this each time page is loaded,
     // since useUser always returns valid Auth0 user even when it does not exist in neo4j db yet
-    if (process.env.NEXT_PUBLIC_BUILDER_HOST?.includes('127.0.0.1')) {
+    if (user && process.env.NEXT_PUBLIC_BUILDER_HOST?.includes('127.0.0.1')) {
       void fetch('/api/upsert-user')
     }
-  })
+  }, [user?.sub])
 
   return (
     <>
@@ -85,7 +85,11 @@ const AppsPage: CodelabPage<DashboardTemplateProps> = (props) => {
       <DeleteAppModal />
 
       <ContentSection>
-        {status === 'loading' ? <Spin /> : <GetAppsList />}
+        {status === 'loading' || status === 'not-executed' ? (
+          <Spin />
+        ) : (
+          <GetAppsList />
+        )}
       </ContentSection>
     </>
   )

--- a/libs/frontend/domain/component/src/use-cases/update-component/update-component.schema.ts
+++ b/libs/frontend/domain/component/src/use-cases/update-component/update-component.schema.ts
@@ -8,6 +8,7 @@ export const updateComponentSchema: JSONSchemaType<IUpdateComponentData> = {
   properties: {
     ...idSchema,
     childrenContainerElement: {
+      label: '',
       properties: {
         id: {
           label: 'Container for component children',

--- a/libs/frontend/domain/element/src/use-cases/element/create-element/create-element.schema.ts
+++ b/libs/frontend/domain/element/src/use-cases/element/create-element/create-element.schema.ts
@@ -68,9 +68,11 @@ export const createElementSchema: JSONSchemaType<
       type: 'object',
     },
     props: {
+      label: '',
       nullable: true,
       properties: {
         data: {
+          label: 'Props Data',
           nullable: true,
           type: 'string',
         },

--- a/libs/frontend/domain/page/src/use-cases/update-page-tab/update-page-tab.schema.ts
+++ b/libs/frontend/domain/page/src/use-cases/update-page-tab/update-page-tab.schema.ts
@@ -13,9 +13,11 @@ export const schema = (kind: IPageKind): JSONSchemaType<IUpdatePageData> =>
       ...appSchema,
       name: { disabled: kind !== IPageKind.Regular, type: 'string' },
       pageContentContainer: {
+        label: '',
         nullable: true,
         properties: {
           id: {
+            label: 'Page Content Container',
             type: 'string',
             uniforms: {
               component: getSelectElementComponent(ElementTypeKind.AllElements),

--- a/libs/frontend/view/components/form/schema/app.schema.ts
+++ b/libs/frontend/view/components/form/schema/app.schema.ts
@@ -4,8 +4,10 @@ import { showFieldOnDev } from './showFieldOnDev'
 
 export const appSchema: PropertiesSchema<IAppSchema> = {
   app: {
+    label: '',
     properties: {
       id: {
+        label: 'App',
         disabled: true,
         type: 'string',
       },

--- a/libs/frontend/view/components/form/schema/owner.schema.ts
+++ b/libs/frontend/view/components/form/schema/owner.schema.ts
@@ -4,8 +4,10 @@ import { showFieldOnDev } from './showFieldOnDev'
 
 export const ownerSchema: PropertiesSchema<IOwnerSchema> = {
   owner: {
+    label: '',
     properties: {
       auth0Id: {
+        label: 'Owner',
         disabled: true,
         type: 'string',
       },


### PR DESCRIPTION
<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(libs-ui-component): must begin with lowercase` -->

## Description

- Fixed double field labels for form fields:

Before|After
:-------------------------:|:-------------------------:
<img width="490" alt="Screenshot 2023-04-01 at 17 41 10" src="https://user-images.githubusercontent.com/74900868/229299442-62857daa-1daf-4e9a-9676-b2491e6a6fd5.png">|<img width="515" alt="Screenshot 2023-04-01 at 17 42 35" src="https://user-images.githubusercontent.com/74900868/229299466-014a8d95-4e32-4883-b2a6-fd8adec490e9.png">


- Fix apps not loaded when /apps page is loaded. It happened because useMountEffect is executed before the `user` is resolved - and request for apps never happens:

Before

https://user-images.githubusercontent.com/74900868/229300415-0d0a2c4b-44ed-48a1-b145-ad8c7b851e4e.mov


After

https://user-images.githubusercontent.com/74900868/229300451-95ea0581-c179-441d-be0d-2984903bb748.mov






## Related Issue(s)

Fixes #
