### PR TITLE
refactor: remove request for components in Select

### DIFF
--- a/libs/backend/infra/adapter/neo4j/src/schema/model/component.schema.ts
+++ b/libs/backend/infra/adapter/neo4j/src/schema/model/component.schema.ts
@@ -1,5 +1,4 @@
 import { gql } from 'apollo-server-micro'
-import { getDescendantComponentIds } from '../../cypher'
 
 export const componentSchema = gql`
   type Component implements WithOwner {
@@ -10,35 +9,29 @@ export const componentSchema = gql`
     owner: User!
 
     store: Store! @relationship(type: "STORE_OF_COMPONENT", direction: IN)
-    
+
     props: Prop! @relationship(type: "PROPS_OF_COMPONENT", direction: OUT)
     # This is the element inside the component that is going to be
     # the container for component instance children
-    childrenContainerElement: Element! @relationship(type: "CHILDREN_CONTAINER_ELEMENT", direction: OUT)
-    # This is used to prevent components from referencing each other in a
-    # circular way. In another words, if component A references component B,
-    # component B cannot reference component A because that would cause
-    # infinite recursion in the renderer.
-    # Note: A component referencing another component means the first component
-    # has an element that is an instance of the second component.
-    descendantComponentIds: [ID!]! @cypher(statement: """${getDescendantComponentIds}""")
+    childrenContainerElement: Element!
+      @relationship(type: "CHILDREN_CONTAINER_ELEMENT", direction: OUT)
   }
 
   extend type Component
