### PR TITLE
refactor: make page load function more reusable

### DIFF
--- a/libs/frontend/abstract/core/src/domain/app/app.service.interface.ts
+++ b/libs/frontend/abstract/core/src/domain/app/app.service.interface.ts
@@ -2,6 +2,7 @@ import type {
   AppOptions,
   AppWhere,
   GetRenderedPageAndCommonAppDataQuery,
+  PageWhere,
 } from '@codelab/shared/abstract/codegen'
 import type { Maybe } from '@codelab/shared/abstract/types'
 import type { ObjectMap, Ref } from 'mobx-keystone'
@@ -31,12 +32,12 @@ export interface IAppService
 
   add(appDto: IAppDTO): IApp
   app(id: string): Maybe<IApp>
+  getAppPages(appId: string, where: PageWhere): Promise<void>
   getRenderedPageAndCommonAppData(
     appId: string,
     pageId: string,
     initialData?: GetRenderedPageAndCommonAppDataQuery,
   ): Promise<IApp | undefined>
-  lazyGetRemainingPages(appId: string): Promise<void>
   loadAppsWithNestedPreviews(where: AppWhere): Promise<Array<IApp>>
   loadPages(data: IPageBuilderAppProps): void
 }

--- a/libs/frontend/presenter/container/src/pageHooks/useRemainingPages.ts
+++ b/libs/frontend/presenter/container/src/pageHooks/useRemainingPages.ts
@@ -12,7 +12,13 @@ export const useRemainingPages = () => {
   const app = appService.app(appId)!
 
   return useAsync(async () => {
-    await appService.lazyGetRemainingPages(appId)
+    const notAlreadyLoadedPages = app.pages
+      .map((page) => page.current.id)
+      .map((id) => ({ NOT: { id } }))
+
+    await appService.getAppPages(appId, {
+      AND: notAlreadyLoadedPages,
+    })
 
     await Promise.all([
       app.pages.map(async (pageRef) => {


### PR DESCRIPTION
<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(libs-ui-component): must begin with lowercase` -->

## Description
Replace `lazyGetRemainingPages` with a more general function `getAppPages` to load pages by any condition
<!-- This is a short description on the Pull Request -->
