### PR TITLE
refactor: remove duplicated data load in builder

### DIFF
--- a/libs/frontend/abstract/core/src/domain/app/app.dto.interface.ts
+++ b/libs/frontend/abstract/core/src/domain/app/app.dto.interface.ts
@@ -1,7 +1,7 @@
 import type { IEntity } from '@codelab/shared/abstract/types'
 import type { RenderedComponentFragment } from '../component/component-render.fragment.graphql.gen'
+import type { BuilderPageFragment } from '../page/page.fragment.graphql.gen'
 import type { IOwnerSchema } from '../user'
-import type { PageBuilderAppFragment } from './app.fragment.graphql.gen'
 
 export interface IAppDTO extends IOwnerSchema {
   domains?: Array<IEntity>
@@ -18,7 +18,6 @@ export type IUpdateAppData = Pick<IAppDTO, 'id' | 'name'>
  * Data required to initialize a page builder app
  */
 export interface IPageBuilderAppProps {
-  appData: PageBuilderAppFragment
-  components: Array<RenderedComponentFragment>
-  pageId: string
+  components?: Array<RenderedComponentFragment>
+  pages: Array<BuilderPageFragment>
 }

--- a/libs/frontend/abstract/core/src/domain/app/app.service.interface.ts
+++ b/libs/frontend/abstract/core/src/domain/app/app.service.interface.ts
@@ -18,7 +18,7 @@ import type {
   IPageBuilderAppProps,
   IUpdateAppData,
 } from './app.dto.interface'
-import type { IApp, IBuilderApp } from './app.model.interface'
+import type { IApp } from './app.model.interface'
 
 export interface IAppService
   extends ICRUDService<IApp, ICreateAppData, IUpdateAppData>,
@@ -36,6 +36,7 @@ export interface IAppService
     pageId: string,
     initialData?: GetRenderedPageAndCommonAppDataQuery,
   ): Promise<IApp | undefined>
+  lazyGetRemainingPages(appId: string): Promise<void>
   loadAppsWithNestedPreviews(where: AppWhere): Promise<Array<IApp>>
-  loadPages(data: IPageBuilderAppProps): IBuilderApp
+  loadPages(data: IPageBuilderAppProps): void
 }

--- a/libs/frontend/domain/builder/src/sections/content/BuilderTabs.tsx
+++ b/libs/frontend/domain/builder/src/sections/content/BuilderTabs.tsx
@@ -1,4 +1,4 @@
-import type { IApp, IPage, IRenderer } from '@codelab/frontend/abstract/core'
+import type { IPage, IRenderer } from '@codelab/frontend/abstract/core'
 import { RendererTab } from '@codelab/frontend/abstract/core'
 import { useStore } from '@codelab/frontend/presenter/container'
 import { extractErrorMessage } from '@codelab/frontend/shared/utils'