-  @auth(
-    rules: [
-      { operations: [CONNECT, DISCONNECT], roles: ["Admin", "User"] }
-      {
-        operations: [UPDATE, CREATE, DELETE]
-        roles: ["User"]
-        where: { owner: { auth0Id: "$jwt.sub" } }
-        bind: { owner: { auth0Id: "$jwt.sub" } }
-      }
-      {
-        operations: [UPDATE, CREATE, DELETE]
-        roles: ["Admin"]
-        bind: { owner: { auth0Id: "$jwt.sub" } }
-      }
-    ]
-  )
+    @auth(
+      rules: [
+        { operations: [CONNECT, DISCONNECT], roles: ["Admin", "User"] }
+        {
+          operations: [UPDATE, CREATE, DELETE]
+          roles: ["User"]
+          where: { owner: { auth0Id: "$jwt.sub" } }
+          bind: { owner: { auth0Id: "$jwt.sub" } }
+        }
+        {
+          operations: [UPDATE, CREATE, DELETE]
+          roles: ["Admin"]
+          bind: { owner: { auth0Id: "$jwt.sub" } }
+        }
+      ]
+    )
 `

--- a/libs/frontend/domain/type/src/graphql/interface-form.endpoints.graphql
+++ b/libs/frontend/domain/type/src/graphql/interface-form.endpoints.graphql
@@ -41,17 +41,6 @@ query InterfaceForm_GetResource(
   }
 }
 
-query InterfaceForm_GetComponents(
-  $options: ComponentOptions
-  $where: ComponentWhere
-) {
-  components(options: $options, where: $where) {
-    id
-    name
-    descendantComponentIds
-  }
-}
-
 query InterfaceForm_GetPages($options: PageOptions, $where: PageWhere) {
   pages(options: $options, where: $where) {
     id

--- a/libs/frontend/domain/type/src/graphql/interface-form.endpoints.graphql.gen.ts
+++ b/libs/frontend/domain/type/src/graphql/interface-form.endpoints.graphql.gen.ts
@@ -48,19 +48,6 @@ export type InterfaceForm_GetResourceQuery = {
   resources: Array<{ id: string; name: string }>
 }
 
-export type InterfaceForm_GetComponentsQueryVariables = Types.Exact<{
-  options?: Types.InputMaybe<Types.ComponentOptions>
-  where?: Types.InputMaybe<Types.ComponentWhere>
-}>
-
-export type InterfaceForm_GetComponentsQuery = {
-  components: Array<{
-    id: string
-    name: string
-    descendantComponentIds: Array<string>
-  }>
-}
-
 export type InterfaceForm_GetPagesQueryVariables = Types.Exact<{
   options?: Types.InputMaybe<Types.PageOptions>
   where?: Types.InputMaybe<Types.PageWhere>
@@ -115,18 +102,6 @@ export const InterfaceForm_GetResourceDocument = gql`
     resources(options: $options, where: $where) {
       id
       name
-    }
-  }
-`
-export const InterfaceForm_GetComponentsDocument = gql`
-  query InterfaceForm_GetComponents(
-    $options: ComponentOptions
-    $where: ComponentWhere
-  ) {
-    components(options: $options, where: $where) {
-      id
-      name
-      descendantComponentIds
     }
   }
 `
@@ -228,21 +203,6 @@ export function getSdk(
             { ...requestHeaders, ...wrappedRequestHeaders },
           ),
         'InterfaceForm_GetResource',
-        'query',
-      )
-    },
-    InterfaceForm_GetComponents(
-      variables?: InterfaceForm_GetComponentsQueryVariables,
-      requestHeaders?: Dom.RequestInit['headers'],
-    ): Promise<InterfaceForm_GetComponentsQuery> {
-      return withWrapper(
-        (wrappedRequestHeaders) =>
-          client.request<InterfaceForm_GetComponentsQuery>(
-            InterfaceForm_GetComponentsDocument,
-            variables,
-            { ...requestHeaders, ...wrappedRequestHeaders },
-          ),
-        'InterfaceForm_GetComponents',
         'query',
       )
     },

--- a/libs/shared/abstract/codegen/src/ogm-types.gen.ts
+++ b/libs/shared/abstract/codegen/src/ogm-types.gen.ts
@@ -3300,7 +3300,6 @@ export type Component = WithOwner & {
   __typename?: 'Component'
   id: Scalars['ID']
   name: Scalars['String']
-  descendantComponentIds: Array<Scalars['ID']>
   rootElement: Element
   rootElementAggregate?: Maybe<ComponentElementRootElementAggregationSelection>
   api: InterfaceType

--- a/libs/shared/abstract/codegen/src/types.api.graphql.gen.ts
+++ b/libs/shared/abstract/codegen/src/types.api.graphql.gen.ts
@@ -5139,7 +5139,6 @@ export type Component = WithOwner & {
   childrenContainerElement: Element
   childrenContainerElementAggregate?: Maybe<ComponentElementChildrenContainerElementAggregationSelection>
   childrenContainerElementConnection: ComponentChildrenContainerElementConnection
-  descendantComponentIds: Array<Scalars['ID']>
   id: Scalars['ID']
   name: Scalars['String']
   owner: User
@@ -21974,21 +21973,6 @@ export type InterfaceForm_GetResourceQueryVariables = Exact<{
 export type InterfaceForm_GetResourceQuery = {
   __typename?: 'Query'
   resources: Array<{ __typename?: 'Resource'; id: string; name: string }>
-}
-
-export type InterfaceForm_GetComponentsQueryVariables = Exact<{
-  options?: InputMaybe<ComponentOptions>
-  where?: InputMaybe<ComponentWhere>
-}>
-
-export type InterfaceForm_GetComponentsQuery = {
-  __typename?: 'Query'
-  components: Array<{
-    __typename?: 'Component'
-    id: string
-    name: string
-    descendantComponentIds: Array<string>
-  }>
 }
 
 export type InterfaceForm_GetPagesQueryVariables = Exact<{

--- a/schema.graphql
+++ b/schema.graphql
@@ -5033,7 +5033,6 @@ type Component implements WithOwner {
     sort: [ComponentChildrenContainerElementConnectionSort!]
     where: ComponentChildrenContainerElementConnectionWhere
   ): ComponentChildrenContainerElementConnection!
-  descendantComponentIds: [ID!]!
   id: ID!
   name: String!
   owner(directed: Boolean = true, options: UserOptions, where: UserWhere): User!


### PR DESCRIPTION
<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(libs-ui-component): must begin with lowercase` -->

## Description
SelectComponent dropdown is used in many places on forms and it sends the request for components each time it is mounted. The only reason for this request is to filter components that include other components as children. No need to do this request at all, since all the data is available at the client and this can be computed with the same algorithm complexity but with no request.

## Video or Image
Before

https://user-images.githubusercontent.com/74900868/229877512-51aa7bac-4fad-4534-b9ce-d91f157c6e2c.mov

After

https://user-images.githubusercontent.com/74900868/229877968-5cc8ab67-8aba-4352-b72e-654e65d4d58d.mov



## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged -->

This is one of the fixes under #2215
