### PR TITLE
refactor: atoms and types dropdown

### DIFF
--- a/apps/platform-e2e/src/support/builder/builder.command.ts
+++ b/apps/platform-e2e/src/support/builder/builder.command.ts
@@ -14,7 +14,7 @@ export const createElementTree = (elements: Array<ElementData>) => {
     cy.getSider()
       .find('.ant-page-header-heading')
       .getButton({ icon: 'plus' })
-      .click()
+      .click({ force: true })
 
     /**
      * We skip this if parent element is root, since it is disabled and can't be accessed

--- a/libs/frontend/abstract/core/src/domain/atom/atom.repo.interface.ts
+++ b/libs/frontend/abstract/core/src/domain/atom/atom.repo.interface.ts
@@ -3,4 +3,6 @@ import type { IEntity } from '@codelab/shared/abstract/types'
 import type { IRepository } from '../../service'
 import type { IAtom } from './atom.model.interface'
 
-export type IAtomRepository = IRepository<IAtom, IEntity, AtomWhere>
+export type IAtomRepository = IRepository<IAtom, IEntity, AtomWhere> & {
+  findOptions(): Promise<Array<Pick<IAtom, 'id' | 'name' | 'type'>>>
+}

--- a/libs/frontend/abstract/core/src/domain/atom/atom.service.interface.ts
+++ b/libs/frontend/abstract/core/src/domain/atom/atom.service.interface.ts
@@ -35,4 +35,5 @@ export interface IAtomService
 
   add(atomDTO: IAtomDTO): IAtom
   delete(ids: Array<string>): Promise<number>
+  getOptions(): Promise<Array<Pick<IAtom, 'id' | 'name' | 'type'>>>
 }

--- a/libs/frontend/abstract/core/src/domain/type/type.repo.interface.ts
+++ b/libs/frontend/abstract/core/src/domain/type/type.repo.interface.ts
@@ -19,4 +19,7 @@ export type ITypeRepository = IRepository<
     items: Array<BaseType_BaseType_Fragment>
     totalCount: number
   }>
+  findOptions(): Promise<
+    Array<Pick<BaseType_BaseType_Fragment, 'id' | 'kind' | 'name'>>
+  >
 }

--- a/libs/frontend/abstract/core/src/domain/type/type.service.interface.ts
+++ b/libs/frontend/abstract/core/src/domain/type/type.service.interface.ts
@@ -2,6 +2,7 @@ import type {
   BaseTypeOptions,
   BaseTypeWhere,
   GetTypesQuery,
+  IBaseType,
 } from '@codelab/shared/abstract/codegen'
 import type { IPrimitiveTypeKind } from '@codelab/shared/abstract/core'
 import type { Maybe, Nullable } from '@codelab/shared/abstract/types'
@@ -33,6 +34,7 @@ export interface ITypeService
   addInterface(data: ICreateTypeData): IInterfaceType
   getAll(ids?: Array<string>): Promise<Array<IType>>
   getInterface(id: IInterfaceTypeRef): Promise<IInterfaceType>
+  getOptions(): Promise<Array<Pick<IBaseType, 'id' | 'kind' | 'name'>>>
   loadTypes(types: Partial<GetTypesQuery>): Array<IType>
   primitiveKind(id: string): Nullable<IPrimitiveTypeKind>
   type(id: string): Maybe<IType>

--- a/libs/frontend/domain/atom/src/graphql/atom.endpoints.graphql
+++ b/libs/frontend/domain/atom/src/graphql/atom.endpoints.graphql
@@ -26,6 +26,14 @@ query GetAtoms($where: AtomWhere, $options: AtomOptions) {
   }
 }
 
+query GetAtomOptions {
+  atoms {
+    id
+    name
+    type
+  }
+}
+
 mutation UpdateAtoms($where: AtomWhere, $update: AtomUpdateInput) {
   updateAtoms(update: $update, where: $where) {
     atoms {

--- a/libs/frontend/domain/atom/src/graphql/atom.endpoints.graphql.gen.ts
+++ b/libs/frontend/domain/atom/src/graphql/atom.endpoints.graphql.gen.ts
@@ -34,6 +34,12 @@ export type GetAtomsQuery = {
   atoms: Array<AtomFragment>
 }
 
+export type GetAtomOptionsQueryVariables = Types.Exact<{ [key: string]: never }>
+
+export type GetAtomOptionsQuery = {
+  atoms: Array<{ id: string; name: string; type: Types.AtomType }>
+}
+
 export type UpdateAtomsMutationVariables = Types.Exact<{
   where?: Types.InputMaybe<Types.AtomWhere>
   update?: Types.InputMaybe<Types.AtomUpdateInput>
@@ -74,6 +80,15 @@ export const GetAtomsDocument = gql`
     }
   }
   ${AtomFragmentDoc}
+`
+export const GetAtomOptionsDocument = gql`
+  query GetAtomOptions {
+    atoms {
+      id
+      name
+      type
+    }
+  }
 `
 export const UpdateAtomsDocument = gql`
   mutation UpdateAtoms($where: AtomWhere, $update: AtomUpdateInput) {
@@ -141,6 +156,21 @@ export function getSdk(
             ...wrappedRequestHeaders,
           }),
         'GetAtoms',
+        'query',
+      )
+    },
+    GetAtomOptions(
+      variables?: GetAtomOptionsQueryVariables,
+      requestHeaders?: Dom.RequestInit['headers'],
+    ): Promise<GetAtomOptionsQuery> {
+      return withWrapper(
+        (wrappedRequestHeaders) =>
+          client.request<GetAtomOptionsQuery>(
+            GetAtomOptionsDocument,
+            variables,
+            { ...requestHeaders, ...wrappedRequestHeaders },
+          ),
+        'GetAtomOptions',
         'query',
       )
     },

--- a/libs/frontend/domain/atom/src/store/atom.repo.ts
+++ b/libs/frontend/domain/atom/src/store/atom.repo.ts
@@ -1,5 +1,10 @@
-import type { IAtom, IAtomRepository } from '@codelab/frontend/abstract/core'
+import {
+  type IAtom,
+  type IAtomRepository,
+  filterNotHookType,
+} from '@codelab/frontend/abstract/core'
 import type { AtomWhere } from '@codelab/shared/abstract/codegen'
+import sortBy from 'lodash/sortBy'
 import { _async, _await, Model, model, modelFlow } from 'mobx-keystone'
 import { atomApi } from './atom.api'
 
@@ -46,5 +51,15 @@ export class AtomRepository extends Model({}) implements IAtomRepository {
     )
 
     return nodesDeleted
+  })
+
+  @modelFlow
+  findOptions = _async(function* (this: AtomRepository) {
+    const { atoms } = yield* _await(atomApi.GetAtomOptions())
+
+    return sortBy(
+      atoms.filter(({ type }) => filterNotHookType(type)),
+      'name',
+    )
   })
 }

--- a/libs/frontend/domain/atom/src/store/atom.service.ts
+++ b/libs/frontend/domain/atom/src/store/atom.service.ts
@@ -169,6 +169,13 @@ export class AtomService
     return all[0]
   })
 
+  @modelFlow
+  getOptions = _async(function* (this: AtomService) {
+    const options = yield* _await(this.atomRepository.findOptions())
+
+    return options
+  })
+
   /**
    * @param interfaceId Optional interface ID for connecting to existing interface, instead of creating an interface
    */

--- a/libs/frontend/domain/type/src/graphql/get-type.endpoints.graphql
+++ b/libs/frontend/domain/type/src/graphql/get-type.endpoints.graphql
@@ -153,3 +153,15 @@ query GetCodeMirrorTypes(
     ...Type
   }
 }
