### PR TITLE
fix: union type and react node field on create/update field modal

### DIFF
--- a/libs/frontend/abstract/types/src/form/form.tsx
+++ b/libs/frontend/abstract/types/src/form/form.tsx
@@ -11,7 +11,7 @@ export type VoidCallback<TInput> = ArrayOrSingle<Callback<TInput, void>>
 export type FormProps<TData, TResponse = unknown> = Partial<
   Pick<
     AutoFormProps<TData>,
-    'autosave' | 'onChange' | 'onChangeModel' | 'submitField'
+    'autosave' | 'modelTransform' | 'onChange' | 'onChangeModel' | 'submitField'
   >
 > &
   Pick<AutoFormProps<TData>, 'model'> &

--- a/libs/frontend/domain/element/src/use-cases/element/update-element-props/UpdateElementPropsForm.tsx
+++ b/libs/frontend/domain/element/src/use-cases/element/update-element-props/UpdateElementPropsForm.tsx
@@ -86,9 +86,6 @@ export const UpdateElementPropsForm = observer<UpdateElementPropsFormProps>(
       currentElement.props.current.values,
     )
 
-    console.log('propsModel', propsModel)
-    console.log('currentElement', currentElement)
-
     return (
       <Spinner isLoading={status === 'loading'}>
         {interfaceType && (

--- a/libs/frontend/domain/element/src/use-cases/element/update-element-props/UpdateElementPropsForm.tsx
+++ b/libs/frontend/domain/element/src/use-cases/element/update-element-props/UpdateElementPropsForm.tsx
@@ -43,7 +43,7 @@ const withCustomTextSchema: JSONSchemaType<{
 
 export const UpdateElementPropsForm = observer<UpdateElementPropsFormProps>(
   ({ element, trackPromises }) => {
-    const { elementService, propService, typeService } = useStore()
+    const { propService, typeService } = useStore()
     const { trackPromise } = trackPromises ?? {}
     const currentElement = element.current
     const apiId = currentElement.renderType?.current.api.id
@@ -81,10 +81,13 @@ export const UpdateElementPropsForm = observer<UpdateElementPropsFormProps>(
     // but should prioritize the element props
     const propsModel = mergeProps(
       isComponentInstance(currentElement.renderType)
-        ? currentElement.renderType.maybeCurrent?.props?.current.values
+        ? currentElement.renderType.maybeCurrent?.props.current.values
         : {},
       currentElement.props.current.values,
     )
+
+    console.log('propsModel', propsModel)
+    console.log('currentElement', currentElement)
 
     return (
       <Spinner isLoading={status === 'loading'}>

--- a/libs/frontend/domain/type/src/interface-form/fields/select-default-value/SelectDefaultValue.tsx
+++ b/libs/frontend/domain/type/src/interface-form/fields/select-default-value/SelectDefaultValue.tsx
@@ -55,10 +55,19 @@ export const SelectDefaultValue = ({
     [type?.id, isRequired],
   )
 
-  const defaultValues =
-    !context.model.defaultValues && type?.kind === ITypeKind.ArrayType
-      ? []
-      : context.model.defaultValues
+  let defaultValues = context.model.defaultValues
+
+  if (isNil(defaultValues) || fieldType.changed) {
+    if (type?.kind === ITypeKind.ArrayType) {
+      defaultValues = []
+    }
+
+    if (type?.kind === ITypeKind.UnionType) {
+      defaultValues = {
+        type: type.typesOfUnionType[0]?.id,
+      }
+    }
+  }
 
   const hasError =
     context.submitted && isRequired && isNil(context.model.defaultValues)
@@ -67,6 +76,9 @@ export const SelectDefaultValue = ({
   // Simple approach for now is to just display the error message for the `defaultValues` below it
   return (
     <Form
+      // key is needed here to re-create this form with a
+      // new model and schema when the field type is changed
+      key={`${fieldType.value}-default-values`}
       model={{ defaultValues }}
       onChange={(key, value) => {
         const formattedValue = value === '' ? undefined : value

--- a/libs/frontend/domain/type/src/interface-form/fields/select-default-value/SelectDefaultValue.tsx
+++ b/libs/frontend/domain/type/src/interface-form/fields/select-default-value/SelectDefaultValue.tsx
@@ -56,16 +56,26 @@ export const SelectDefaultValue = ({
   )
 
   let defaultValues = context.model.defaultValues
+  const currentFieldType = React.useRef(fieldType.value)
 
-  if (isNil(defaultValues) || fieldType.changed) {
+  if (
+    isNil(defaultValues) ||
+    (fieldType.changed && currentFieldType.current !== fieldType.value)
+  ) {
+    currentFieldType.current = fieldType.value
+
     if (type?.kind === ITypeKind.ArrayType) {
       defaultValues = []
+      // Sets initial value of `defaultValues` in the parent form model
+      context.onChange('defaultValues', defaultValues)
     }
 
     if (type?.kind === ITypeKind.UnionType) {
       defaultValues = {
         type: type.typesOfUnionType[0]?.id,
       }
+      // Sets initial value of `defaultValues` in the parent form model
+      context.onChange('defaultValues', defaultValues)
     }
   }
 

--- a/libs/frontend/domain/type/src/interface-form/fields/select-union-type-value/SelectUnionTypeValue.tsx
+++ b/libs/frontend/domain/type/src/interface-form/fields/select-union-type-value/SelectUnionTypeValue.tsx
@@ -1,8 +1,10 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
+import type { IFieldDefaultValue } from '@codelab/frontend/abstract/core'
 import { usePrevious } from '@codelab/frontend/shared/utils'
 import { Form } from '@codelab/frontend/view/components'
 import { css } from '@emotion/react'
 import { Form as AntdForm } from 'antd'
+import isNil from 'lodash/isNil'
 import React, { useEffect } from 'react'
 import tw from 'twin.macro'
 import { useField } from 'uniforms'
@@ -10,7 +12,10 @@ import { AutoField, SelectField } from 'uniforms-antd'
 
 export interface SelectUnionTypeValueProps {
   name: string
-  value: any
+  value: {
+    type: string
+    value?: IFieldDefaultValue
+  }
 }
 
 const makeSelectOptions = (oneOf: Array<any>) => {
@@ -49,7 +54,7 @@ export const SelectUnionTypeValue = (props: SelectUnionTypeValueProps) => {
     throw new Error('SelectUnionTypeValue must be used with a oneOf field')
   }
 
-  const { type: selectedTypeId } = (fieldProps.value as any) ?? {}
+  const { type: selectedTypeId } = fieldProps.value
   const selectOptions = makeSelectOptions(oneOf)
 
   const valueSchema = {
@@ -62,7 +67,10 @@ export const SelectUnionTypeValue = (props: SelectUnionTypeValueProps) => {
 
   const previousSelectedTypeId = usePrevious(selectedTypeId)
   useEffect(() => {
-    if (previousSelectedTypeId !== selectedTypeId) {
+    if (
+      !isNil(previousSelectedTypeId) &&
+      previousSelectedTypeId !== selectedTypeId
+    ) {
       context.onChange(valueFieldName, undefined)
     }
   }, [

--- a/libs/frontend/domain/type/src/interface-form/type-schema.factory.ts
+++ b/libs/frontend/domain/type/src/interface-form/type-schema.factory.ts
@@ -68,7 +68,7 @@ export class TypeSchemaFactory {
       case ITypeKind.EnumType:
         return this.fromEnumType(type)
       case ITypeKind.UnionType:
-        return this.fromUnionType(type)
+        return this.fromUnionType(type, context)
       case ITypeKind.InterfaceType:
         return this.fromInterfaceType(type)
       case ITypeKind.ArrayType:
@@ -96,7 +96,9 @@ export class TypeSchemaFactory {
         fieldName: field.name,
         validationRules: field.validationRules ?? undefined,
       }),
-      ...field.validationRules?.general,
+      ...(field.type.current.kind !== ITypeKind.UnionType
+        ? field.validationRules?.general
+        : undefined),
     })
 
     const makeFieldProperties = (
@@ -125,7 +127,7 @@ export class TypeSchemaFactory {
     }
   }
 
-  fromUnionType(type: IUnionType): JsonSchema {
+  fromUnionType(type: IUnionType, context?: UiPropertiesContext): JsonSchema {
     // This is the extra for the union type. Not to be confused with the extra for the value type
     const extra = this.getExtraProperties(type)
     const label: string | undefined = extra?.label
@@ -146,7 +148,7 @@ export class TypeSchemaFactory {
         return {
           label: '',
           properties,
-
+          ...context?.validationRules?.general,
           type: 'object',
           // We use this as label of the select field item
           typeName: innerType.current.name,

--- a/libs/frontend/domain/type/src/use-cases/fields/create-field/CreateFieldModal.tsx
+++ b/libs/frontend/domain/type/src/use-cases/fields/create-field/CreateFieldModal.tsx
@@ -12,11 +12,11 @@ import { SelectDefaultValue } from '../../../interface-form'
 import { TypeSelect } from '../../../shared'
 import { createFieldSchema } from './create-field.schema'
 import {
+  canSetDefaultValue,
   filterValidationRules,
   isBoolean,
   isFloat,
   isInteger,
-  isInterfaceType,
   isPrimitive,
   isString,
 } from './field-utils'
@@ -71,7 +71,8 @@ export const CreateFieldModal = observer(() => {
         <TypeSelect label="Type" name="fieldType" />
         <DisplayIfField<ICreateFieldData>
           condition={({ model }) =>
-            Boolean(model.fieldType) && !isBoolean(typeService, model.fieldType)
+            !isBoolean(typeService, model.fieldType) &&
+            canSetDefaultValue(typeService, model.fieldType)
           }
         >
           <AutoFields fields={['validationRules.general']} />
@@ -103,7 +104,7 @@ export const CreateFieldModal = observer(() => {
         </DisplayIfField>
         <DisplayIfField<ICreateFieldData>
           condition={({ model }) =>
-            !isInterfaceType(typeService, model.fieldType)
+            canSetDefaultValue(typeService, model.fieldType)
           }
         >
           <SelectDefaultValue typeService={typeService} />

--- a/libs/frontend/domain/type/src/use-cases/fields/create-field/CreateFieldModal.tsx
+++ b/libs/frontend/domain/type/src/use-cases/fields/create-field/CreateFieldModal.tsx
@@ -52,6 +52,26 @@ export const CreateFieldModal = observer(() => {
           id: v4(),
           interfaceTypeId,
         }}
+        modelTransform={(mode, model) => {
+          // This automatically sets the `defaultValue` to be nullable for types
+          // where we dont set a default value like ReactNodeType, InterfaceType
+          if (
+            mode === 'form' &&
+            model.fieldType &&
+            !canSetDefaultValue(typeService, model.fieldType)
+          ) {
+            return {
+              ...model,
+              validationRules: {
+                general: {
+                  nullable: true,
+                },
+              },
+            }
+          }
+
+          return model
+        }}
         onSubmit={onSubmit}
         onSubmitError={createNotificationHandler({
           title: 'Error while creating field',

--- a/libs/frontend/domain/type/src/use-cases/fields/create-field/field-utils.ts
+++ b/libs/frontend/domain/type/src/use-cases/fields/create-field/field-utils.ts
@@ -45,9 +45,11 @@ export const isInteger: FieldCondition = (typeService, fieldType) =>
       typeService.primitiveKind(fieldType) === IPrimitiveTypeKind.Integer,
   )
 
-export const isInterfaceType: FieldCondition = (typeService, fieldType) =>
+export const canSetDefaultValue: FieldCondition = (typeService, fieldType) =>
   Boolean(
-    fieldType && typeService.type(fieldType)?.kind === ITypeKind.InterfaceType,
+    fieldType &&
+      typeService.type(fieldType)?.kind !== ITypeKind.InterfaceType &&
+      typeService.type(fieldType)?.kind !== ITypeKind.ReactNodeType,
   )
 
 export const isFloat: FieldCondition = (typeService, fieldType) =>

--- a/libs/frontend/domain/type/src/use-cases/fields/update-field/UpdateFieldModal.tsx
+++ b/libs/frontend/domain/type/src/use-cases/fields/update-field/UpdateFieldModal.tsx
@@ -10,11 +10,12 @@ import { AutoFields } from 'uniforms-antd'
 import { SelectDefaultValue } from '../../../interface-form'
 import { TypeSelect } from '../../../shared'
 import {
+  canSetDefaultValue,
   createFieldSchema,
   filterValidationRules,
+  isBoolean,
   isFloat,
   isInteger,
-  isInterfaceType,
   isPrimitive,
   isString,
 } from '../create-field'
@@ -66,7 +67,14 @@ export const UpdateFieldModal = observer(() => {
       >
         <AutoFields fields={['key', 'name', 'description']} />
         <TypeSelect label="Type" name="fieldType" />
-        <AutoFields fields={['validationRules.general']} />
+        <DisplayIfField<IUpdateFieldData>
+          condition={({ model }) =>
+            !isBoolean(typeService, model.fieldType) &&
+            canSetDefaultValue(typeService, model.fieldType)
+          }
+        >
+          <AutoFields fields={['validationRules.general']} />
+        </DisplayIfField>
         <DisplayIfField<IUpdateFieldData>
           condition={({ model }) => isPrimitive(typeService, model.fieldType)}
         >
@@ -95,7 +103,7 @@ export const UpdateFieldModal = observer(() => {
 
         <DisplayIfField<IUpdateFieldData>
           condition={({ model }) =>
-            !isInterfaceType(typeService, model.fieldType)
+            canSetDefaultValue(typeService, model.fieldType)
           }
         >
           <SelectDefaultValue typeService={typeService} />

--- a/libs/frontend/domain/type/src/use-cases/fields/update-field/UpdateFieldModal.tsx
+++ b/libs/frontend/domain/type/src/use-cases/fields/update-field/UpdateFieldModal.tsx
@@ -57,6 +57,26 @@ export const UpdateFieldModal = observer(() => {
           name: field?.name,
           validationRules: field?.validationRules,
         }}
+        modelTransform={(mode, model) => {
+          // This automatically sets the `defaultValue` to be nullable for types
+          // where we dont set a default value like ReactNodeType, InterfaceType
+          if (
+            mode === 'form' &&
+            model.fieldType &&
+            !canSetDefaultValue(typeService, model.fieldType)
+          ) {
+            return {
+              ...model,
+              validationRules: {
+                general: {
+                  nullable: true,
+                },
+              },
+            }
+          }
+
+          return model
+        }}
         onSubmit={onSubmit}
         onSubmitError={createNotificationHandler({
           title: 'Error while updating field',

--- a/libs/frontend/view/components/form/components/Form.tsx
+++ b/libs/frontend/view/components/form/components/Form.tsx
@@ -19,6 +19,7 @@ export const withAutoForm = (AutoForm: typeof BaseAutoForm) => {
     children,
     cssString,
     model,
+    modelTransform,
     onChange,
     onChangeModel,
     onSubmit = (_model: TData) => Promise.resolve(),
@@ -62,6 +63,7 @@ export const withAutoForm = (AutoForm: typeof BaseAutoForm) => {
           autosave={autosave}
           autosaveDelay={500}
           model={autosave ? modelRef.current : model}
+          modelTransform={modelTransform}
           onChange={onChange}
           onChangeModel={onChangeModel}
           onSubmit={(formData) => {

--- a/libs/frontend/view/components/form/modal/ModalForm.Form.tsx
+++ b/libs/frontend/view/components/form/modal/ModalForm.Form.tsx
@@ -18,6 +18,7 @@ export const Form = <TData, TResponse = unknown>({
   autosave = false,
   children,
   model,
+  modelTransform,
   onChange,
   onChangeModel,
   onSubmit = (_model: unknown) => Promise.resolve(),
@@ -42,6 +43,7 @@ export const Form = <TData, TResponse = unknown>({
       autosave={autosave}
       autosaveDelay={500}
       model={model}
+      modelTransform={modelTransform}
       onChange={onChange}
       onChangeModel={onChangeModel}
       onSubmit={handleFormSubmit<TData, TResponse>(


### PR DESCRIPTION
<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(libs-ui-component): must begin with lowercase` -->

## Description

<!-- This is a short description on the Pull Request -->
- fixed `defaultValues` for UnionType so it will initially set the first of its types as the default
- hide the `nullable` option and the `defaultValues` field if field type is ReactNodeType or InterfaceType since we cannot set a default value for it

## Video or Image

<!-- Add video or image showing how the new feature works -->

https://user-images.githubusercontent.com/27695022/231506074-a9350b79-f8b5-4056-b566-1462a69c1e14.mp4


## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged -->

Fixes #2459 
