### PR TITLE
fix: move element to another tree crashes the builder

### DIFF
--- a/libs/frontend/abstract/core/src/domain/element/element.service.interface.ts
+++ b/libs/frontend/abstract/core/src/domain/element/element.service.interface.ts
@@ -83,9 +83,11 @@ export interface IElementService
     element: IEntity
     targetElement: IEntity
   }): Promise<void>
+  /**
+   * @param props.object an element or a component
+   */
   moveObjectToAnotherTree(props: {
     dropPosition: number
-    // an element or a component
     object: IEntity
     targetElement: IEntity
   }): Promise<void>

--- a/libs/frontend/abstract/core/src/domain/element/element.service.interface.ts
+++ b/libs/frontend/abstract/core/src/domain/element/element.service.interface.ts
@@ -83,9 +83,10 @@ export interface IElementService
     element: IEntity
     targetElement: IEntity
   }): Promise<void>
-  moveElementToAnotherTree(props: {
+  moveObjectToAnotherTree(props: {
     dropPosition: number
-    element: IEntity
+    // an element or a component
+    object: IEntity
     targetElement: IEntity
   }): Promise<void>
 }

--- a/libs/frontend/abstract/core/src/domain/element/element.service.interface.ts
+++ b/libs/frontend/abstract/core/src/domain/element/element.service.interface.ts
@@ -86,7 +86,7 @@ export interface IElementService
   /**
    * @param props.object an element or a component
    */
-  moveObjectToAnotherTree(props: {
+  moveNodeToAnotherTree(props: {
     dropPosition: number
     object: IEntity
     targetElement: IEntity

--- a/libs/frontend/domain/builder/src/hooks/useElementTreeDrop/useElementTreeDrop.ts
+++ b/libs/frontend/domain/builder/src/hooks/useElementTreeDrop/useElementTreeDrop.ts
@@ -38,9 +38,9 @@ export const useElementTreeDrop = (elementService: IElementService) => {
         return
       }
 
-      void elementService.moveElementToAnotherTree({
+      void elementService.moveObjectToAnotherTree({
         dropPosition: info.dropPosition,
-        element: dragElement,
+        object: dragElement,
         targetElement: dropElement,
       })
 

--- a/libs/frontend/domain/builder/src/hooks/useElementTreeDrop/useElementTreeDrop.ts
+++ b/libs/frontend/domain/builder/src/hooks/useElementTreeDrop/useElementTreeDrop.ts
@@ -38,7 +38,7 @@ export const useElementTreeDrop = (elementService: IElementService) => {
         return
       }
 
-      void elementService.moveObjectToAnotherTree({
+      void elementService.moveNodeToAnotherTree({
         dropPosition: info.dropPosition,
         object: dragElement,
         targetElement: dropElement,

--- a/libs/frontend/domain/element/src/store/element.service.ts
+++ b/libs/frontend/domain/element/src/store/element.service.ts
@@ -15,6 +15,7 @@ import {
   isComponentInstance,
 } from '@codelab/frontend/abstract/core'
 import { getAtomService } from '@codelab/frontend/domain/atom'
+import { Component } from '@codelab/frontend/domain/component'
 import { getPropService } from '@codelab/frontend/domain/prop'
 import { getTypeService, InterfaceType } from '@codelab/frontend/domain/type'
 import {
@@ -517,6 +518,21 @@ export class ElementService
     const existingInstances = elementTree.elements.filter(
       ({ renderType }) => renderType?.id === component.id,
     )
+
+    /**
+     * Check if there is circular referance
+     */
+    const componentDescendants = component.descendantComponents
+
+    if (
+      elementTree instanceof Component &&
+      componentDescendants.includes(elementTree)
+    ) {
+      throw new Error(
+        `Cannot move ${component.name} into ${targetElement.name} because of a circular reference between ${component.name} and ${elementTree.name}
+        `,
+      )
+    }
 
     /**
      * Create a new element as an instance of the component

--- a/libs/frontend/domain/element/src/store/element.service.ts
+++ b/libs/frontend/domain/element/src/store/element.service.ts
@@ -574,13 +574,13 @@ export class ElementService
 
   @modelFlow
   @transaction
-  moveObjectToAnotherTree = _async(function* (
+  moveNodeToAnotherTree = _async(function* (
     this: ElementService,
     {
       dropPosition,
       object: { id: objectId },
       targetElement: { id: targetElementId },
-    }: Parameters<IElementService['moveObjectToAnotherTree']>[0],
+    }: Parameters<IElementService['moveNodeToAnotherTree']>[0],
   ) {
     const targetElement = this.element(targetElementId)
     const element = this.maybeElement(objectId)


### PR DESCRIPTION
## Description

The issue stems from pushing partial updates to the backend. more specifically, we used to detach the elements from their current tree, push updates, then attach to the new tree. and it seems like mobx tried to recalculate the value of `closestContainerNode` while we're pushing the updates, which causes the crash.

Instead we can perform all the actions on the local cache: detaching from current tree and attaching to the new tree, then push the changes to the backend.

On a separate note, the logic of `moveElementToAnotherTree` seemed quite complicated because it tries to perform one of two things: either move an element to another tree, or create a new element in the other tree as an instance of the component. hence, I renamed it to `moveNodeToAnotherTree` and made it call another method based on what will be performed: `moveElementToAnotherTree` or `moveComponentToAnotherTree`

TODO: 

- [x] fix builder crashes when moving element to another tree
- [x] prevent circular reference when drag/dropping a component to another.

## Video or Image

https://user-images.githubusercontent.com/51242349/231723971-d424af48-4e7c-48d9-93d5-100f349b0dab.mp4

https://user-images.githubusercontent.com/51242349/231737427-703750a4-beb0-477d-bd0b-3bdb5f85da8e.mp4

## Related Issue(s)

Fixes #2465