@@ -11,7 +11,6 @@ import { BaseBuilder } from './BaseBuilder'
 import { BuilderComponent } from './Builder-Component'
 
 export interface BuilderTabsProps {
-  app: Maybe<IApp>
   error: Nullish<string>
   isLoading: boolean
   page: Maybe<IPage>
@@ -19,7 +18,7 @@ export interface BuilderTabsProps {
 }
 
 export const BuilderTabs = observer<BuilderTabsProps>(
-  ({ app, error, isLoading, page, renderer }) => {
+  ({ error, isLoading, page, renderer }) => {
     const { builderService } = useStore()
     const store = page?.store.current
 

--- a/libs/frontend/domain/page/src/view/PageDetailHeader.tsx
+++ b/libs/frontend/domain/page/src/view/PageDetailHeader.tsx
@@ -16,12 +16,11 @@ import {
   useCurrentPageId,
   useStore,
 } from '@codelab/frontend/presenter/container'
-import { useAsync } from '@react-hookz/web'
 import { InputNumber, Menu, Space } from 'antd'
 import type { ItemType } from 'antd/lib/menu/hooks/useItems'
 import { observer } from 'mobx-react-lite'
 import { useRouter } from 'next/router'
-import React, { useCallback, useEffect, useState } from 'react'
+import React, { useCallback, useState } from 'react'
 import tw from 'twin.macro'
 
 export type MenuItemProps = ItemType & {
@@ -33,15 +32,6 @@ export const PageDetailHeader = observer(() => {
   const router = useRouter()
   const appId = useCurrentAppId()
   const pageId = useCurrentPageId()
-
-  const getPages = useAsync(() =>
-    pageService.getAll({ appConnection: { node: { id: appId } } }),
-  )[1]
-
-  useEffect(() => {
-    void getPages.execute()
-  }, [appId])
-
   const pagesList = pageService.pagesByApp(appId)
   const currentPage = pagesList.find((page) => page.id === pageId)
   const isBuilder = router.pathname === PageType.PageBuilder

--- a/libs/frontend/presenter/container/src/pageHooks/index.ts
+++ b/libs/frontend/presenter/container/src/pageHooks/index.ts
@@ -1,1 +1,2 @@
+export * from './useRemainingPages'
 export * from './useRenderedPage'

--- a/libs/frontend/presenter/container/src/pageHooks/useRemainingPages.ts
+++ b/libs/frontend/presenter/container/src/pageHooks/useRemainingPages.ts
@@ -1,0 +1,33 @@
+import { RendererType } from '@codelab/frontend/abstract/core'
+import { useAsync } from '@react-hookz/web'
+import { useStore } from '../providers'
+import { useCurrentAppId } from '../routerHooks'
+
+/**
+ * Fetch and load the remaining app pages (that currently were not loaded from server)
+ */
+export const useRemainingPages = () => {
+  const { appService, builderRenderService } = useStore()
+  const appId = useCurrentAppId()
+  const app = appService.app(appId)!
+
+  return useAsync(async () => {
+    await appService.lazyGetRemainingPages(appId)
+
+    await Promise.all([
+      app.pages.map(async (pageRef) => {
+        const page = pageRef.current
+        const rendererExists = builderRenderService.renderers.has(page.id)
+
+        if (!rendererExists) {
+          await builderRenderService.addRenderer({
+            elementTree: page,
+            id: page.id,
+            providerTree: app.providerPage,
+            rendererType: RendererType.PageBuilder,
+          })
+        }
+      }),
+    ])
+  })
+}


### PR DESCRIPTION
<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(libs-ui-component): must begin with lowercase` -->

## Description

Suppose we have an app with 5 pages:
- Main
- Secondary
- _app
- 404
- 500

When builder is opened (`apps/{appId}/pages/${pageId}/builder`) two requests are performed:
- request to load the current page and system pages (Main, _app, 404, 500) and all related data: components, interfaces, and other types. The response is cached to the store. No problem with this request.
- request to load all the pages for the current app (Main, Secondary, _app, 404, 500), even though Main, _app, 404, 500 are already loaded by the first request. This request is sent from the `PageDetailHeader` component to display all pages and allow users to switch between them. There are 2 problems with this request: it loads duplicated data; and it DOES NOT CACHE response. So when the user switches to another page from that dropdown - again these two requests will be executed even though all data was already requested by the client.
<img width="872" alt="Screenshot 2023-04-13 at 09 54 58" src="https://user-images.githubusercontent.com/74900868/231692905-3066ca62-0e92-47f7-ae86-863d9ce9f103.png">


As a fix - the second request was updated to load only information that does not exist on the client as well as to cache the response. After the fix, no duplicated data is transferred to the client as well as the user is able to switch between pages instantly, without any requests. See the result below:


https://user-images.githubusercontent.com/74900868/231694019-35287ee6-e560-4a2f-a183-bf108e29b611.mov



## Related Issue(s)

Fixes #2215 
