### PR TITLE
feat: support import and export of union types

### DIFF
--- a/data/export/admin/atoms/AntDesignAvatar.json
+++ b/data/export/admin/atoms/AntDesignAvatar.json
@@ -201,13 +201,13 @@
       "key": "src",
       "name": "Src",
       "description": null,
-      "validationRules": null,
-      "defaultValues": null,
+      "validationRules": "{}",
+      "defaultValues": "{\"type\":\"3a0d0fc6-c51e-4f05-85b4-cde709fe5625\"}",
       "fieldType": {
-        "__typename": "EnumType",
-        "id": "e5d234f7-9ac2-47cb-9a1c-60e8c75bd16e",
-        "kind": "EnumType",
-        "name": "AntDesignAvatar Src Enum"
+        "__typename": "UnionType",
+        "id": "e1489c1e-c897-400b-8806-d22320a01bf7",
+        "kind": "UnionType",
+        "name": "AntDesignAvatar Src Union"
       },
       "api": {
         "id": "b97d5258-936f-4396-81d4-c3acefe05cd1"
@@ -330,20 +330,26 @@
       ]
     },
     {
-      "__typename": "EnumType",
-      "id": "e5d234f7-9ac2-47cb-9a1c-60e8c75bd16e",
-      "kind": "EnumType",
-      "name": "AntDesignAvatar Src Enum",
-      "allowedValues": [
+      "__typename": "UnionType",
+      "id": "e1489c1e-c897-400b-8806-d22320a01bf7",
+      "kind": "UnionType",
+      "name": "AntDesignAvatar Src Union",
+      "descendantTypesIds": [
+        "7333edde-f8f5-4d3c-a595-01b5585b37da",
+        "3a0d0fc6-c51e-4f05-85b4-cde709fe5625"
+      ],
+      "typesOfUnionType": [
         {
-          "id": "e9e6470d-64ac-49c9-9ddf-2744e4f1b831",
-          "key": "ReactNode",
-          "value": "ReactNode"
+          "__typename": "PrimitiveType",
+          "id": "3a0d0fc6-c51e-4f05-85b4-cde709fe5625",
+          "kind": "PrimitiveType",
+          "name": "String"
         },
         {
-          "id": "2fd3fd9d-fb90-4f31-9f45-26a1254516e4",
-          "key": "string",
-          "value": "string"
+          "__typename": "ReactNodeType",
+          "id": "7333edde-f8f5-4d3c-a595-01b5585b37da",
+          "kind": "ReactNodeType",
+          "name": "ReactNodeType"
         }
       ]
     }

--- a/libs/backend/application/admin/src/use-case/export-admin-data.service.ts
+++ b/libs/backend/application/admin/src/use-case/export-admin-data.service.ts
@@ -101,6 +101,7 @@ export class ExportAdminDataService extends IUseCase<
         const apiFields = filter(apis.fields, { api: { id: atom.api.id } })
 
         const { fields = [], types } = await exportAdminTypes({
+          apiFields,
           apiId: atom.api.id,
         })
 

--- a/libs/backend/application/type/src/use-case/export-admin-types.ts
+++ b/libs/backend/application/type/src/use-case/export-admin-types.ts
@@ -4,8 +4,10 @@ import {
   exportEnumTypeSelectionSet,
   exportFieldSelectionSet,
   exportInterfaceTypeSelectionSet,
+  exportUnionTypeSelectionSet,
   Repository,
 } from '@codelab/backend/infra/adapter/neo4j'
+import type { IFieldDTO } from '@codelab/frontend/abstract/core'
 import { OGM_TYPES } from '@codelab/shared/abstract/codegen'
 import { sortInterfaceTypesFields } from '../mapper/sort'
 
@@ -13,6 +15,7 @@ import { sortInterfaceTypesFields } from '../mapper/sort'
  * Allows us to get only types for an api
  */
 interface ExportAdminTypesProps {
+  apiFields?: Array<IFieldDTO>
   apiId?: string
 }
 
@@ -28,6 +31,20 @@ export const exportAdminTypes = async (
   const InterfaceType = await Repository.instance.InterfaceType
   const Field = await Repository.instance.Field
   const Array = await Repository.instance.ArrayType
+  const UnionType = await Repository.instance.UnionType
+
+  /**
+   * UnionTypes
+   */
+  const unionTypes = await UnionType.find({
+    options: {
+      sort: [{ name: OGM_TYPES.SortDirection.Asc }],
+    },
+    selectionSet: exportUnionTypeSelectionSet,
+    where: {
+      id_IN: props.apiFields?.map((field) => field.fieldType.id),
+    },
+  })
 
   /**
    * Array
@@ -187,6 +204,7 @@ export const exportAdminTypes = async (
       ...secondLevelInterfaceTypes,
       ...arrayInterfaceItemTypes,
       ...arrayTypes,
+      ...unionTypes,
     ],
   }
 }

--- a/libs/backend/domain/type/src/repository/union-type.repo.ts
+++ b/libs/backend/domain/type/src/repository/union-type.repo.ts
@@ -32,18 +32,22 @@ export class UnionTypeRepository extends AbstractRepository<
         await this.UnionType
       ).create({
         input: unionTypes.map(
-          ({ __typename, owner, typesOfUnionType, ...type }) => ({
-            ...type,
-            owner: connectAuth0Owner(owner),
-            typesOfUnionType: {
-              ArrayType: connectNodeIds([]),
-              EnumType: connectNodeIds([]),
-              InterfaceType: connectNodeIds([]),
-              PrimitiveType: connectNodeIds([]),
-              ReactNodeType: connectNodeIds([]),
-              RenderPropsType: connectNodeIds([]),
-            },
-          }),
+          ({ __typename, owner, typesOfUnionType, ...type }) => {
+            const connectIds = typesOfUnionType.map(({ id }) => id)
+
+            return {
+              ...type,
+              owner: connectAuth0Owner(owner),
+              typesOfUnionType: {
+                ArrayType: connectNodeIds(connectIds),
+                EnumType: connectNodeIds(connectIds),
+                InterfaceType: connectNodeIds(connectIds),
+                PrimitiveType: connectNodeIds(connectIds),
+                ReactNodeType: connectNodeIds(connectIds),
+                RenderPropsType: connectNodeIds(connectIds),
+              },
+            }
+          },
         ),
         selectionSet: `{ unionTypes ${exportUnionTypeSelectionSet} }`,
       })
@@ -51,9 +55,11 @@ export class UnionTypeRepository extends AbstractRepository<
   }
 
   protected async _update(
-    { __typename, id, kind, name, owner, typesOfUnionType }: IUnionTypeDTO,
+    { id, name, typesOfUnionType }: IUnionTypeDTO,
     where: OGM_TYPES.UnionTypeWhere,
   ) {
+    const connectIds = typesOfUnionType.map(({ id: typeId }) => typeId)
+
     return (
       await (
         await this.UnionType
@@ -63,12 +69,12 @@ export class UnionTypeRepository extends AbstractRepository<
           id,
           name,
           typesOfUnionType: {
-            ArrayType: [connectNodeIds([])],
-            EnumType: [connectNodeIds([])],
-            InterfaceType: [connectNodeIds([])],
-            PrimitiveType: [connectNodeIds([])],
-            ReactNodeType: [connectNodeIds([])],
-            RenderPropsType: [connectNodeIds([])],
+            ArrayType: [connectNodeIds(connectIds)],
+            EnumType: [connectNodeIds(connectIds)],
+            InterfaceType: [connectNodeIds(connectIds)],
+            PrimitiveType: [connectNodeIds(connectIds)],
+            ReactNodeType: [connectNodeIds(connectIds)],
+            RenderPropsType: [connectNodeIds(connectIds)],
           },
         },
         where,

--- a/libs/backend/infra/adapter/neo4j/src/selectionSet/typeSelectionSet.ts
+++ b/libs/backend/infra/adapter/neo4j/src/selectionSet/typeSelectionSet.ts
@@ -64,6 +64,11 @@ export const exportInterfaceTypeSelectionSet = `{
 export const exportUnionTypeSelectionSet = `{
   ${exportBaseTypeSelection}
   descendantTypesIds
+  typesOfUnionType {
+    ... on IBaseType {
+      ${exportBaseTypeSelection}
+    }
+  }
 }`
 
 export const interfaceTypeSelectionSet = `{


### PR DESCRIPTION
<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(libs-ui-component): must begin with lowercase` -->

## Description

<!-- This is a short description on the Pull Request -->
- includes union types fields when exporting the atoms
- fixed selection set for union types so that `typesOfUnionType` is included which is needed for importing the union type fields
- fixed connecting of nodes for the `typesOfUnionType` ids when importing
- fixed src field of AntDesignAvatar so that it is a union type of String and ReactNode

## Video or Image

<!-- Add video or image showing how the new feature works -->

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged -->

Fixes #2466 