+
+query GetTypeOptions {
+  # needs hardcoded limit here since the cypher query for base types requires a limit
+  # and it is set to 10 by default in the backend and is safer to just hardcode here
+  baseTypes(options: { limit: 99999 }) {
+    items {
+      id
+      name
+      kind
+    }
+  }
+}

--- a/libs/frontend/domain/type/src/graphql/get-type.endpoints.graphql.gen.ts
+++ b/libs/frontend/domain/type/src/graphql/get-type.endpoints.graphql.gen.ts
@@ -176,6 +176,14 @@ export type GetCodeMirrorTypesQuery = {
   types: Array<Type_CodeMirrorType_Fragment>
 }
 
+export type GetTypeOptionsQueryVariables = Types.Exact<{ [key: string]: never }>
+
+export type GetTypeOptionsQuery = {
+  baseTypes: {
+    items: Array<{ id: string; name: string; kind: Types.TypeKind }>
+  }
+}
+
 export const GetBaseTypesDocument = gql`
   query GetBaseTypes($options: GetBaseTypesOptions) {
     baseTypes(options: $options) {
@@ -365,6 +373,17 @@ export const GetCodeMirrorTypesDocument = gql`
     }
   }
   ${TypeFragmentDoc}
+`
+export const GetTypeOptionsDocument = gql`
+  query GetTypeOptions {
+    baseTypes(options: { limit: 99999 }) {
+      items {
+        id
+        name
+        kind
+      }
+    }
+  }
 `
 
 export type SdkFunctionWrapper = <T>(
@@ -614,6 +633,21 @@ export function getSdk(
             { ...requestHeaders, ...wrappedRequestHeaders },
           ),
         'GetCodeMirrorTypes',
+        'query',
+      )
+    },
+    GetTypeOptions(
+      variables?: GetTypeOptionsQueryVariables,
+      requestHeaders?: Dom.RequestInit['headers'],
+    ): Promise<GetTypeOptionsQuery> {
+      return withWrapper(
+        (wrappedRequestHeaders) =>
+          client.request<GetTypeOptionsQuery>(
+            GetTypeOptionsDocument,
+            variables,
+            { ...requestHeaders, ...wrappedRequestHeaders },
+          ),
+        'GetTypeOptions',
         'query',
       )
     },

--- a/libs/frontend/domain/type/src/services/type.repo.ts
+++ b/libs/frontend/domain/type/src/services/type.repo.ts
@@ -4,6 +4,7 @@ import type {
   ITypeRepository,
 } from '@codelab/frontend/abstract/core'
 import type { BaseTypeWhere } from '@codelab/shared/abstract/codegen'
+import sortBy from 'lodash/sortBy'
 import { _async, _await, Model, model, modelFlow } from 'mobx-keystone'
 import {
   createTypeApi,
@@ -106,5 +107,14 @@ export class TypeRepository extends Model({}) implements ITypeRepository {
     )
 
     return nodesDeleted
+  })
+
+  @modelFlow
+  findOptions = _async(function* (this: TypeRepository) {
+    const {
+      baseTypes: { items },
+    } = yield* _await(getTypeApi.GetTypeOptions())
+
+    return sortBy(items, 'name')
   })
 }

--- a/libs/frontend/domain/type/src/store/type.service.ts
+++ b/libs/frontend/domain/type/src/store/type.service.ts
@@ -259,6 +259,13 @@ export class TypeService
     return all[0]
   })
 
+  @modelFlow
+  getOptions = _async(function* (this: TypeService) {
+    const options = yield* _await(this.typeRepository.findOptions())
+
+    return options
+  })
+
   /**
    * A wrapper around getAll with some type checking.
    * Gets the interface while loading its descendant types

--- a/libs/shared/abstract/codegen/src/types.api.graphql.gen.ts
+++ b/libs/shared/abstract/codegen/src/types.api.graphql.gen.ts
@@ -21258,6 +21258,18 @@ export type GetAtomsQuery = {
   atoms: Array<{ __typename?: 'Atom' } & AtomFragment>
 }
 
+export type GetAtomOptionsQueryVariables = Exact<{ [key: string]: never }>
+
+export type GetAtomOptionsQuery = {
+  __typename?: 'Query'
+  atoms: Array<{
+    __typename?: 'Atom'
+    id: string
+    name: string
+    type: AtomType
+  }>
+}
+
 export type UpdateAtomsMutationVariables = Exact<{
   where?: InputMaybe<AtomWhere>
   update?: InputMaybe<AtomUpdateInput>
@@ -22366,6 +22378,21 @@ export type GetCodeMirrorTypesQueryVariables = Exact<{
 export type GetCodeMirrorTypesQuery = {
   __typename?: 'Query'
   types: Array<{ __typename?: 'CodeMirrorType' } & Type_CodeMirrorType_Fragment>
+}
+
+export type GetTypeOptionsQueryVariables = Exact<{ [key: string]: never }>
+
+export type GetTypeOptionsQuery = {
+  __typename?: 'Query'
+  baseTypes: {
+    __typename?: 'GetBaseTypesReturn'
+    items: Array<{
+      __typename?: 'BaseType'
+      id: string
+      name: string
+      kind: TypeKind
+    }>
+  }
 }
 
 export type InterfaceForm_GetAppsQueryVariables = Exact<{


### PR DESCRIPTION
<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(libs-ui-component): must begin with lowercase` -->

