### PR TITLE
fix: crash when element has react node prop

### DIFF
--- a/libs/frontend/view/components/codeMirror/completionOptions.ts
+++ b/libs/frontend/view/components/codeMirror/completionOptions.ts
@@ -4,23 +4,33 @@ import capitalize from 'lodash/capitalize'
 import isArray from 'lodash/isArray'
 import isElement from 'lodash/isElement'
 import isObjectLike from 'lodash/isObjectLike'
+import { modelTypeKey } from 'mobx-keystone'
+
+const isReactNode = (obj?: IPropData) => Boolean(obj?.['$$typeof'])
+const isMobxModel = (obj?: IPropData) => Boolean(obj?.[modelTypeKey])
+const isHtmlNode = (obj: unknown) => obj instanceof HTMLElement
+
+const isCyclic = (obj?: IPropData) =>
+  (isObjectLike(obj) && isReactNode(obj)) || isMobxModel(obj) || isHtmlNode(obj)
 
 // for making autocomplete of code mirror
 export const createAutoCompleteOptions = (
   context: IPropData = {},
   parentKey = '',
-): Array<Completion> =>
-  Object.entries(context).flatMap(([key, value]) => {
+): Array<Completion> => {
+  return Object.entries(context).flatMap(([key, value]) => {
     const option = {
       detail: capitalize(typeof value),
       label: parentKey ? `${parentKey}.${key}` : key,
       type: typeof value == 'function' ? 'function' : 'variable',
     }
 
+    if (isCyclic(value)) {
+      return [option]
+    }
+
     if (isArray(value)) {
-      // [item1, item2 ...] = value
       const children = value.flatMap((_value, index) =>
-        // [...autoComplete of item1 [option1,2...], ...autoComplete of item2, ...]
         createAutoCompleteOptions(_value, `${key}.${index}`),
       )
 
@@ -33,3 +43,4 @@ export const createAutoCompleteOptions = (
 
     return [option]
   })
+}


### PR DESCRIPTION
<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(libs-ui-component): must begin with lowercase` -->

## Description

<!-- This is a short description on the Pull Request -->
It seems its because when the react node prop is transformed to an actual ReactNode then we try to build the autocomplete options thats used for fields like **"Render If"**, it was trying to get all the properties of the transformed ReactNode.

We need another condition on the generating of auto complete options to stop when it is a ReactNode. This PR uses the same logic from the [mapDeep](https://github.com/codelab-app/platform/blob/3244eb84af4b70be0dbb890c32dab749c633b6d5/libs/shared/utils/src/mapDeep/mapDeep.ts)

## Video or Image

<!-- Add video or image showing how the new feature works -->


https://user-images.githubusercontent.com/27695022/231777585-8d7d2f85-1e63-4f56-a844-422c9d35c997.mp4



## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged -->

Fixes #2469 
