### PR TITLE
refactor: simplify app query to use less resources

### DIFF
--- a/libs/frontend/abstract/core/src/domain/element/element.fragment.graphql
+++ b/libs/frontend/abstract/core/src/domain/element/element.fragment.graphql
@@ -8,7 +8,7 @@ fragment Element on Element {
     id
   }
   renderComponentType {
-    ...Component
+    id
   }
   renderAtomType {
     ...Atom
@@ -25,7 +25,7 @@ fragment Element on Element {
     id
   }
   parentComponent {
-    ...Component
+    id
   }
   parent {
     id

--- a/libs/frontend/abstract/core/src/domain/element/element.fragment.graphql.gen.ts
+++ b/libs/frontend/abstract/core/src/domain/element/element.fragment.graphql.gen.ts
@@ -1,14 +1,12 @@
 import * as Types from '@codelab/shared/abstract/codegen'
 
-import { ComponentFragment } from '../component/component.fragment.graphql.gen'
-import { PropFragment } from '../prop/prop.fragment.graphql.gen'
 import { AtomFragment } from '../atom/atom.fragment.graphql.gen'
+import { PropFragment } from '../prop/prop.fragment.graphql.gen'
 import { GraphQLClient } from 'graphql-request'
 import * as Dom from 'graphql-request/dist/types.dom'
 import { gql } from 'graphql-tag'
-import { ComponentFragmentDoc } from '../component/component.fragment.graphql.gen'
-import { PropFragmentDoc } from '../prop/prop.fragment.graphql.gen'
 import { AtomFragmentDoc } from '../atom/atom.fragment.graphql.gen'
+import { PropFragmentDoc } from '../prop/prop.fragment.graphql.gen'
 export type ElementFragment = {
   __typename: 'Element'
   id: string
@@ -19,12 +17,12 @@ export type ElementFragment = {
   renderIfExpression?: string | null
   propTransformationJs?: string | null
   page?: { id: string } | null
-  renderComponentType?: ComponentFragment | null
+  renderComponentType?: { id: string } | null
   renderAtomType?: AtomFragment | null
   renderType?: { id: string; kind: Types.RenderTypeKind } | null
   prevSibling?: { id: string } | null
   nextSibling?: { id: string } | null
-  parentComponent?: ComponentFragment | null
+  parentComponent?: { id: string } | null
   parent?: { id: string } | null
   firstChild?: { id: string } | null
   props: PropFragment
@@ -43,7 +41,7 @@ export const ElementFragmentDoc = gql`
       id
     }
     renderComponentType {
-      ...Component
+      id
     }
     renderAtomType {
       ...Atom
@@ -59,7 +57,7 @@ export const ElementFragmentDoc = gql`
       id
     }
     parentComponent {
-      ...Component
+      id
     }
     parent {
       id
@@ -80,7 +78,6 @@ export const ElementFragmentDoc = gql`
     }
     propTransformationJs
   }
-  ${ComponentFragmentDoc}
   ${AtomFragmentDoc}
   ${PropFragmentDoc}
 `

--- a/libs/frontend/abstract/core/src/domain/page/page.fragment.graphql
+++ b/libs/frontend/abstract/core/src/domain/page/page.fragment.graphql
@@ -32,9 +32,6 @@ fragment BuilderPage on Page {
   }
   app {
     id
-    owner {
-      ...Owner
-    }
   }
   store {
     ...Store

--- a/libs/frontend/abstract/core/src/domain/page/page.fragment.graphql.gen.ts
+++ b/libs/frontend/abstract/core/src/domain/page/page.fragment.graphql.gen.ts
@@ -1,13 +1,11 @@
 import * as Types from '@codelab/shared/abstract/codegen'
 
 import { ElementFragment } from '../element/element.fragment.graphql.gen'
-import { OwnerFragment } from '../user/owner.fragment.graphql.gen'
 import { StoreFragment } from '../store/store.fragment.graphql.gen'
 import { GraphQLClient } from 'graphql-request'
 import * as Dom from 'graphql-request/dist/types.dom'
 import { gql } from 'graphql-tag'
 import { ElementFragmentDoc } from '../element/element.fragment.graphql.gen'
-import { OwnerFragmentDoc } from '../user/owner.fragment.graphql.gen'
 import { StoreFragmentDoc } from '../store/store.fragment.graphql.gen'
 export type PageFragment = {
   id: string
@@ -26,7 +24,7 @@ export type BuilderPageFragment = {
   slug: string
   kind: Types.PageKind
   rootElement: { descendantElements: Array<ElementFragment> } & ElementFragment
-  app: { id: string; owner: OwnerFragment }
+  app: { id: string }
   store: StoreFragment
   pageContentContainer?: { id: string } | null
 }
@@ -69,9 +67,6 @@ export const BuilderPageFragmentDoc = gql`
     }
     app {
       id
-      owner {
-        ...Owner
-      }
     }
     store {
       ...Store
@@ -82,7 +77,6 @@ export const BuilderPageFragmentDoc = gql`
     kind
   }
   ${ElementFragmentDoc}
-  ${OwnerFragmentDoc}
   ${StoreFragmentDoc}
 `
 

--- a/libs/frontend/domain/app/src/store/app.service.ts
+++ b/libs/frontend/domain/app/src/store/app.service.ts
@@ -124,6 +124,8 @@ export class AppService
 
     components.forEach((componentData) => {
       this.propService.add(componentData.props)
+      this.componentService.add(componentData)
+      this.typeService.addInterface(componentData.api)
     })
 
     // Sorting the components here so that they will be sorted when referenced in the
@@ -155,15 +157,6 @@ export class AppService
         )
 
         this.atomService.add(elementData.renderAtomType)
-      }
-
-      if (elementData.renderComponentType || elementData.parentComponent) {
-        const component = (elementData.renderComponentType ??
-          elementData.parentComponent)!
-
-        this.typeService.addInterface(component.api)
-
-        this.componentService.add(component)
       }
 
       this.elementService.add(elementData)

--- a/libs/shared/abstract/codegen/src/types.api.graphql.gen.ts
+++ b/libs/shared/abstract/codegen/src/types.api.graphql.gen.ts
@@ -20267,9 +20267,7 @@ export type ElementFragment = {
   renderIfExpression?: string | null
   propTransformationJs?: string | null
   page?: { __typename?: 'Page'; id: string } | null
-  renderComponentType?:
-    | ({ __typename?: 'Component' } & ComponentFragment)
-    | null
+  renderComponentType?: { __typename?: 'Component'; id: string } | null
   renderAtomType?: ({ __typename?: 'Atom' } & AtomFragment) | null
   renderType?: {
     __typename?: 'RenderType'
@@ -20278,7 +20276,7 @@ export type ElementFragment = {
   } | null
   prevSibling?: { __typename?: 'Element'; id: string } | null
   nextSibling?: { __typename?: 'Element'; id: string } | null
-  parentComponent?: ({ __typename?: 'Component' } & ComponentFragment) | null
+  parentComponent?: { __typename?: 'Component'; id: string } | null
   parent?: { __typename?: 'Element'; id: string } | null
   firstChild?: { __typename?: 'Element'; id: string } | null
   props: { __typename?: 'Prop' } & PropFragment
@@ -20327,11 +20325,7 @@ export type BuilderPageFragment = {
     __typename?: 'Element'
     descendantElements: Array<{ __typename?: 'Element' } & ElementFragment>
   } & ElementFragment
-  app: {
-    __typename?: 'App'
-    id: string
-    owner: { __typename?: 'User' } & OwnerFragment
-  }
+  app: { __typename?: 'App'; id: string }
   store: { __typename?: 'Store' } & StoreFragment
   pageContentContainer?: { __typename?: 'Element'; id: string } | null
 }


### PR DESCRIPTION
<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(libs-ui-component): must begin with lowercase` -->

## Description

Query to get app and all related resources (pages, elements, components, stores, etc) cause the image that has only 1GB RAM to crash with an Out Of Memory error.
Reduce the complexity of the query by replacing full components information loading with only ID.
Not the query successes on 1GB ram image

Before

https://user-images.githubusercontent.com/74900868/231205525-69cfdbd9-a1c8-4a89-8d5c-ad5ca0825612.mov



## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged -->

Fixes #2441 