## Description

<!-- This is a short description on the Pull Request -->
- created new queries for [atoms](https://github.com/codelab-app/platform/pull/2479/files#diff-36c113451e50e0945bc589072123548132618c3473c3b2dde8574d552162b0bfR29) and [types](https://github.com/codelab-app/platform/pull/2479/files#diff-b876f80c92ce861ebb6a7992b0928b077561c15751f7669eaa2e84710c73742aR157) to be specifically used for fetching all the atoms and types for the dropdown
- new queries are a lot smaller compared to the older query being used where lots of extra unused fields are being fetched
- created new methods for the atoms and types service (`getOptions`) that will use the new queries and will not do extra stuffs like storing to cache or loading underlying types that potentially freezes the app
- since this reduces the size of the responses and the extra processes like storing and loading stuffs, this is a lot quicker now and doesn't have to do pagination on the dropdown which just adds complex codes

## Video or Image

<!-- Add video or image showing how the new feature works -->

Loading of types options on the dropdown is very quick now and doesn't freeze the app

https://user-images.githubusercontent.com/27695022/232540964-cd3022d0-71a1-4a99-93f0-834688fc63e3.mp4

<br />

Loading of atoms options on the dropdown is very quick now and doesn't freeze the app


https://user-images.githubusercontent.com/27695022/232541213-c80a1258-c81a-4438-81dc-95eb2c662c7c.mp4




## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged -->

Fixes #2476 
