### PR TITLE
fix: use interface from store if exists

### DIFF
--- a/apps/cli/src/commands/tasks/tasks.command.ts
+++ b/apps/cli/src/commands/tasks/tasks.command.ts
@@ -64,7 +64,7 @@ export const tasksCommand: CommandModule<unknown, unknown> = {
 
           if (stage === Stage.CI) {
             execCommand(
-              'npx nx affected --target=test --testPathPattern="[^i].spec.ts" --color --parallel=3 --verbose',
+              'npx nx affected --target=test --testPathPattern="[^i].spec.ts" --color --verbose',
             )
           }
         },

--- a/libs/backend/shared/util/src/file/save-formatted-file.ts
+++ b/libs/backend/shared/util/src/file/save-formatted-file.ts
@@ -1,4 +1,5 @@
 import fs from 'fs'
+import { EOL } from 'os'
 import * as path from 'path'
 
 export const saveFormattedFile = (outputFilePath: string, data: object) => {
@@ -11,4 +12,5 @@ export const saveFormattedFile = (outputFilePath: string, data: object) => {
 
   fs.mkdirSync(path.dirname(exportPath), { recursive: true })
   fs.writeFileSync(exportPath, json)
+  fs.appendFileSync(exportPath, EOL, 'utf8')
 }

--- a/libs/frontend/domain/type/src/store/type.service.ts
+++ b/libs/frontend/domain/type/src/store/type.service.ts
@@ -216,6 +216,15 @@ export class TypeService
     this: TypeService,
     interfaceTypeId: IInterfaceTypeRef,
   ) {
+    const interfaceFromStore = this.type(interfaceTypeId)
+
+    if (
+      interfaceFromStore &&
+      interfaceFromStore.kind === ITypeKind.InterfaceType
+    ) {
+      return interfaceFromStore
+    }
+
     const [interfaceType] = yield* _await(this.getAll([interfaceTypeId]))
 
     if (!interfaceType) {


### PR DESCRIPTION
<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(libs-ui-component): must begin with lowercase` -->

## Description

- Do not request types over and over again if they were already loaded
- Fix linting errors on exported files with data (no new line in the end)
- Reduce the amount of parallel unit tests runs in CI. This is an experimental fix, since unit tests currently fail on CI almost in 100% cases with strange errors like `A jest worker process (pid=11453) was terminated by another process: signal=SIGKILL, exitCode=null.` This may be because of memory issues.

## Video or Image

Before

https://user-images.githubusercontent.com/74900868/230017315-71274696-b682-4bd2-9f81-8bffa25f73e1.mov

After

https://user-images.githubusercontent.com/74900868/230017349-758461a8-af7a-4cc8-8b4c-6fa6f5c2c48c.mov


## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged -->

One of the fixes under #2215 
