### PR TITLE
2447 enable order for api fields

### DIFF
--- a/libs/backend/domain/type/src/model/field.model.ts
+++ b/libs/backend/domain/type/src/model/field.model.ts
@@ -19,6 +19,10 @@ export class Field implements IFieldDTO {
 
   readonly validationRules: string | null
 
+  nextSibling?: IEntity | null | undefined
+
+  prevSibling?: IEntity | null | undefined
+
   constructor({
     api,
     defaultValues = null,
@@ -27,6 +31,8 @@ export class Field implements IFieldDTO {
     id,
     key,
     name = null,
+    nextSibling = null,
+    prevSibling = null,
     validationRules = null,
   }: IFieldDTO) {
     this.api = { id: api.id }
@@ -37,6 +43,8 @@ export class Field implements IFieldDTO {
     this.key = key
     this.name = name
     this.validationRules = validationRules
+    this.nextSibling = nextSibling
+    this.prevSibling = prevSibling
   }
 
   /**

--- a/libs/backend/domain/type/src/repository/field.repo.ts
+++ b/libs/backend/domain/type/src/repository/field.repo.ts
@@ -28,10 +28,12 @@ export class FieldRepository extends AbstractRepository<
       await (
         await this.Field
       ).create({
-        input: fields.map(({ api, fieldType, ...field }) => ({
+        input: fields.map(({ api, fieldType, nextSibling , prevSibling ,...field }) => ({
           ...field,
           api: connectNodeId(api.id),
           fieldType: connectNodeId(fieldType.id),
+          nextSibling : connectNodeId(nextSibling?.id),
+          prevSibling : connectNodeId(prevSibling?.id)
         })),
       })
     ).fields
@@ -43,7 +45,7 @@ export class FieldRepository extends AbstractRepository<
    * Scenario: Say a field was deleted, then we run a seeder, we would have to create for the deleted field
    */
   protected async _update(
-    { api, fieldType, id, ...field }: IFieldDTO,
+    { api, fieldType, id, nextSibling , prevSibling ,...field }: IFieldDTO,
     where: OGM_TYPES.FieldWhere,
   ) {
     return (
@@ -54,6 +56,8 @@ export class FieldRepository extends AbstractRepository<
           ...field,
           api: reconnectNodeId(api.id),
           fieldType: reconnectNodeId(fieldType.id),
+          nextSibling : reconnectNodeId(nextSibling?.id),
+          prevSibling : reconnectNodeId(prevSibling?.id)
         },
         where,
       })

--- a/libs/backend/domain/type/src/repository/field.repo.ts
+++ b/libs/backend/domain/type/src/repository/field.repo.ts
@@ -28,12 +28,12 @@ export class FieldRepository extends AbstractRepository<
       await (
         await this.Field
       ).create({
-        input: fields.map(({ api, fieldType, nextSibling , prevSibling ,...field }) => ({
+        input: fields.map(({ api, fieldType, ...field }) => ({
           ...field,
           api: connectNodeId(api.id),
           fieldType: connectNodeId(fieldType.id),
-          nextSibling : connectNodeId(nextSibling?.id),
-          prevSibling : connectNodeId(prevSibling?.id)
+          nextSibling: connectNodeId(field.nextSibling?.id),
+          prevSibling: connectNodeId(field.prevSibling?.id),
         })),
       })
     ).fields
@@ -45,7 +45,7 @@ export class FieldRepository extends AbstractRepository<
    * Scenario: Say a field was deleted, then we run a seeder, we would have to create for the deleted field
    */
   protected async _update(
-    { api, fieldType, id, nextSibling , prevSibling ,...field }: IFieldDTO,
+    { api, fieldType, id, ...field }: IFieldDTO,
     where: OGM_TYPES.FieldWhere,
   ) {
     return (
@@ -56,8 +56,8 @@ export class FieldRepository extends AbstractRepository<
           ...field,
           api: reconnectNodeId(api.id),
           fieldType: reconnectNodeId(fieldType.id),
-          nextSibling : reconnectNodeId(nextSibling?.id),
-          prevSibling : reconnectNodeId(prevSibling?.id)
+          nextSibling: reconnectNodeId(field.nextSibling?.id),
+          prevSibling: reconnectNodeId(field.prevSibling?.id),
         },
         where,
       })

--- a/libs/backend/domain/type/src/repository/interface-type.repo.ts
+++ b/libs/backend/domain/type/src/repository/interface-type.repo.ts
@@ -80,14 +80,16 @@ export class InterfaceTypeRepository extends AbstractRepository<
     fields: Array<IFieldDTO>,
   ): OGM_TYPES.InterfaceTypeFieldsFieldInput {
     return {
-      create: fields.map(({ api, fieldType, nextSibling , prevSibling , ...field }) => ({
-        node: {
-          ...field,
-          fieldType: connectNodeId(fieldType.id),
-          nextSibling : connectNodeId(nextSibling?.id),
-          prevSibling : connectNodeId(prevSibling?.id)
-        },
-      })),
+      create: fields.map(
+        ({ api, fieldType, nextSibling, prevSibling, ...field }) => ({
+          node: {
+            ...field,
+            fieldType: connectNodeId(fieldType.id),
+            nextSibling: connectNodeId(nextSibling?.id),
+            prevSibling: connectNodeId(prevSibling?.id),
+          },
+        }),
+      ),
     }
   }
 

--- a/libs/backend/domain/type/src/repository/interface-type.repo.ts
+++ b/libs/backend/domain/type/src/repository/interface-type.repo.ts
@@ -80,10 +80,12 @@ export class InterfaceTypeRepository extends AbstractRepository<
     fields: Array<IFieldDTO>,
   ): OGM_TYPES.InterfaceTypeFieldsFieldInput {
     return {
-      create: fields.map(({ api, fieldType, ...field }) => ({
+      create: fields.map(({ api, fieldType, nextSibling , prevSibling , ...field }) => ({
         node: {
           ...field,
           fieldType: connectNodeId(fieldType.id),
+          nextSibling : connectNodeId(nextSibling?.id),
+          prevSibling : connectNodeId(prevSibling?.id)
         },
       })),
     }

--- a/libs/backend/infra/adapter/neo4j/src/schema/type/field.schema.ts
+++ b/libs/backend/infra/adapter/neo4j/src/schema/type/field.schema.ts
@@ -5,6 +5,8 @@ export const fieldSchema = gql`
     id: ID!
     key: String!
     name: String
+    nextSibling: Field @relationship(type: "FIELD_NEXT_SIBLING", direction: IN)
+    prevSibling: Field @relationship(type: "FIELD_PREV_SIBLING", direction: OUT)
     description: String
     validationRules: String
     defaultValues: String

--- a/libs/backend/infra/adapter/neo4j/src/selectionSet/fieldSelectionSet.ts
+++ b/libs/backend/infra/adapter/neo4j/src/selectionSet/fieldSelectionSet.ts
@@ -5,6 +5,12 @@ export const fieldSelectionSet = `{
   description
   validationRules
   defaultValues
+  prevSibling {
+    id
+  }
+  nextSibling {
+    id
+  }
   fieldType {
     __typename
     id

--- a/libs/frontend/abstract/core/src/domain/type/field.dto.interface.ts
+++ b/libs/frontend/abstract/core/src/domain/type/field.dto.interface.ts
@@ -56,11 +56,12 @@ export interface ICreateFieldData {
   interfaceTypeId: IInterfaceTypeRef
   key: string
   name?: Nullish<string>
+  nextSibling?: Nullish<IEntity>
+  prevSibling?: Nullish<IEntity>
   validationRules?: Nullish<IValidationRules>
 }
 
 export type IUpdateFieldData = ICreateFieldData
-
 /**
  * Props imply as input for something, in this case a model
  */
@@ -72,5 +73,7 @@ export interface IFieldDTO {
   id: string
   key: string
   name?: string | null
+  nextSibling?: IEntity | null
+  prevSibling?: IEntity | null
   validationRules?: string | null
 }

--- a/libs/frontend/abstract/core/src/domain/type/field.dto.interface.ts
+++ b/libs/frontend/abstract/core/src/domain/type/field.dto.interface.ts
@@ -56,8 +56,6 @@ export interface ICreateFieldData {
   interfaceTypeId: IInterfaceTypeRef
   key: string
   name?: Nullish<string>
-  nextSibling?: Nullish<IEntity>
-  prevSibling?: Nullish<IEntity>
   validationRules?: Nullish<IValidationRules>
 }
 

--- a/libs/frontend/abstract/core/src/domain/type/field/field.interface.ts
+++ b/libs/frontend/abstract/core/src/domain/type/field/field.interface.ts
@@ -31,8 +31,16 @@ export interface IField<T extends IType = IType>
    * Allows default to null
    */
   name: Nullish<string>
+  nextSibling?: Nullish<Ref<IField>>
+  prevSibling?: Nullish<Ref<IField>>
   type: Ref<T>
   validationRules: Nullish<IValidationRules>
+  attachAsNextSibling(sibling: IField): void
+  attachAsPrevSibling(sibling: IField): void
+  changePrev(sibling: IField): void
+  connectPrevToNextSibling(): void
+  detachPrevSibling(): void
+  toUpdateNodesInput(): Pick<FieldUpdateInput, 'nextSibling' | 'prevSibling'>
 }
 
 export type IFieldRef = string

--- a/libs/frontend/abstract/core/src/domain/type/field/field.record.interface.ts
+++ b/libs/frontend/abstract/core/src/domain/type/field/field.record.interface.ts
@@ -1,4 +1,4 @@
-import type { Nullish } from '@codelab/shared/abstract/types'
+import type { IEntity, Nullish } from '@codelab/shared/abstract/types'
 import type { ITypeRecord } from '../type.record.interface'
 
 export interface ValidationRuleTag {
@@ -12,6 +12,8 @@ export interface IFieldRecord {
   id: string
   key: string
   name: Nullish<string>
+  nextSibling?: IEntity | null
+  prevSibling?: IEntity | null
   type?: {
     id: string
     kind: string

--- a/libs/frontend/abstract/core/src/domain/type/field/field.service.interface.ts
+++ b/libs/frontend/abstract/core/src/domain/type/field/field.service.interface.ts
@@ -1,4 +1,4 @@
-import type { Maybe } from '@codelab/shared/abstract/types'
+import type { IEntity, Maybe } from '@codelab/shared/abstract/types'
 import type { ObjectMap, Ref } from 'mobx-keystone'
 import type {
   ICRUDModalService,
@@ -28,9 +28,16 @@ export interface IFieldService
     { interface: Maybe<IInterfaceType> }
   >
   fields: ObjectMap<IField>
-
   add(fieldDTO: IFieldDTO): IField
   delete(fields: Array<IField>): Promise<number>
   getField(id: string): Maybe<IField<IType>>
   load(fields: Array<FieldFragment>): void
+  moveFieldAsNextSibling(props: {
+    field: IEntity
+    targetField: IEntity
+  }): Promise<void>
+  moveFieldAsPrevSibling(props: {
+    field: IEntity
+    targetField: IEntity
+  }): Promise<void>
 }

--- a/libs/frontend/abstract/core/src/domain/type/fragments/field.fragment.graphql
+++ b/libs/frontend/abstract/core/src/domain/type/fragments/field.fragment.graphql
@@ -4,6 +4,12 @@ fragment Field on Field {
   name
   description
   validationRules
+  prevSibling {
+    id
+  }
+  nextSibling {
+    id
+  }
   fieldType {
     ... on IBaseType {
       __typename

--- a/libs/frontend/abstract/core/src/domain/type/fragments/field.fragment.graphql.gen.ts
+++ b/libs/frontend/abstract/core/src/domain/type/fragments/field.fragment.graphql.gen.ts
@@ -10,6 +10,8 @@ export type FieldFragment = {
   description?: string | null
   validationRules?: string | null
   defaultValues?: string | null
+  prevSibling?: { id: string } | null
+  nextSibling?: { id: string } | null
   fieldType:
     | {
         __typename: 'ActionType'
@@ -85,6 +87,12 @@ export const FieldFragmentDoc = gql`
     name
     description
     validationRules
+    prevSibling {
+      id
+    }
+    nextSibling {
+      id
+    }
     fieldType {
       ... on IBaseType {
         __typename

--- a/libs/frontend/domain/type/src/services/field.repo.ts
+++ b/libs/frontend/domain/type/src/services/field.repo.ts
@@ -38,6 +38,20 @@ export class FieldRepository extends Model({}) implements IFieldRepository {
   })
 
   @modelFlow
+  updateNodes = _async(function* (this: FieldRepository, field: IField) {
+    const {
+      updateFields: { fields },
+    } = yield* _await(
+      fieldApi.UpdateFields({
+        update: field.toUpdateNodesInput(),
+        where: { id: field.id },
+      }),
+    )
+
+    return fields[0]
+  })
+
+  @modelFlow
   delete = _async(function* (this: FieldRepository, fields: Array<IField>) {
     const {
       deleteFields: { nodesDeleted },

--- a/libs/frontend/domain/type/src/store/field.service.ts
+++ b/libs/frontend/domain/type/src/store/field.service.ts
@@ -6,6 +6,9 @@ import type {
 } from '@codelab/frontend/abstract/core'
 import { getElementService, IFieldDTO } from '@codelab/frontend/abstract/core'
 import type { FieldFragment } from '@codelab/shared/abstract/codegen'
+import type { IEntity } from '@codelab/shared/abstract/types'
+import compact from 'lodash/compact'
+import uniq from 'lodash/uniq'
 import { computed } from 'mobx'
 import {
   _async,
@@ -51,6 +54,17 @@ export class FieldService
 
   getField(id: string) {
     return this.fields.get(id)
+  }
+
+  @modelAction
+  field(id: string) {
+    const element = this.getField(id)
+
+    if (!element) {
+      throw new Error('Missing element')
+    }
+
+    return element
   }
 
   // The field actions are here because if I put them in InterfaceType
@@ -137,6 +151,132 @@ export class FieldService
 
     return field
   }
+
+  @modelAction
+  private attatchFieldAsNextSibling(
+    this: FieldService,
+    {
+      field: existingField,
+      targetField: existingTargetField,
+    }: {
+      field: IEntity
+      targetField: IEntity
+    },
+  ) {
+    const field = this.field(existingField.id)
+    const targetField = this.field(existingTargetField.id)
+    const affectedNodeIds: Array<string> = []
+
+    if (targetField.nextSibling) {
+      field.attachAsPrevSibling(targetField.nextSibling.current)
+      affectedNodeIds.push(targetField.nextSibling.current.id)
+    }
+
+    field.attachAsNextSibling(targetField)
+    affectedNodeIds.push(targetField.id)
+    affectedNodeIds.push(field.id)
+
+    return affectedNodeIds
+  }
+
+  @modelAction
+  private attatchFieldAsPrevSibling(
+    this: FieldService,
+    {
+      field: existingField,
+      targetField: existingTargetField,
+    }: {
+      field: IEntity
+      targetField: IEntity
+    },
+  ) {
+    const field = this.field(existingField.id)
+    const targetField = this.field(existingTargetField.id)
+    const affectedNodeIds: Array<string> = []
+
+    if (targetField.prevSibling) {
+      field.attachAsNextSibling(targetField.prevSibling.current)
+      affectedNodeIds.push(targetField.prevSibling.current.id)
+    }
+
+    field.attachAsPrevSibling(targetField)
+    affectedNodeIds.push(targetField.id)
+    affectedNodeIds.push(field.id)
+
+    return affectedNodeIds
+  }
+
+  @modelAction
+  private detachFieldFromFieldTree(this: FieldService, fieldId: string) {
+    const field = this.field(fieldId)
+    const affedtedNodeIds = [field.prevSibling?.id, field.nextSibling?.id]
+
+    field.connectPrevToNextSibling()
+
+    return compact(affedtedNodeIds)
+  }
+
+  @modelFlow
+  @transaction
+  moveFieldAsNextSibling = _async(function* (
+    this: FieldService,
+    {
+      field,
+      targetField,
+    }: Parameters<IFieldService['moveFieldAsNextSibling']>[0],
+  ) {
+    const target = this.getField(targetField.id)
+
+    if (target?.nextSibling?.getRefId() === field.id) {
+      return
+    }
+
+    const oldConnectedNodeIds = this.detachFieldFromFieldTree(field.id)
+
+    const newConnectedNodeIds = this.attatchFieldAsNextSibling({
+      field,
+      targetField,
+    })
+
+    yield* _await(
+      Promise.all(
+        uniq([...newConnectedNodeIds, ...oldConnectedNodeIds]).map((id) =>
+          this.fieldRepository.updateNodes(this.field(id)),
+        ),
+      ),
+    )
+  })
+
+  @modelFlow
+  @transaction
+  moveFieldAsPrevSibling = _async(function* (
+    this: FieldService,
+    {
+      field,
+      targetField,
+    }: Parameters<IFieldService['moveFieldAsPrevSibling']>[0],
+  ) {
+    const target = this.getField(targetField.id)
+
+    if (target?.nextSibling?.getRefId() === field.id) {
+      return
+    }
+
+    const oldConnectedNodeIds = this.detachFieldFromFieldTree(field.id)
+
+    const newConnectedNodeIds = this.attatchFieldAsPrevSibling({
+      field,
+      targetField,
+    })
+
+    yield* _await(
+      Promise.all(
+        uniq([...newConnectedNodeIds, ...oldConnectedNodeIds]).map((id) =>
+          this.fieldRepository.updateNodes(this.field(id)),
+        ),
+      ),
+    )
+  })
 
   private static mapDataToDTO(fieldData: ICreateFieldData) {
     return {

--- a/libs/frontend/domain/type/src/store/field.service.ts
+++ b/libs/frontend/domain/type/src/store/field.service.ts
@@ -153,7 +153,7 @@ export class FieldService
   }
 
   @modelAction
-  private attatchFieldAsNextSibling(
+  private attachFieldAsNextSibling(
     this: FieldService,
     {
       field: existingField,
@@ -180,7 +180,7 @@ export class FieldService
   }
 
   @modelAction
-  private attatchFieldAsPrevSibling(
+  private attachFieldAsPrevSibling(
     this: FieldService,
     {
       field: existingField,
@@ -209,11 +209,11 @@ export class FieldService
   @modelAction
   private detachFieldFromFieldTree(this: FieldService, fieldId: string) {
     const field = this.field(fieldId)
-    const affedtedNodeIds = [field.prevSibling?.id, field.nextSibling?.id]
+    const affectedNodeIds = [field.prevSibling?.id, field.nextSibling?.id]
 
     field.connectPrevToNextSibling()
 
-    return compact(affedtedNodeIds)
+    return compact(affectedNodeIds)
   }
 
   @modelFlow
@@ -233,7 +233,7 @@ export class FieldService
 
     const oldConnectedNodeIds = this.detachFieldFromFieldTree(field.id)
 
-    const newConnectedNodeIds = this.attatchFieldAsNextSibling({
+    const newConnectedNodeIds = this.attachFieldAsNextSibling({
       field,
       targetField,
     })
@@ -264,7 +264,7 @@ export class FieldService
 
     const oldConnectedNodeIds = this.detachFieldFromFieldTree(field.id)
 
-    const newConnectedNodeIds = this.attatchFieldAsPrevSibling({
+    const newConnectedNodeIds = this.attachFieldAsPrevSibling({
       field,
       targetField,
     })

--- a/libs/frontend/domain/type/src/use-cases/types/get-types/tables/FieldsTable.tsx
+++ b/libs/frontend/domain/type/src/use-cases/types/get-types/tables/FieldsTable.tsx
@@ -1,4 +1,5 @@
 import type {
+  IField,
   IFieldRecord,
   IFieldService,
   IInterfaceType,
@@ -10,11 +11,14 @@ import {
   ListItemEditButton,
 } from '@codelab/frontend/view/components'
 import { ITypeKind } from '@codelab/shared/abstract/core'
+import { faArrowsUpDownLeftRight } from '@fortawesome/pro-light-svg-icons'
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { Divider, Space, Table, Tag } from 'antd'
 import type { ColumnProps } from 'antd/lib/table/Column'
 import isNil from 'lodash/isNil'
 import { Observer, observer } from 'mobx-react-lite'
 import React from 'react'
+import ReactDragListView from 'react-drag-listview'
 import tw from 'twin.macro'
 import { fieldRef, typeRef } from '../../../../store'
 import { CreateFieldButton } from '../../../fields/create-field'
@@ -34,6 +38,15 @@ const headerCellProps = () => ({ style: tw`font-semibold text-gray-900` })
 export const FieldsTable = observer<FieldsTableProps>(
   ({ fieldService, hideActions, interfaceType, isLoading, typeService }) => {
     const columns: Array<ColumnProps<IFieldRecord>> = [
+      {
+        key: '',
+        render: (text, record, index) => (
+          <span className="drag-handle">
+            <FontAwesomeIcon icon={faArrowsUpDownLeftRight} size="lg" />
+          </span>
+        ),
+        title: '',
+      },
       {
         dataIndex: 'name',
         key: 'name',
@@ -150,14 +163,33 @@ export const FieldsTable = observer<FieldsTableProps>(
       },
     ]
 
-    const dataSource: Array<IFieldRecord> = interfaceType.fields.map(
-      (field) => {
+    const compareNodes = (node1: IField, node2: IField) => {
+      if (node1.nextSibling === null) {
+        return 1
+      } else if (node2.nextSibling === null) {
+        return -1
+      } else if (node1.prevSibling === null) {
+        return -1
+      } else if (node2.prevSibling === null) {
+        return 1
+      } else if (node1.nextSibling?.id === node2.id) {
+        return -1
+      } else {
+        return -1
+      }
+    }
+
+    const dataSource: Array<IFieldRecord> = interfaceType.fields
+      .sort(compareNodes)
+      .map((field) => {
         return {
           dependentTypes: [],
           description: field.description || '',
           id: field.id,
           key: field.key,
           name: field.name || '',
+          nextSibling: field.nextSibling,
+          prevSibling: field.prevSibling,
           type: {
             id: field.type.maybeCurrent?.id ?? '',
             kind: field.type.maybeCurrent?.kind ?? '',
@@ -165,30 +197,54 @@ export const FieldsTable = observer<FieldsTableProps>(
           },
           validationRules: getValidationRuleTagsArray(field.validationRules),
         }
-      },
-    )
+      })
+
+    const onDragEnd = async (fromIndex: number, toIndex: number) => {
+      if (fromIndex === toIndex) {
+        return
+      }
+
+      if (fromIndex < toIndex && toIndex !== 0) {
+        await fieldService.moveFieldAsNextSibling({
+          field: { id: dataSource[fromIndex]?.id as string },
+          targetField: { id: dataSource[toIndex]?.id as string },
+        })
+      } else if (toIndex === 0) {
+        await fieldService.moveFieldAsNextSibling({
+          field: { id: dataSource[toIndex]?.id as string },
+          targetField: { id: dataSource[fromIndex]?.id as string },
+        })
+      } else if (fromIndex > toIndex && toIndex !== 0) {
+        await fieldService.moveFieldAsNextSibling({
+          field: { id: dataSource[fromIndex]?.id as string },
+          targetField: { id: dataSource[toIndex - 1]?.id as string },
+        })
+      }
+    }
 
     return (
-      <Table
-        columns={
-          hideActions
-            ? columns.filter((column) => column.key !== 'action')
-            : columns
-        }
-        dataSource={dataSource}
-        expandable={{
-          expandedRowRender: (record) => {
-            return record.type ? (
-              <TypeDetailsTable typeId={record.type.id} />
-            ) : null
-          },
-          indentSize: 0,
-        }}
-        loading={isLoading}
-        pagination={{ disabled: false, hideOnSinglePage: true, pageSize: 25 }}
-        rowKey={({ key }) => key}
-        size="small"
-      />
+      <ReactDragListView handleSelector="span" onDragEnd={onDragEnd}>
+        <Table
+          columns={
+            hideActions
+              ? columns.filter((column) => column.key !== 'action')
+              : columns
+          }
+          dataSource={dataSource}
+          expandable={{
+            expandedRowRender: (record) => {
+              return record.type ? (
+                <TypeDetailsTable typeId={record.type.id} />
+              ) : null
+            },
+            indentSize: 0,
+          }}
+          loading={isLoading}
+          pagination={{ disabled: false, hideOnSinglePage: true, pageSize: 25 }}
+          rowKey={({ key }) => key}
+          size="small"
+        />
+      </ReactDragListView>
     )
   },
 )

--- a/libs/frontend/domain/type/src/use-cases/types/get-types/tables/FieldsTable.tsx
+++ b/libs/frontend/domain/type/src/use-cases/types/get-types/tables/FieldsTable.tsx
@@ -163,20 +163,29 @@ export const FieldsTable = observer<FieldsTableProps>(
       },
     ]
 
-    const compareNodes = (node1: IField, node2: IField) => {
-      if (node1.nextSibling === null) {
-        return 1
-      } else if (node2.nextSibling === null) {
-        return -1
-      } else if (node1.prevSibling === null) {
-        return -1
-      } else if (node2.prevSibling === null) {
-        return 1
-      } else if (node1.nextSibling?.id === node2.id) {
-        return -1
-      } else {
-        return -1
+    const compareNodes = (field1: IField, field2: IField) => {
+      let node1 = field1
+      let node2 = field2
+      const pathA = [field1.id]
+      const pathB = [field2.id]
+
+      while (node1.prevSibling) {
+        node1 = interfaceType.fields.find(
+          (node) => node.id === node1.prevSibling?.id,
+        ) as IField
+        pathA.unshift(node1.id)
       }
+
+      while (node2.prevSibling) {
+        node2 = interfaceType.fields.find(
+          (node) => node.id === node2.prevSibling?.id,
+        ) as IField
+        pathB.unshift(node2.id)
+      }
+
+      const result = pathA.join().localeCompare(pathB.join())
+
+      return result !== 0 ? result : field1.id.localeCompare(field2.id)
     }
 
     const dataSource: Array<IFieldRecord> = interfaceType.fields

--- a/libs/shared/abstract/codegen/src/ogm-types.gen.ts
+++ b/libs/shared/abstract/codegen/src/ogm-types.gen.ts
@@ -4877,11 +4877,39 @@ export type Field = {
   description?: Maybe<Scalars['String']>
   validationRules?: Maybe<Scalars['String']>
   defaultValues?: Maybe<Scalars['String']>
+  nextSibling?: Maybe<Field>
+  nextSiblingAggregate?: Maybe<FieldFieldNextSiblingAggregationSelection>
+  prevSibling?: Maybe<Field>
+  prevSiblingAggregate?: Maybe<FieldFieldPrevSiblingAggregationSelection>
   fieldType: IBaseType
   api: InterfaceType
   apiAggregate?: Maybe<FieldInterfaceTypeApiAggregationSelection>
+  nextSiblingConnection: FieldNextSiblingConnection
+  prevSiblingConnection: FieldPrevSiblingConnection
   fieldTypeConnection: FieldFieldTypeConnection
   apiConnection: FieldApiConnection
+}
+
+export type FieldNextSiblingArgs = {
+  where?: InputMaybe<FieldWhere>
+  options?: InputMaybe<FieldOptions>
+  directed?: InputMaybe<Scalars['Boolean']>
+}
+
+export type FieldNextSiblingAggregateArgs = {
+  where?: InputMaybe<FieldWhere>
+  directed?: InputMaybe<Scalars['Boolean']>
+}
+
+export type FieldPrevSiblingArgs = {
+  where?: InputMaybe<FieldWhere>
+  options?: InputMaybe<FieldOptions>
+  directed?: InputMaybe<Scalars['Boolean']>
+}
+
+export type FieldPrevSiblingAggregateArgs = {
+  where?: InputMaybe<FieldWhere>
+  directed?: InputMaybe<Scalars['Boolean']>
 }
 
 export type FieldFieldTypeArgs = {
@@ -4899,6 +4927,22 @@ export type FieldApiArgs = {
 export type FieldApiAggregateArgs = {
   where?: InputMaybe<InterfaceTypeWhere>
   directed?: InputMaybe<Scalars['Boolean']>
+}
+
+export type FieldNextSiblingConnectionArgs = {
+  where?: InputMaybe<FieldNextSiblingConnectionWhere>
+  first?: InputMaybe<Scalars['Int']>
+  after?: InputMaybe<Scalars['String']>
+  directed?: InputMaybe<Scalars['Boolean']>
+  sort?: InputMaybe<Array<FieldNextSiblingConnectionSort>>
+}
+
+export type FieldPrevSiblingConnectionArgs = {
+  where?: InputMaybe<FieldPrevSiblingConnectionWhere>
+  first?: InputMaybe<Scalars['Int']>
+  after?: InputMaybe<Scalars['String']>
+  directed?: InputMaybe<Scalars['Boolean']>
+  sort?: InputMaybe<Array<FieldPrevSiblingConnectionSort>>
 }
 
 export type FieldFieldTypeConnectionArgs = {
@@ -4947,6 +4991,38 @@ export type FieldEdge = {
   node: Field
 }
 
+export type FieldFieldNextSiblingAggregationSelection = {
+  __typename?: 'FieldFieldNextSiblingAggregationSelection'
+  count: Scalars['Int']
+  node?: Maybe<FieldFieldNextSiblingNodeAggregateSelection>
+}
+
+export type FieldFieldNextSiblingNodeAggregateSelection = {
+  __typename?: 'FieldFieldNextSiblingNodeAggregateSelection'
+  id: IdAggregateSelectionNonNullable
+  key: StringAggregateSelectionNonNullable
+  name: StringAggregateSelectionNullable
+  description: StringAggregateSelectionNullable
+  validationRules: StringAggregateSelectionNullable
+  defaultValues: StringAggregateSelectionNullable
+}
+
+export type FieldFieldPrevSiblingAggregationSelection = {
+  __typename?: 'FieldFieldPrevSiblingAggregationSelection'
+  count: Scalars['Int']
+  node?: Maybe<FieldFieldPrevSiblingNodeAggregateSelection>
+}
+
+export type FieldFieldPrevSiblingNodeAggregateSelection = {
+  __typename?: 'FieldFieldPrevSiblingNodeAggregateSelection'
+  id: IdAggregateSelectionNonNullable
+  key: StringAggregateSelectionNonNullable
+  name: StringAggregateSelectionNullable
+  description: StringAggregateSelectionNullable
+  validationRules: StringAggregateSelectionNullable
+  defaultValues: StringAggregateSelectionNullable
+}
+
 export type FieldFieldTypeConnection = {
   __typename?: 'FieldFieldTypeConnection'
   edges: Array<FieldFieldTypeRelationship>
@@ -4970,6 +5046,32 @@ export type FieldInterfaceTypeApiNodeAggregateSelection = {
   __typename?: 'FieldInterfaceTypeApiNodeAggregateSelection'
   id: IdAggregateSelectionNonNullable
   name: StringAggregateSelectionNonNullable
+}
+
+export type FieldNextSiblingConnection = {
+  __typename?: 'FieldNextSiblingConnection'
+  edges: Array<FieldNextSiblingRelationship>
+  totalCount: Scalars['Int']
+  pageInfo: PageInfo
+}
+
+export type FieldNextSiblingRelationship = {
+  __typename?: 'FieldNextSiblingRelationship'
+  cursor: Scalars['String']
+  node: Field
+}
+
+export type FieldPrevSiblingConnection = {
+  __typename?: 'FieldPrevSiblingConnection'
+  edges: Array<FieldPrevSiblingRelationship>
+  totalCount: Scalars['Int']
+  pageInfo: PageInfo
+}
+
+export type FieldPrevSiblingRelationship = {
+  __typename?: 'FieldPrevSiblingRelationship'
+  cursor: Scalars['String']
+  node: Field
 }
 
 export type FieldsConnection = {
@@ -19795,6 +19897,8 @@ export type FieldApiUpdateFieldInput = {
 }
 
 export type FieldConnectInput = {
+  nextSibling?: InputMaybe<FieldNextSiblingConnectFieldInput>
+  prevSibling?: InputMaybe<FieldPrevSiblingConnectFieldInput>
   fieldType?: InputMaybe<FieldFieldTypeConnectFieldInput>
   api?: InputMaybe<FieldApiConnectFieldInput>
 }
@@ -19814,16 +19918,22 @@ export type FieldCreateInput = {
   description?: InputMaybe<Scalars['String']>
   validationRules?: InputMaybe<Scalars['String']>
   defaultValues?: InputMaybe<Scalars['String']>
+  nextSibling?: InputMaybe<FieldNextSiblingFieldInput>
+  prevSibling?: InputMaybe<FieldPrevSiblingFieldInput>
   fieldType?: InputMaybe<FieldFieldTypeFieldInput>
   api?: InputMaybe<FieldApiFieldInput>
 }
 
 export type FieldDeleteInput = {
+  nextSibling?: InputMaybe<FieldNextSiblingDeleteFieldInput>
+  prevSibling?: InputMaybe<FieldPrevSiblingDeleteFieldInput>
   fieldType?: InputMaybe<FieldFieldTypeDeleteFieldInput>
   api?: InputMaybe<FieldApiDeleteFieldInput>
 }
 
 export type FieldDisconnectInput = {
+  nextSibling?: InputMaybe<FieldNextSiblingDisconnectFieldInput>
+  prevSibling?: InputMaybe<FieldPrevSiblingDisconnectFieldInput>
   fieldType?: InputMaybe<FieldFieldTypeDisconnectFieldInput>
   api?: InputMaybe<FieldApiDisconnectFieldInput>
 }
@@ -19878,6 +19988,353 @@ export type FieldFieldTypeUpdateFieldInput = {
   where?: InputMaybe<FieldFieldTypeConnectionWhere>
 }
 
+export type FieldNextSiblingAggregateInput = {
+  count?: InputMaybe<Scalars['Int']>
+  count_LT?: InputMaybe<Scalars['Int']>
+  count_LTE?: InputMaybe<Scalars['Int']>
+  count_GT?: InputMaybe<Scalars['Int']>
+  count_GTE?: InputMaybe<Scalars['Int']>
+  AND?: InputMaybe<Array<FieldNextSiblingAggregateInput>>
+  OR?: InputMaybe<Array<FieldNextSiblingAggregateInput>>
+  NOT?: InputMaybe<FieldNextSiblingAggregateInput>
+  node?: InputMaybe<FieldNextSiblingNodeAggregationWhereInput>
+}
+
+export type FieldNextSiblingConnectFieldInput = {
+  where?: InputMaybe<FieldConnectWhere>
+  connect?: InputMaybe<FieldConnectInput>
+  /** Whether or not to overwrite any matching relationship with the new properties. Will default to `false` in 4.0.0. */
+  overwrite?: Scalars['Boolean']
+}
+
+export type FieldNextSiblingConnectionSort = {
+  node?: InputMaybe<FieldSort>
+}
+
+export type FieldNextSiblingConnectionWhere = {
+  AND?: InputMaybe<Array<FieldNextSiblingConnectionWhere>>
+  OR?: InputMaybe<Array<FieldNextSiblingConnectionWhere>>
+  NOT?: InputMaybe<FieldNextSiblingConnectionWhere>
+  node?: InputMaybe<FieldWhere>
+  /** @deprecated Negation filters will be deprecated, use the NOT operator to achieve the same behavior */
+  node_NOT?: InputMaybe<FieldWhere>
+}
+
+export type FieldNextSiblingCreateFieldInput = {
+  node: FieldCreateInput
+}
+
+export type FieldNextSiblingDeleteFieldInput = {
+  where?: InputMaybe<FieldNextSiblingConnectionWhere>
+  delete?: InputMaybe<FieldDeleteInput>
+}
+
+export type FieldNextSiblingDisconnectFieldInput = {
+  where?: InputMaybe<FieldNextSiblingConnectionWhere>
+  disconnect?: InputMaybe<FieldDisconnectInput>
+}
+
+export type FieldNextSiblingFieldInput = {
+  create?: InputMaybe<FieldNextSiblingCreateFieldInput>
+  connect?: InputMaybe<FieldNextSiblingConnectFieldInput>
+}
+
+export type FieldNextSiblingNodeAggregationWhereInput = {
+  AND?: InputMaybe<Array<FieldNextSiblingNodeAggregationWhereInput>>
+  OR?: InputMaybe<Array<FieldNextSiblingNodeAggregationWhereInput>>
+  NOT?: InputMaybe<FieldNextSiblingNodeAggregationWhereInput>
+  /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
+  id_EQUAL?: InputMaybe<Scalars['ID']>
+  /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
+  key_EQUAL?: InputMaybe<Scalars['String']>
+  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
+  key_AVERAGE_EQUAL?: InputMaybe<Scalars['Float']>
+  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
+  key_LONGEST_EQUAL?: InputMaybe<Scalars['Int']>
+  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
+  key_SHORTEST_EQUAL?: InputMaybe<Scalars['Int']>
+  key_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars['Float']>
+  key_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars['Int']>
+  key_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars['Int']>
+  /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
+  key_GT?: InputMaybe<Scalars['Int']>
+  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
+  key_AVERAGE_GT?: InputMaybe<Scalars['Float']>
+  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
+  key_LONGEST_GT?: InputMaybe<Scalars['Int']>
+  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
+  key_SHORTEST_GT?: InputMaybe<Scalars['Int']>
+  key_AVERAGE_LENGTH_GT?: InputMaybe<Scalars['Float']>
+  key_LONGEST_LENGTH_GT?: InputMaybe<Scalars['Int']>
+  key_SHORTEST_LENGTH_GT?: InputMaybe<Scalars['Int']>
+  /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
+  key_GTE?: InputMaybe<Scalars['Int']>
+  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
+  key_AVERAGE_GTE?: InputMaybe<Scalars['Float']>
+  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
+  key_LONGEST_GTE?: InputMaybe<Scalars['Int']>
+  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
+  key_SHORTEST_GTE?: InputMaybe<Scalars['Int']>
+  key_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars['Float']>
+  key_LONGEST_LENGTH_GTE?: InputMaybe<Scalars['Int']>
+  key_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars['Int']>
+  /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
+  key_LT?: InputMaybe<Scalars['Int']>
+  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
+  key_AVERAGE_LT?: InputMaybe<Scalars['Float']>
+  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
+  key_LONGEST_LT?: InputMaybe<Scalars['Int']>
+  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
+  key_SHORTEST_LT?: InputMaybe<Scalars['Int']>
+  key_AVERAGE_LENGTH_LT?: InputMaybe<Scalars['Float']>
+  key_LONGEST_LENGTH_LT?: InputMaybe<Scalars['Int']>
+  key_SHORTEST_LENGTH_LT?: InputMaybe<Scalars['Int']>
+  /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
+  key_LTE?: InputMaybe<Scalars['Int']>
+  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
+  key_AVERAGE_LTE?: InputMaybe<Scalars['Float']>
+  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
+  key_LONGEST_LTE?: InputMaybe<Scalars['Int']>
+  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
+  key_SHORTEST_LTE?: InputMaybe<Scalars['Int']>
+  key_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars['Float']>
+  key_LONGEST_LENGTH_LTE?: InputMaybe<Scalars['Int']>
+  key_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars['Int']>
+  /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
+  name_EQUAL?: InputMaybe<Scalars['String']>
+  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
+  name_AVERAGE_EQUAL?: InputMaybe<Scalars['Float']>
+  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
+  name_LONGEST_EQUAL?: InputMaybe<Scalars['Int']>
+  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
+  name_SHORTEST_EQUAL?: InputMaybe<Scalars['Int']>
+  name_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars['Float']>
+  name_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars['Int']>
+  name_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars['Int']>
+  /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
+  name_GT?: InputMaybe<Scalars['Int']>
+  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
+  name_AVERAGE_GT?: InputMaybe<Scalars['Float']>
+  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
+  name_LONGEST_GT?: InputMaybe<Scalars['Int']>
+  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
+  name_SHORTEST_GT?: InputMaybe<Scalars['Int']>
+  name_AVERAGE_LENGTH_GT?: InputMaybe<Scalars['Float']>
+  name_LONGEST_LENGTH_GT?: InputMaybe<Scalars['Int']>
+  name_SHORTEST_LENGTH_GT?: InputMaybe<Scalars['Int']>
+  /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
+  name_GTE?: InputMaybe<Scalars['Int']>
+  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
+  name_AVERAGE_GTE?: InputMaybe<Scalars['Float']>
+  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
+  name_LONGEST_GTE?: InputMaybe<Scalars['Int']>
+  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
+  name_SHORTEST_GTE?: InputMaybe<Scalars['Int']>
+  name_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars['Float']>
+  name_LONGEST_LENGTH_GTE?: InputMaybe<Scalars['Int']>
+  name_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars['Int']>
+  /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
+  name_LT?: InputMaybe<Scalars['Int']>
+  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
+  name_AVERAGE_LT?: InputMaybe<Scalars['Float']>
+  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
+  name_LONGEST_LT?: InputMaybe<Scalars['Int']>
+  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
+  name_SHORTEST_LT?: InputMaybe<Scalars['Int']>
+  name_AVERAGE_LENGTH_LT?: InputMaybe<Scalars['Float']>
+  name_LONGEST_LENGTH_LT?: InputMaybe<Scalars['Int']>
+  name_SHORTEST_LENGTH_LT?: InputMaybe<Scalars['Int']>
+  /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
+  name_LTE?: InputMaybe<Scalars['Int']>
+  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
+  name_AVERAGE_LTE?: InputMaybe<Scalars['Float']>
+  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
+  name_LONGEST_LTE?: InputMaybe<Scalars['Int']>
+  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
+  name_SHORTEST_LTE?: InputMaybe<Scalars['Int']>
+  name_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars['Float']>
+  name_LONGEST_LENGTH_LTE?: InputMaybe<Scalars['Int']>
+  name_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars['Int']>
+  /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
+  description_EQUAL?: InputMaybe<Scalars['String']>
+  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
+  description_AVERAGE_EQUAL?: InputMaybe<Scalars['Float']>
+  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
+  description_LONGEST_EQUAL?: InputMaybe<Scalars['Int']>
+  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
+  description_SHORTEST_EQUAL?: InputMaybe<Scalars['Int']>
+  description_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars['Float']>
+  description_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars['Int']>
+  description_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars['Int']>
+  /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
+  description_GT?: InputMaybe<Scalars['Int']>
+  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
+  description_AVERAGE_GT?: InputMaybe<Scalars['Float']>
+  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
+  description_LONGEST_GT?: InputMaybe<Scalars['Int']>
+  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
+  description_SHORTEST_GT?: InputMaybe<Scalars['Int']>
+  description_AVERAGE_LENGTH_GT?: InputMaybe<Scalars['Float']>
+  description_LONGEST_LENGTH_GT?: InputMaybe<Scalars['Int']>
+  description_SHORTEST_LENGTH_GT?: InputMaybe<Scalars['Int']>
+  /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
+  description_GTE?: InputMaybe<Scalars['Int']>
+  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
+  description_AVERAGE_GTE?: InputMaybe<Scalars['Float']>
+  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
+  description_LONGEST_GTE?: InputMaybe<Scalars['Int']>
+  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
+  description_SHORTEST_GTE?: InputMaybe<Scalars['Int']>
+  description_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars['Float']>
+  description_LONGEST_LENGTH_GTE?: InputMaybe<Scalars['Int']>
+  description_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars['Int']>
+  /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
+  description_LT?: InputMaybe<Scalars['Int']>
+  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
+  description_AVERAGE_LT?: InputMaybe<Scalars['Float']>
+  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
+  description_LONGEST_LT?: InputMaybe<Scalars['Int']>
+  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
+  description_SHORTEST_LT?: InputMaybe<Scalars['Int']>
+  description_AVERAGE_LENGTH_LT?: InputMaybe<Scalars['Float']>
+  description_LONGEST_LENGTH_LT?: InputMaybe<Scalars['Int']>
+  description_SHORTEST_LENGTH_LT?: InputMaybe<Scalars['Int']>
+  /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
+  description_LTE?: InputMaybe<Scalars['Int']>
+  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
+  description_AVERAGE_LTE?: InputMaybe<Scalars['Float']>
+  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
+  description_LONGEST_LTE?: InputMaybe<Scalars['Int']>
+  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
+  description_SHORTEST_LTE?: InputMaybe<Scalars['Int']>
+  description_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars['Float']>
+  description_LONGEST_LENGTH_LTE?: InputMaybe<Scalars['Int']>
+  description_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars['Int']>
+  /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
+  validationRules_EQUAL?: InputMaybe<Scalars['String']>
+  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
+  validationRules_AVERAGE_EQUAL?: InputMaybe<Scalars['Float']>
+  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
+  validationRules_LONGEST_EQUAL?: InputMaybe<Scalars['Int']>
+  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
+  validationRules_SHORTEST_EQUAL?: InputMaybe<Scalars['Int']>
+  validationRules_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars['Float']>
+  validationRules_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars['Int']>
+  validationRules_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars['Int']>
+  /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
+  validationRules_GT?: InputMaybe<Scalars['Int']>
+  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
+  validationRules_AVERAGE_GT?: InputMaybe<Scalars['Float']>
+  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
+  validationRules_LONGEST_GT?: InputMaybe<Scalars['Int']>
+  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
+  validationRules_SHORTEST_GT?: InputMaybe<Scalars['Int']>
+  validationRules_AVERAGE_LENGTH_GT?: InputMaybe<Scalars['Float']>
+  validationRules_LONGEST_LENGTH_GT?: InputMaybe<Scalars['Int']>
+  validationRules_SHORTEST_LENGTH_GT?: InputMaybe<Scalars['Int']>
+  /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
+  validationRules_GTE?: InputMaybe<Scalars['Int']>
+  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
+  validationRules_AVERAGE_GTE?: InputMaybe<Scalars['Float']>
+  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
+  validationRules_LONGEST_GTE?: InputMaybe<Scalars['Int']>
+  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
+  validationRules_SHORTEST_GTE?: InputMaybe<Scalars['Int']>
+  validationRules_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars['Float']>
+  validationRules_LONGEST_LENGTH_GTE?: InputMaybe<Scalars['Int']>
+  validationRules_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars['Int']>
+  /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
+  validationRules_LT?: InputMaybe<Scalars['Int']>
+  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
+  validationRules_AVERAGE_LT?: InputMaybe<Scalars['Float']>
+  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
+  validationRules_LONGEST_LT?: InputMaybe<Scalars['Int']>
+  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
+  validationRules_SHORTEST_LT?: InputMaybe<Scalars['Int']>
+  validationRules_AVERAGE_LENGTH_LT?: InputMaybe<Scalars['Float']>
+  validationRules_LONGEST_LENGTH_LT?: InputMaybe<Scalars['Int']>
+  validationRules_SHORTEST_LENGTH_LT?: InputMaybe<Scalars['Int']>
+  /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
+  validationRules_LTE?: InputMaybe<Scalars['Int']>
+  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
+  validationRules_AVERAGE_LTE?: InputMaybe<Scalars['Float']>
+  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
+  validationRules_LONGEST_LTE?: InputMaybe<Scalars['Int']>
+  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
+  validationRules_SHORTEST_LTE?: InputMaybe<Scalars['Int']>
+  validationRules_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars['Float']>
+  validationRules_LONGEST_LENGTH_LTE?: InputMaybe<Scalars['Int']>
+  validationRules_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars['Int']>
+  /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
+  defaultValues_EQUAL?: InputMaybe<Scalars['String']>
+  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
+  defaultValues_AVERAGE_EQUAL?: InputMaybe<Scalars['Float']>
+  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
+  defaultValues_LONGEST_EQUAL?: InputMaybe<Scalars['Int']>
+  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
+  defaultValues_SHORTEST_EQUAL?: InputMaybe<Scalars['Int']>
+  defaultValues_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars['Float']>
+  defaultValues_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars['Int']>
+  defaultValues_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars['Int']>
+  /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
+  defaultValues_GT?: InputMaybe<Scalars['Int']>
+  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
+  defaultValues_AVERAGE_GT?: InputMaybe<Scalars['Float']>
+  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
+  defaultValues_LONGEST_GT?: InputMaybe<Scalars['Int']>
+  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
+  defaultValues_SHORTEST_GT?: InputMaybe<Scalars['Int']>
+  defaultValues_AVERAGE_LENGTH_GT?: InputMaybe<Scalars['Float']>
+  defaultValues_LONGEST_LENGTH_GT?: InputMaybe<Scalars['Int']>
+  defaultValues_SHORTEST_LENGTH_GT?: InputMaybe<Scalars['Int']>
+  /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
+  defaultValues_GTE?: InputMaybe<Scalars['Int']>
+  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
+  defaultValues_AVERAGE_GTE?: InputMaybe<Scalars['Float']>
+  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
+  defaultValues_LONGEST_GTE?: InputMaybe<Scalars['Int']>
+  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
+  defaultValues_SHORTEST_GTE?: InputMaybe<Scalars['Int']>
+  defaultValues_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars['Float']>
+  defaultValues_LONGEST_LENGTH_GTE?: InputMaybe<Scalars['Int']>
+  defaultValues_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars['Int']>
+  /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
+  defaultValues_LT?: InputMaybe<Scalars['Int']>
+  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
+  defaultValues_AVERAGE_LT?: InputMaybe<Scalars['Float']>
+  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
+  defaultValues_LONGEST_LT?: InputMaybe<Scalars['Int']>
+  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
+  defaultValues_SHORTEST_LT?: InputMaybe<Scalars['Int']>
+  defaultValues_AVERAGE_LENGTH_LT?: InputMaybe<Scalars['Float']>
+  defaultValues_LONGEST_LENGTH_LT?: InputMaybe<Scalars['Int']>
+  defaultValues_SHORTEST_LENGTH_LT?: InputMaybe<Scalars['Int']>
+  /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
+  defaultValues_LTE?: InputMaybe<Scalars['Int']>
+  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
+  defaultValues_AVERAGE_LTE?: InputMaybe<Scalars['Float']>
+  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
+  defaultValues_LONGEST_LTE?: InputMaybe<Scalars['Int']>
+  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
+  defaultValues_SHORTEST_LTE?: InputMaybe<Scalars['Int']>
+  defaultValues_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars['Float']>
+  defaultValues_LONGEST_LENGTH_LTE?: InputMaybe<Scalars['Int']>
+  defaultValues_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars['Int']>
+}
+
+export type FieldNextSiblingUpdateConnectionInput = {
+  node?: InputMaybe<FieldUpdateInput>
+}
+
+export type FieldNextSiblingUpdateFieldInput = {
+  where?: InputMaybe<FieldNextSiblingConnectionWhere>
+  update?: InputMaybe<FieldNextSiblingUpdateConnectionInput>
+  connect?: InputMaybe<FieldNextSiblingConnectFieldInput>
+  disconnect?: InputMaybe<FieldNextSiblingDisconnectFieldInput>
+  create?: InputMaybe<FieldNextSiblingCreateFieldInput>
+  delete?: InputMaybe<FieldNextSiblingDeleteFieldInput>
+}
+
 export type FieldOptions = {
   /** Specify one or more FieldSort objects to sort Fields by. The sorts will be applied in the order in which they are arranged in the array. */
   sort?: InputMaybe<Array<FieldSort>>
@@ -19885,7 +20342,356 @@ export type FieldOptions = {
   offset?: InputMaybe<Scalars['Int']>
 }
 
+export type FieldPrevSiblingAggregateInput = {
+  count?: InputMaybe<Scalars['Int']>
+  count_LT?: InputMaybe<Scalars['Int']>
+  count_LTE?: InputMaybe<Scalars['Int']>
+  count_GT?: InputMaybe<Scalars['Int']>
+  count_GTE?: InputMaybe<Scalars['Int']>
+  AND?: InputMaybe<Array<FieldPrevSiblingAggregateInput>>
+  OR?: InputMaybe<Array<FieldPrevSiblingAggregateInput>>
+  NOT?: InputMaybe<FieldPrevSiblingAggregateInput>
+  node?: InputMaybe<FieldPrevSiblingNodeAggregationWhereInput>
+}
+
+export type FieldPrevSiblingConnectFieldInput = {
+  where?: InputMaybe<FieldConnectWhere>
+  connect?: InputMaybe<FieldConnectInput>
+  /** Whether or not to overwrite any matching relationship with the new properties. Will default to `false` in 4.0.0. */
+  overwrite?: Scalars['Boolean']
+}
+
+export type FieldPrevSiblingConnectionSort = {
+  node?: InputMaybe<FieldSort>
+}
+
+export type FieldPrevSiblingConnectionWhere = {
+  AND?: InputMaybe<Array<FieldPrevSiblingConnectionWhere>>
+  OR?: InputMaybe<Array<FieldPrevSiblingConnectionWhere>>
+  NOT?: InputMaybe<FieldPrevSiblingConnectionWhere>
+  node?: InputMaybe<FieldWhere>
+  /** @deprecated Negation filters will be deprecated, use the NOT operator to achieve the same behavior */
+  node_NOT?: InputMaybe<FieldWhere>
+}
+
+export type FieldPrevSiblingCreateFieldInput = {
+  node: FieldCreateInput
+}
+
+export type FieldPrevSiblingDeleteFieldInput = {
+  where?: InputMaybe<FieldPrevSiblingConnectionWhere>
+  delete?: InputMaybe<FieldDeleteInput>
+}
+
+export type FieldPrevSiblingDisconnectFieldInput = {
+  where?: InputMaybe<FieldPrevSiblingConnectionWhere>
+  disconnect?: InputMaybe<FieldDisconnectInput>
+}
+
+export type FieldPrevSiblingFieldInput = {
+  create?: InputMaybe<FieldPrevSiblingCreateFieldInput>
+  connect?: InputMaybe<FieldPrevSiblingConnectFieldInput>
+}
+
+export type FieldPrevSiblingNodeAggregationWhereInput = {
+  AND?: InputMaybe<Array<FieldPrevSiblingNodeAggregationWhereInput>>
+  OR?: InputMaybe<Array<FieldPrevSiblingNodeAggregationWhereInput>>
+  NOT?: InputMaybe<FieldPrevSiblingNodeAggregationWhereInput>
+  /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
+  id_EQUAL?: InputMaybe<Scalars['ID']>
+  /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
+  key_EQUAL?: InputMaybe<Scalars['String']>
+  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
+  key_AVERAGE_EQUAL?: InputMaybe<Scalars['Float']>
+  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
+  key_LONGEST_EQUAL?: InputMaybe<Scalars['Int']>
+  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
+  key_SHORTEST_EQUAL?: InputMaybe<Scalars['Int']>
+  key_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars['Float']>
+  key_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars['Int']>
+  key_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars['Int']>
+  /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
+  key_GT?: InputMaybe<Scalars['Int']>
+  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
+  key_AVERAGE_GT?: InputMaybe<Scalars['Float']>
+  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
+  key_LONGEST_GT?: InputMaybe<Scalars['Int']>
+  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
+  key_SHORTEST_GT?: InputMaybe<Scalars['Int']>
+  key_AVERAGE_LENGTH_GT?: InputMaybe<Scalars['Float']>
+  key_LONGEST_LENGTH_GT?: InputMaybe<Scalars['Int']>
+  key_SHORTEST_LENGTH_GT?: InputMaybe<Scalars['Int']>
+  /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
+  key_GTE?: InputMaybe<Scalars['Int']>
+  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
+  key_AVERAGE_GTE?: InputMaybe<Scalars['Float']>
+  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
+  key_LONGEST_GTE?: InputMaybe<Scalars['Int']>
+  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
+  key_SHORTEST_GTE?: InputMaybe<Scalars['Int']>
+  key_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars['Float']>
+  key_LONGEST_LENGTH_GTE?: InputMaybe<Scalars['Int']>
+  key_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars['Int']>
+  /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
+  key_LT?: InputMaybe<Scalars['Int']>
+  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
+  key_AVERAGE_LT?: InputMaybe<Scalars['Float']>
+  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
+  key_LONGEST_LT?: InputMaybe<Scalars['Int']>
+  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
+  key_SHORTEST_LT?: InputMaybe<Scalars['Int']>
+  key_AVERAGE_LENGTH_LT?: InputMaybe<Scalars['Float']>
+  key_LONGEST_LENGTH_LT?: InputMaybe<Scalars['Int']>
+  key_SHORTEST_LENGTH_LT?: InputMaybe<Scalars['Int']>
+  /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
+  key_LTE?: InputMaybe<Scalars['Int']>
+  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
+  key_AVERAGE_LTE?: InputMaybe<Scalars['Float']>
+  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
+  key_LONGEST_LTE?: InputMaybe<Scalars['Int']>
+  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
+  key_SHORTEST_LTE?: InputMaybe<Scalars['Int']>
+  key_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars['Float']>
+  key_LONGEST_LENGTH_LTE?: InputMaybe<Scalars['Int']>
+  key_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars['Int']>
+  /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
+  name_EQUAL?: InputMaybe<Scalars['String']>
+  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
+  name_AVERAGE_EQUAL?: InputMaybe<Scalars['Float']>
+  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
+  name_LONGEST_EQUAL?: InputMaybe<Scalars['Int']>
+  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
+  name_SHORTEST_EQUAL?: InputMaybe<Scalars['Int']>
+  name_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars['Float']>
+  name_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars['Int']>
+  name_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars['Int']>
+  /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
+  name_GT?: InputMaybe<Scalars['Int']>
+  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
+  name_AVERAGE_GT?: InputMaybe<Scalars['Float']>
+  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
+  name_LONGEST_GT?: InputMaybe<Scalars['Int']>
+  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
+  name_SHORTEST_GT?: InputMaybe<Scalars['Int']>
+  name_AVERAGE_LENGTH_GT?: InputMaybe<Scalars['Float']>
+  name_LONGEST_LENGTH_GT?: InputMaybe<Scalars['Int']>
+  name_SHORTEST_LENGTH_GT?: InputMaybe<Scalars['Int']>
+  /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
+  name_GTE?: InputMaybe<Scalars['Int']>
+  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
+  name_AVERAGE_GTE?: InputMaybe<Scalars['Float']>
+  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
+  name_LONGEST_GTE?: InputMaybe<Scalars['Int']>
+  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
+  name_SHORTEST_GTE?: InputMaybe<Scalars['Int']>
+  name_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars['Float']>
+  name_LONGEST_LENGTH_GTE?: InputMaybe<Scalars['Int']>
+  name_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars['Int']>
+  /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
+  name_LT?: InputMaybe<Scalars['Int']>
+  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
+  name_AVERAGE_LT?: InputMaybe<Scalars['Float']>
+  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
+  name_LONGEST_LT?: InputMaybe<Scalars['Int']>
+  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
+  name_SHORTEST_LT?: InputMaybe<Scalars['Int']>
+  name_AVERAGE_LENGTH_LT?: InputMaybe<Scalars['Float']>
+  name_LONGEST_LENGTH_LT?: InputMaybe<Scalars['Int']>
+  name_SHORTEST_LENGTH_LT?: InputMaybe<Scalars['Int']>
+  /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
+  name_LTE?: InputMaybe<Scalars['Int']>
+  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
+  name_AVERAGE_LTE?: InputMaybe<Scalars['Float']>
+  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
+  name_LONGEST_LTE?: InputMaybe<Scalars['Int']>
+  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
+  name_SHORTEST_LTE?: InputMaybe<Scalars['Int']>
+  name_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars['Float']>
+  name_LONGEST_LENGTH_LTE?: InputMaybe<Scalars['Int']>
+  name_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars['Int']>
+  /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
+  description_EQUAL?: InputMaybe<Scalars['String']>
+  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
+  description_AVERAGE_EQUAL?: InputMaybe<Scalars['Float']>
+  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
+  description_LONGEST_EQUAL?: InputMaybe<Scalars['Int']>
+  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
+  description_SHORTEST_EQUAL?: InputMaybe<Scalars['Int']>
+  description_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars['Float']>
+  description_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars['Int']>
+  description_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars['Int']>
+  /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
+  description_GT?: InputMaybe<Scalars['Int']>
+  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
+  description_AVERAGE_GT?: InputMaybe<Scalars['Float']>
+  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
+  description_LONGEST_GT?: InputMaybe<Scalars['Int']>
+  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
+  description_SHORTEST_GT?: InputMaybe<Scalars['Int']>
+  description_AVERAGE_LENGTH_GT?: InputMaybe<Scalars['Float']>
+  description_LONGEST_LENGTH_GT?: InputMaybe<Scalars['Int']>
+  description_SHORTEST_LENGTH_GT?: InputMaybe<Scalars['Int']>
+  /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
+  description_GTE?: InputMaybe<Scalars['Int']>
+  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
+  description_AVERAGE_GTE?: InputMaybe<Scalars['Float']>
+  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
+  description_LONGEST_GTE?: InputMaybe<Scalars['Int']>
+  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
+  description_SHORTEST_GTE?: InputMaybe<Scalars['Int']>
+  description_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars['Float']>
+  description_LONGEST_LENGTH_GTE?: InputMaybe<Scalars['Int']>
+  description_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars['Int']>
+  /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
+  description_LT?: InputMaybe<Scalars['Int']>
+  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
+  description_AVERAGE_LT?: InputMaybe<Scalars['Float']>
+  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
+  description_LONGEST_LT?: InputMaybe<Scalars['Int']>
+  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
+  description_SHORTEST_LT?: InputMaybe<Scalars['Int']>
+  description_AVERAGE_LENGTH_LT?: InputMaybe<Scalars['Float']>
+  description_LONGEST_LENGTH_LT?: InputMaybe<Scalars['Int']>
+  description_SHORTEST_LENGTH_LT?: InputMaybe<Scalars['Int']>
+  /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
+  description_LTE?: InputMaybe<Scalars['Int']>
+  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
+  description_AVERAGE_LTE?: InputMaybe<Scalars['Float']>
+  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
+  description_LONGEST_LTE?: InputMaybe<Scalars['Int']>
+  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
+  description_SHORTEST_LTE?: InputMaybe<Scalars['Int']>
+  description_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars['Float']>
+  description_LONGEST_LENGTH_LTE?: InputMaybe<Scalars['Int']>
+  description_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars['Int']>
+  /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
+  validationRules_EQUAL?: InputMaybe<Scalars['String']>
+  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
+  validationRules_AVERAGE_EQUAL?: InputMaybe<Scalars['Float']>
+  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
+  validationRules_LONGEST_EQUAL?: InputMaybe<Scalars['Int']>
+  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
+  validationRules_SHORTEST_EQUAL?: InputMaybe<Scalars['Int']>
+  validationRules_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars['Float']>
+  validationRules_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars['Int']>
+  validationRules_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars['Int']>
+  /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
+  validationRules_GT?: InputMaybe<Scalars['Int']>
+  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
+  validationRules_AVERAGE_GT?: InputMaybe<Scalars['Float']>
+  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
+  validationRules_LONGEST_GT?: InputMaybe<Scalars['Int']>
+  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
+  validationRules_SHORTEST_GT?: InputMaybe<Scalars['Int']>
+  validationRules_AVERAGE_LENGTH_GT?: InputMaybe<Scalars['Float']>
+  validationRules_LONGEST_LENGTH_GT?: InputMaybe<Scalars['Int']>
+  validationRules_SHORTEST_LENGTH_GT?: InputMaybe<Scalars['Int']>
+  /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
+  validationRules_GTE?: InputMaybe<Scalars['Int']>
+  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
+  validationRules_AVERAGE_GTE?: InputMaybe<Scalars['Float']>
+  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
+  validationRules_LONGEST_GTE?: InputMaybe<Scalars['Int']>
+  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
+  validationRules_SHORTEST_GTE?: InputMaybe<Scalars['Int']>
+  validationRules_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars['Float']>
+  validationRules_LONGEST_LENGTH_GTE?: InputMaybe<Scalars['Int']>
+  validationRules_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars['Int']>
+  /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
+  validationRules_LT?: InputMaybe<Scalars['Int']>
+  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
+  validationRules_AVERAGE_LT?: InputMaybe<Scalars['Float']>
+  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
+  validationRules_LONGEST_LT?: InputMaybe<Scalars['Int']>
+  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
+  validationRules_SHORTEST_LT?: InputMaybe<Scalars['Int']>
+  validationRules_AVERAGE_LENGTH_LT?: InputMaybe<Scalars['Float']>
+  validationRules_LONGEST_LENGTH_LT?: InputMaybe<Scalars['Int']>
+  validationRules_SHORTEST_LENGTH_LT?: InputMaybe<Scalars['Int']>
+  /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
+  validationRules_LTE?: InputMaybe<Scalars['Int']>
+  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
+  validationRules_AVERAGE_LTE?: InputMaybe<Scalars['Float']>
+  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
+  validationRules_LONGEST_LTE?: InputMaybe<Scalars['Int']>
+  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
+  validationRules_SHORTEST_LTE?: InputMaybe<Scalars['Int']>
+  validationRules_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars['Float']>
+  validationRules_LONGEST_LENGTH_LTE?: InputMaybe<Scalars['Int']>
+  validationRules_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars['Int']>
+  /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
+  defaultValues_EQUAL?: InputMaybe<Scalars['String']>
+  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
+  defaultValues_AVERAGE_EQUAL?: InputMaybe<Scalars['Float']>
+  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
+  defaultValues_LONGEST_EQUAL?: InputMaybe<Scalars['Int']>
+  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
+  defaultValues_SHORTEST_EQUAL?: InputMaybe<Scalars['Int']>
+  defaultValues_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars['Float']>
+  defaultValues_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars['Int']>
+  defaultValues_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars['Int']>
+  /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
+  defaultValues_GT?: InputMaybe<Scalars['Int']>
+  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
+  defaultValues_AVERAGE_GT?: InputMaybe<Scalars['Float']>
+  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
+  defaultValues_LONGEST_GT?: InputMaybe<Scalars['Int']>
+  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
+  defaultValues_SHORTEST_GT?: InputMaybe<Scalars['Int']>
+  defaultValues_AVERAGE_LENGTH_GT?: InputMaybe<Scalars['Float']>
+  defaultValues_LONGEST_LENGTH_GT?: InputMaybe<Scalars['Int']>
+  defaultValues_SHORTEST_LENGTH_GT?: InputMaybe<Scalars['Int']>
+  /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
+  defaultValues_GTE?: InputMaybe<Scalars['Int']>
+  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
+  defaultValues_AVERAGE_GTE?: InputMaybe<Scalars['Float']>
+  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
+  defaultValues_LONGEST_GTE?: InputMaybe<Scalars['Int']>
+  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
+  defaultValues_SHORTEST_GTE?: InputMaybe<Scalars['Int']>
+  defaultValues_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars['Float']>
+  defaultValues_LONGEST_LENGTH_GTE?: InputMaybe<Scalars['Int']>
+  defaultValues_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars['Int']>
+  /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
+  defaultValues_LT?: InputMaybe<Scalars['Int']>
+  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
+  defaultValues_AVERAGE_LT?: InputMaybe<Scalars['Float']>
+  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
+  defaultValues_LONGEST_LT?: InputMaybe<Scalars['Int']>
+  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
+  defaultValues_SHORTEST_LT?: InputMaybe<Scalars['Int']>
+  defaultValues_AVERAGE_LENGTH_LT?: InputMaybe<Scalars['Float']>
+  defaultValues_LONGEST_LENGTH_LT?: InputMaybe<Scalars['Int']>
+  defaultValues_SHORTEST_LENGTH_LT?: InputMaybe<Scalars['Int']>
+  /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
+  defaultValues_LTE?: InputMaybe<Scalars['Int']>
+  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
+  defaultValues_AVERAGE_LTE?: InputMaybe<Scalars['Float']>
+  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
+  defaultValues_LONGEST_LTE?: InputMaybe<Scalars['Int']>
+  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
+  defaultValues_SHORTEST_LTE?: InputMaybe<Scalars['Int']>
+  defaultValues_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars['Float']>
+  defaultValues_LONGEST_LENGTH_LTE?: InputMaybe<Scalars['Int']>
+  defaultValues_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars['Int']>
+}
+
+export type FieldPrevSiblingUpdateConnectionInput = {
+  node?: InputMaybe<FieldUpdateInput>
+}
+
+export type FieldPrevSiblingUpdateFieldInput = {
+  where?: InputMaybe<FieldPrevSiblingConnectionWhere>
+  update?: InputMaybe<FieldPrevSiblingUpdateConnectionInput>
+  connect?: InputMaybe<FieldPrevSiblingConnectFieldInput>
+  disconnect?: InputMaybe<FieldPrevSiblingDisconnectFieldInput>
+  create?: InputMaybe<FieldPrevSiblingCreateFieldInput>
+  delete?: InputMaybe<FieldPrevSiblingDeleteFieldInput>
+}
+
 export type FieldRelationInput = {
+  nextSibling?: InputMaybe<FieldNextSiblingCreateFieldInput>
+  prevSibling?: InputMaybe<FieldPrevSiblingCreateFieldInput>
   fieldType?: InputMaybe<FieldFieldTypeCreateFieldInput>
   api?: InputMaybe<FieldApiCreateFieldInput>
 }
@@ -19907,6 +20713,8 @@ export type FieldUpdateInput = {
   description?: InputMaybe<Scalars['String']>
   validationRules?: InputMaybe<Scalars['String']>
   defaultValues?: InputMaybe<Scalars['String']>
+  nextSibling?: InputMaybe<FieldNextSiblingUpdateFieldInput>
+  prevSibling?: InputMaybe<FieldPrevSiblingUpdateFieldInput>
   fieldType?: InputMaybe<FieldFieldTypeUpdateFieldInput>
   api?: InputMaybe<FieldApiUpdateFieldInput>
 }
@@ -20011,9 +20819,19 @@ export type FieldWhere = {
   defaultValues_NOT_STARTS_WITH?: InputMaybe<Scalars['String']>
   /** @deprecated Negation filters will be deprecated, use the NOT operator to achieve the same behavior */
   defaultValues_NOT_ENDS_WITH?: InputMaybe<Scalars['String']>
+  nextSibling?: InputMaybe<FieldWhere>
+  nextSibling_NOT?: InputMaybe<FieldWhere>
+  nextSiblingAggregate?: InputMaybe<FieldNextSiblingAggregateInput>
+  prevSibling?: InputMaybe<FieldWhere>
+  prevSibling_NOT?: InputMaybe<FieldWhere>
+  prevSiblingAggregate?: InputMaybe<FieldPrevSiblingAggregateInput>
   api?: InputMaybe<InterfaceTypeWhere>
   api_NOT?: InputMaybe<InterfaceTypeWhere>
   apiAggregate?: InputMaybe<FieldApiAggregateInput>
+  nextSiblingConnection?: InputMaybe<FieldNextSiblingConnectionWhere>
+  nextSiblingConnection_NOT?: InputMaybe<FieldNextSiblingConnectionWhere>
+  prevSiblingConnection?: InputMaybe<FieldPrevSiblingConnectionWhere>
+  prevSiblingConnection_NOT?: InputMaybe<FieldPrevSiblingConnectionWhere>
   fieldTypeConnection?: InputMaybe<FieldFieldTypeConnectionWhere>
   fieldTypeConnection_NOT?: InputMaybe<FieldFieldTypeConnectionWhere>
   apiConnection?: InputMaybe<FieldApiConnectionWhere>

--- a/libs/shared/abstract/codegen/src/types.api.graphql.gen.ts
+++ b/libs/shared/abstract/codegen/src/types.api.graphql.gen.ts
@@ -9968,6 +9968,12 @@ export type Field = {
   id: Scalars['ID']
   key: Scalars['String']
   name?: Maybe<Scalars['String']>
+  nextSibling?: Maybe<Field>
+  nextSiblingAggregate?: Maybe<FieldFieldNextSiblingAggregationSelection>
+  nextSiblingConnection: FieldNextSiblingConnection
+  prevSibling?: Maybe<Field>
+  prevSiblingAggregate?: Maybe<FieldFieldPrevSiblingAggregationSelection>
+  prevSiblingConnection: FieldPrevSiblingConnection
   validationRules?: Maybe<Scalars['String']>
 }
 
@@ -10002,6 +10008,44 @@ export type FieldFieldTypeConnectionArgs = {
   first?: InputMaybe<Scalars['Int']>
   sort?: InputMaybe<Array<FieldFieldTypeConnectionSort>>
   where?: InputMaybe<FieldFieldTypeConnectionWhere>
+}
+
+export type FieldNextSiblingArgs = {
+  directed?: InputMaybe<Scalars['Boolean']>
+  options?: InputMaybe<FieldOptions>
+  where?: InputMaybe<FieldWhere>
+}
+
+export type FieldNextSiblingAggregateArgs = {
+  directed?: InputMaybe<Scalars['Boolean']>
+  where?: InputMaybe<FieldWhere>
+}
+
+export type FieldNextSiblingConnectionArgs = {
+  after?: InputMaybe<Scalars['String']>
+  directed?: InputMaybe<Scalars['Boolean']>
+  first?: InputMaybe<Scalars['Int']>
+  sort?: InputMaybe<Array<FieldNextSiblingConnectionSort>>
+  where?: InputMaybe<FieldNextSiblingConnectionWhere>
+}
+
+export type FieldPrevSiblingArgs = {
+  directed?: InputMaybe<Scalars['Boolean']>
+  options?: InputMaybe<FieldOptions>
+  where?: InputMaybe<FieldWhere>
+}
+
+export type FieldPrevSiblingAggregateArgs = {
+  directed?: InputMaybe<Scalars['Boolean']>
+  where?: InputMaybe<FieldWhere>
+}
+
+export type FieldPrevSiblingConnectionArgs = {
+  after?: InputMaybe<Scalars['String']>
+  directed?: InputMaybe<Scalars['Boolean']>
+  first?: InputMaybe<Scalars['Int']>
+  sort?: InputMaybe<Array<FieldPrevSiblingConnectionSort>>
+  where?: InputMaybe<FieldPrevSiblingConnectionWhere>
 }
 
 export type FieldAggregateSelection = {
@@ -10125,6 +10169,8 @@ export type FieldApiUpdateFieldInput = {
 export type FieldConnectInput = {
   api?: InputMaybe<FieldApiConnectFieldInput>
   fieldType?: InputMaybe<FieldFieldTypeConnectFieldInput>
+  nextSibling?: InputMaybe<FieldNextSiblingConnectFieldInput>
+  prevSibling?: InputMaybe<FieldPrevSiblingConnectFieldInput>
 }
 
 export type FieldConnectOrCreateInput = {
@@ -10143,23 +10189,61 @@ export type FieldCreateInput = {
   id: Scalars['ID']
   key: Scalars['String']
   name?: InputMaybe<Scalars['String']>
+  nextSibling?: InputMaybe<FieldNextSiblingFieldInput>
+  prevSibling?: InputMaybe<FieldPrevSiblingFieldInput>
   validationRules?: InputMaybe<Scalars['String']>
 }
 
 export type FieldDeleteInput = {
   api?: InputMaybe<FieldApiDeleteFieldInput>
   fieldType?: InputMaybe<FieldFieldTypeDeleteFieldInput>
+  nextSibling?: InputMaybe<FieldNextSiblingDeleteFieldInput>
+  prevSibling?: InputMaybe<FieldPrevSiblingDeleteFieldInput>
 }
 
 export type FieldDisconnectInput = {
   api?: InputMaybe<FieldApiDisconnectFieldInput>
   fieldType?: InputMaybe<FieldFieldTypeDisconnectFieldInput>
+  nextSibling?: InputMaybe<FieldNextSiblingDisconnectFieldInput>
+  prevSibling?: InputMaybe<FieldPrevSiblingDisconnectFieldInput>
 }
 
 export type FieldEdge = {
   __typename?: 'FieldEdge'
   cursor: Scalars['String']
   node: Field
+}
+
+export type FieldFieldNextSiblingAggregationSelection = {
+  __typename?: 'FieldFieldNextSiblingAggregationSelection'
+  count: Scalars['Int']
+  node?: Maybe<FieldFieldNextSiblingNodeAggregateSelection>
+}
+
+export type FieldFieldNextSiblingNodeAggregateSelection = {
+  __typename?: 'FieldFieldNextSiblingNodeAggregateSelection'
+  defaultValues: StringAggregateSelectionNullable
+  description: StringAggregateSelectionNullable
+  id: IdAggregateSelectionNonNullable
+  key: StringAggregateSelectionNonNullable
+  name: StringAggregateSelectionNullable
+  validationRules: StringAggregateSelectionNullable
+}
+
+export type FieldFieldPrevSiblingAggregationSelection = {
+  __typename?: 'FieldFieldPrevSiblingAggregationSelection'
+  count: Scalars['Int']
+  node?: Maybe<FieldFieldPrevSiblingNodeAggregateSelection>
+}
+
+export type FieldFieldPrevSiblingNodeAggregateSelection = {
+  __typename?: 'FieldFieldPrevSiblingNodeAggregateSelection'
+  defaultValues: StringAggregateSelectionNullable
+  description: StringAggregateSelectionNullable
+  id: IdAggregateSelectionNonNullable
+  key: StringAggregateSelectionNonNullable
+  name: StringAggregateSelectionNullable
+  validationRules: StringAggregateSelectionNullable
 }
 
 export type FieldFieldTypeConnectFieldInput = {
@@ -10235,6 +10319,162 @@ export type FieldInterfaceTypeApiNodeAggregateSelection = {
   name: StringAggregateSelectionNonNullable
 }
 
+export type FieldNextSiblingAggregateInput = {
+  AND?: InputMaybe<Array<FieldNextSiblingAggregateInput>>
+  NOT?: InputMaybe<FieldNextSiblingAggregateInput>
+  OR?: InputMaybe<Array<FieldNextSiblingAggregateInput>>
+  count?: InputMaybe<Scalars['Int']>
+  count_GT?: InputMaybe<Scalars['Int']>
+  count_GTE?: InputMaybe<Scalars['Int']>
+  count_LT?: InputMaybe<Scalars['Int']>
+  count_LTE?: InputMaybe<Scalars['Int']>
+  node?: InputMaybe<FieldNextSiblingNodeAggregationWhereInput>
+}
+
+export type FieldNextSiblingConnectFieldInput = {
+  connect?: InputMaybe<FieldConnectInput>
+  /** Whether or not to overwrite any matching relationship with the new properties. Will default to `false` in 4.0.0. */
+  overwrite?: Scalars['Boolean']
+  where?: InputMaybe<FieldConnectWhere>
+}
+
+export type FieldNextSiblingConnection = {
+  __typename?: 'FieldNextSiblingConnection'
+  edges: Array<FieldNextSiblingRelationship>
+  pageInfo: PageInfo
+  totalCount: Scalars['Int']
+}
+
+export type FieldNextSiblingConnectionSort = {
+  node?: InputMaybe<FieldSort>
+}
+
+export type FieldNextSiblingConnectionWhere = {
+  AND?: InputMaybe<Array<FieldNextSiblingConnectionWhere>>
+  NOT?: InputMaybe<FieldNextSiblingConnectionWhere>
+  OR?: InputMaybe<Array<FieldNextSiblingConnectionWhere>>
+  node?: InputMaybe<FieldWhere>
+}
+
+export type FieldNextSiblingCreateFieldInput = {
+  node: FieldCreateInput
+}
+
+export type FieldNextSiblingDeleteFieldInput = {
+  delete?: InputMaybe<FieldDeleteInput>
+  where?: InputMaybe<FieldNextSiblingConnectionWhere>
+}
+
+export type FieldNextSiblingDisconnectFieldInput = {
+  disconnect?: InputMaybe<FieldDisconnectInput>
+  where?: InputMaybe<FieldNextSiblingConnectionWhere>
+}
+
+export type FieldNextSiblingFieldInput = {
+  connect?: InputMaybe<FieldNextSiblingConnectFieldInput>
+  create?: InputMaybe<FieldNextSiblingCreateFieldInput>
+}
+
+export type FieldNextSiblingNodeAggregationWhereInput = {
+  AND?: InputMaybe<Array<FieldNextSiblingNodeAggregationWhereInput>>
+  NOT?: InputMaybe<FieldNextSiblingNodeAggregationWhereInput>
+  OR?: InputMaybe<Array<FieldNextSiblingNodeAggregationWhereInput>>
+  defaultValues_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars['Float']>
+  defaultValues_AVERAGE_LENGTH_GT?: InputMaybe<Scalars['Float']>
+  defaultValues_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars['Float']>
+  defaultValues_AVERAGE_LENGTH_LT?: InputMaybe<Scalars['Float']>
+  defaultValues_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars['Float']>
+  defaultValues_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars['Int']>
+  defaultValues_LONGEST_LENGTH_GT?: InputMaybe<Scalars['Int']>
+  defaultValues_LONGEST_LENGTH_GTE?: InputMaybe<Scalars['Int']>
+  defaultValues_LONGEST_LENGTH_LT?: InputMaybe<Scalars['Int']>
+  defaultValues_LONGEST_LENGTH_LTE?: InputMaybe<Scalars['Int']>
+  defaultValues_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars['Int']>
+  defaultValues_SHORTEST_LENGTH_GT?: InputMaybe<Scalars['Int']>
+  defaultValues_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars['Int']>
+  defaultValues_SHORTEST_LENGTH_LT?: InputMaybe<Scalars['Int']>
+  defaultValues_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars['Int']>
+  description_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars['Float']>
+  description_AVERAGE_LENGTH_GT?: InputMaybe<Scalars['Float']>
+  description_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars['Float']>
+  description_AVERAGE_LENGTH_LT?: InputMaybe<Scalars['Float']>
+  description_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars['Float']>
+  description_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars['Int']>
+  description_LONGEST_LENGTH_GT?: InputMaybe<Scalars['Int']>
+  description_LONGEST_LENGTH_GTE?: InputMaybe<Scalars['Int']>
+  description_LONGEST_LENGTH_LT?: InputMaybe<Scalars['Int']>
+  description_LONGEST_LENGTH_LTE?: InputMaybe<Scalars['Int']>
+  description_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars['Int']>
+  description_SHORTEST_LENGTH_GT?: InputMaybe<Scalars['Int']>
+  description_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars['Int']>
+  description_SHORTEST_LENGTH_LT?: InputMaybe<Scalars['Int']>
+  description_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars['Int']>
+  key_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars['Float']>
+  key_AVERAGE_LENGTH_GT?: InputMaybe<Scalars['Float']>
+  key_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars['Float']>
+  key_AVERAGE_LENGTH_LT?: InputMaybe<Scalars['Float']>
+  key_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars['Float']>
+  key_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars['Int']>
+  key_LONGEST_LENGTH_GT?: InputMaybe<Scalars['Int']>
+  key_LONGEST_LENGTH_GTE?: InputMaybe<Scalars['Int']>
+  key_LONGEST_LENGTH_LT?: InputMaybe<Scalars['Int']>
+  key_LONGEST_LENGTH_LTE?: InputMaybe<Scalars['Int']>
+  key_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars['Int']>
+  key_SHORTEST_LENGTH_GT?: InputMaybe<Scalars['Int']>
+  key_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars['Int']>
+  key_SHORTEST_LENGTH_LT?: InputMaybe<Scalars['Int']>
+  key_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars['Int']>
+  name_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars['Float']>
+  name_AVERAGE_LENGTH_GT?: InputMaybe<Scalars['Float']>
+  name_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars['Float']>
+  name_AVERAGE_LENGTH_LT?: InputMaybe<Scalars['Float']>
+  name_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars['Float']>
+  name_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars['Int']>
+  name_LONGEST_LENGTH_GT?: InputMaybe<Scalars['Int']>
+  name_LONGEST_LENGTH_GTE?: InputMaybe<Scalars['Int']>
+  name_LONGEST_LENGTH_LT?: InputMaybe<Scalars['Int']>
+  name_LONGEST_LENGTH_LTE?: InputMaybe<Scalars['Int']>
+  name_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars['Int']>
+  name_SHORTEST_LENGTH_GT?: InputMaybe<Scalars['Int']>
+  name_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars['Int']>
+  name_SHORTEST_LENGTH_LT?: InputMaybe<Scalars['Int']>
+  name_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars['Int']>
+  validationRules_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars['Float']>
+  validationRules_AVERAGE_LENGTH_GT?: InputMaybe<Scalars['Float']>
+  validationRules_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars['Float']>
+  validationRules_AVERAGE_LENGTH_LT?: InputMaybe<Scalars['Float']>
+  validationRules_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars['Float']>
+  validationRules_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars['Int']>
+  validationRules_LONGEST_LENGTH_GT?: InputMaybe<Scalars['Int']>
+  validationRules_LONGEST_LENGTH_GTE?: InputMaybe<Scalars['Int']>
+  validationRules_LONGEST_LENGTH_LT?: InputMaybe<Scalars['Int']>
+  validationRules_LONGEST_LENGTH_LTE?: InputMaybe<Scalars['Int']>
+  validationRules_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars['Int']>
+  validationRules_SHORTEST_LENGTH_GT?: InputMaybe<Scalars['Int']>
+  validationRules_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars['Int']>
+  validationRules_SHORTEST_LENGTH_LT?: InputMaybe<Scalars['Int']>
+  validationRules_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars['Int']>
+}
+
+export type FieldNextSiblingRelationship = {
+  __typename?: 'FieldNextSiblingRelationship'
+  cursor: Scalars['String']
+  node: Field
+}
+
+export type FieldNextSiblingUpdateConnectionInput = {
+  node?: InputMaybe<FieldUpdateInput>
+}
+
+export type FieldNextSiblingUpdateFieldInput = {
+  connect?: InputMaybe<FieldNextSiblingConnectFieldInput>
+  create?: InputMaybe<FieldNextSiblingCreateFieldInput>
+  delete?: InputMaybe<FieldNextSiblingDeleteFieldInput>
+  disconnect?: InputMaybe<FieldNextSiblingDisconnectFieldInput>
+  update?: InputMaybe<FieldNextSiblingUpdateConnectionInput>
+  where?: InputMaybe<FieldNextSiblingConnectionWhere>
+}
+
 export type FieldOptions = {
   limit?: InputMaybe<Scalars['Int']>
   offset?: InputMaybe<Scalars['Int']>
@@ -10242,9 +10482,167 @@ export type FieldOptions = {
   sort?: InputMaybe<Array<FieldSort>>
 }
 
+export type FieldPrevSiblingAggregateInput = {
+  AND?: InputMaybe<Array<FieldPrevSiblingAggregateInput>>
+  NOT?: InputMaybe<FieldPrevSiblingAggregateInput>
+  OR?: InputMaybe<Array<FieldPrevSiblingAggregateInput>>
+  count?: InputMaybe<Scalars['Int']>
+  count_GT?: InputMaybe<Scalars['Int']>
+  count_GTE?: InputMaybe<Scalars['Int']>
+  count_LT?: InputMaybe<Scalars['Int']>
+  count_LTE?: InputMaybe<Scalars['Int']>
+  node?: InputMaybe<FieldPrevSiblingNodeAggregationWhereInput>
+}
+
+export type FieldPrevSiblingConnectFieldInput = {
+  connect?: InputMaybe<FieldConnectInput>
+  /** Whether or not to overwrite any matching relationship with the new properties. Will default to `false` in 4.0.0. */
+  overwrite?: Scalars['Boolean']
+  where?: InputMaybe<FieldConnectWhere>
+}
+
+export type FieldPrevSiblingConnection = {
+  __typename?: 'FieldPrevSiblingConnection'
+  edges: Array<FieldPrevSiblingRelationship>
+  pageInfo: PageInfo
+  totalCount: Scalars['Int']
+}
+
+export type FieldPrevSiblingConnectionSort = {
+  node?: InputMaybe<FieldSort>
+}
+
+export type FieldPrevSiblingConnectionWhere = {
+  AND?: InputMaybe<Array<FieldPrevSiblingConnectionWhere>>
+  NOT?: InputMaybe<FieldPrevSiblingConnectionWhere>
+  OR?: InputMaybe<Array<FieldPrevSiblingConnectionWhere>>
+  node?: InputMaybe<FieldWhere>
+}
+
+export type FieldPrevSiblingCreateFieldInput = {
+  node: FieldCreateInput
+}
+
+export type FieldPrevSiblingDeleteFieldInput = {
+  delete?: InputMaybe<FieldDeleteInput>
+  where?: InputMaybe<FieldPrevSiblingConnectionWhere>
+}
+
+export type FieldPrevSiblingDisconnectFieldInput = {
+  disconnect?: InputMaybe<FieldDisconnectInput>
+  where?: InputMaybe<FieldPrevSiblingConnectionWhere>
+}
+
+export type FieldPrevSiblingFieldInput = {
+  connect?: InputMaybe<FieldPrevSiblingConnectFieldInput>
+  create?: InputMaybe<FieldPrevSiblingCreateFieldInput>
+}
+
+export type FieldPrevSiblingNodeAggregationWhereInput = {
+  AND?: InputMaybe<Array<FieldPrevSiblingNodeAggregationWhereInput>>
+  NOT?: InputMaybe<FieldPrevSiblingNodeAggregationWhereInput>
+  OR?: InputMaybe<Array<FieldPrevSiblingNodeAggregationWhereInput>>
+  defaultValues_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars['Float']>
+  defaultValues_AVERAGE_LENGTH_GT?: InputMaybe<Scalars['Float']>
+  defaultValues_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars['Float']>
+  defaultValues_AVERAGE_LENGTH_LT?: InputMaybe<Scalars['Float']>
+  defaultValues_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars['Float']>
+  defaultValues_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars['Int']>
+  defaultValues_LONGEST_LENGTH_GT?: InputMaybe<Scalars['Int']>
+  defaultValues_LONGEST_LENGTH_GTE?: InputMaybe<Scalars['Int']>
+  defaultValues_LONGEST_LENGTH_LT?: InputMaybe<Scalars['Int']>
+  defaultValues_LONGEST_LENGTH_LTE?: InputMaybe<Scalars['Int']>
+  defaultValues_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars['Int']>
+  defaultValues_SHORTEST_LENGTH_GT?: InputMaybe<Scalars['Int']>
+  defaultValues_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars['Int']>
+  defaultValues_SHORTEST_LENGTH_LT?: InputMaybe<Scalars['Int']>
+  defaultValues_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars['Int']>
+  description_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars['Float']>
+  description_AVERAGE_LENGTH_GT?: InputMaybe<Scalars['Float']>
+  description_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars['Float']>
+  description_AVERAGE_LENGTH_LT?: InputMaybe<Scalars['Float']>
+  description_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars['Float']>
+  description_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars['Int']>
+  description_LONGEST_LENGTH_GT?: InputMaybe<Scalars['Int']>
+  description_LONGEST_LENGTH_GTE?: InputMaybe<Scalars['Int']>
+  description_LONGEST_LENGTH_LT?: InputMaybe<Scalars['Int']>
+  description_LONGEST_LENGTH_LTE?: InputMaybe<Scalars['Int']>
+  description_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars['Int']>
+  description_SHORTEST_LENGTH_GT?: InputMaybe<Scalars['Int']>
+  description_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars['Int']>
+  description_SHORTEST_LENGTH_LT?: InputMaybe<Scalars['Int']>
+  description_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars['Int']>
+  key_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars['Float']>
+  key_AVERAGE_LENGTH_GT?: InputMaybe<Scalars['Float']>
+  key_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars['Float']>
+  key_AVERAGE_LENGTH_LT?: InputMaybe<Scalars['Float']>
+  key_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars['Float']>
+  key_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars['Int']>
+  key_LONGEST_LENGTH_GT?: InputMaybe<Scalars['Int']>
+  key_LONGEST_LENGTH_GTE?: InputMaybe<Scalars['Int']>
+  key_LONGEST_LENGTH_LT?: InputMaybe<Scalars['Int']>
+  key_LONGEST_LENGTH_LTE?: InputMaybe<Scalars['Int']>
+  key_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars['Int']>
+  key_SHORTEST_LENGTH_GT?: InputMaybe<Scalars['Int']>
+  key_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars['Int']>
+  key_SHORTEST_LENGTH_LT?: InputMaybe<Scalars['Int']>
+  key_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars['Int']>
+  name_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars['Float']>
+  name_AVERAGE_LENGTH_GT?: InputMaybe<Scalars['Float']>
+  name_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars['Float']>
+  name_AVERAGE_LENGTH_LT?: InputMaybe<Scalars['Float']>
+  name_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars['Float']>
+  name_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars['Int']>
+  name_LONGEST_LENGTH_GT?: InputMaybe<Scalars['Int']>
+  name_LONGEST_LENGTH_GTE?: InputMaybe<Scalars['Int']>
+  name_LONGEST_LENGTH_LT?: InputMaybe<Scalars['Int']>
+  name_LONGEST_LENGTH_LTE?: InputMaybe<Scalars['Int']>
+  name_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars['Int']>
+  name_SHORTEST_LENGTH_GT?: InputMaybe<Scalars['Int']>
+  name_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars['Int']>
+  name_SHORTEST_LENGTH_LT?: InputMaybe<Scalars['Int']>
+  name_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars['Int']>
+  validationRules_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars['Float']>
+  validationRules_AVERAGE_LENGTH_GT?: InputMaybe<Scalars['Float']>
+  validationRules_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars['Float']>
+  validationRules_AVERAGE_LENGTH_LT?: InputMaybe<Scalars['Float']>
+  validationRules_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars['Float']>
+  validationRules_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars['Int']>
+  validationRules_LONGEST_LENGTH_GT?: InputMaybe<Scalars['Int']>
+  validationRules_LONGEST_LENGTH_GTE?: InputMaybe<Scalars['Int']>
+  validationRules_LONGEST_LENGTH_LT?: InputMaybe<Scalars['Int']>
+  validationRules_LONGEST_LENGTH_LTE?: InputMaybe<Scalars['Int']>
+  validationRules_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars['Int']>
+  validationRules_SHORTEST_LENGTH_GT?: InputMaybe<Scalars['Int']>
+  validationRules_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars['Int']>
+  validationRules_SHORTEST_LENGTH_LT?: InputMaybe<Scalars['Int']>
+  validationRules_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars['Int']>
+}
+
+export type FieldPrevSiblingRelationship = {
+  __typename?: 'FieldPrevSiblingRelationship'
+  cursor: Scalars['String']
+  node: Field
+}
+
+export type FieldPrevSiblingUpdateConnectionInput = {
+  node?: InputMaybe<FieldUpdateInput>
+}
+
+export type FieldPrevSiblingUpdateFieldInput = {
+  connect?: InputMaybe<FieldPrevSiblingConnectFieldInput>
+  create?: InputMaybe<FieldPrevSiblingCreateFieldInput>
+  delete?: InputMaybe<FieldPrevSiblingDeleteFieldInput>
+  disconnect?: InputMaybe<FieldPrevSiblingDisconnectFieldInput>
+  update?: InputMaybe<FieldPrevSiblingUpdateConnectionInput>
+  where?: InputMaybe<FieldPrevSiblingConnectionWhere>
+}
+
 export type FieldRelationInput = {
   api?: InputMaybe<FieldApiCreateFieldInput>
   fieldType?: InputMaybe<FieldFieldTypeCreateFieldInput>
+  nextSibling?: InputMaybe<FieldNextSiblingCreateFieldInput>
+  prevSibling?: InputMaybe<FieldPrevSiblingCreateFieldInput>
 }
 
 /** Fields to sort Fields by. The order in which sorts are applied is not guaranteed when specifying many fields in one FieldSort object. */
@@ -10265,6 +10663,8 @@ export type FieldUpdateInput = {
   id?: InputMaybe<Scalars['ID']>
   key?: InputMaybe<Scalars['String']>
   name?: InputMaybe<Scalars['String']>
+  nextSibling?: InputMaybe<FieldNextSiblingUpdateFieldInput>
+  prevSibling?: InputMaybe<FieldPrevSiblingUpdateFieldInput>
   validationRules?: InputMaybe<Scalars['String']>
 }
 
@@ -10309,6 +10709,16 @@ export type FieldWhere = {
   name_IN?: InputMaybe<Array<InputMaybe<Scalars['String']>>>
   name_MATCHES?: InputMaybe<Scalars['String']>
   name_STARTS_WITH?: InputMaybe<Scalars['String']>
+  nextSibling?: InputMaybe<FieldWhere>
+  nextSiblingAggregate?: InputMaybe<FieldNextSiblingAggregateInput>
+  nextSiblingConnection?: InputMaybe<FieldNextSiblingConnectionWhere>
+  nextSiblingConnection_NOT?: InputMaybe<FieldNextSiblingConnectionWhere>
+  nextSibling_NOT?: InputMaybe<FieldWhere>
+  prevSibling?: InputMaybe<FieldWhere>
+  prevSiblingAggregate?: InputMaybe<FieldPrevSiblingAggregateInput>
+  prevSiblingConnection?: InputMaybe<FieldPrevSiblingConnectionWhere>
+  prevSiblingConnection_NOT?: InputMaybe<FieldPrevSiblingConnectionWhere>
+  prevSibling_NOT?: InputMaybe<FieldWhere>
   validationRules?: InputMaybe<Scalars['String']>
   validationRules_CONTAINS?: InputMaybe<Scalars['String']>
   validationRules_ENDS_WITH?: InputMaybe<Scalars['String']>
@@ -20610,6 +21020,8 @@ export type FieldFragment = {
   description?: string | null
   validationRules?: string | null
   defaultValues?: string | null
+  prevSibling?: { __typename?: 'Field'; id: string } | null
+  nextSibling?: { __typename?: 'Field'; id: string } | null
   fieldType:
     | { __typename: 'ActionType'; id: string; kind: TypeKind; name: string }
     | { __typename: 'AppType'; id: string; kind: TypeKind; name: string }

--- a/package.json
+++ b/package.json
@@ -115,7 +115,7 @@
     "re-resizable": "6.9.1",
     "react": "18.2.0",
     "react-dom": "18.2.0",
-    "react-drag-listview": "^2.0.0",
+    "react-drag-listview": "2.0.0",
     "react-error-boundary": "^3.1.4",
     "react-grid-layout": "1.3.4",
     "react-helmet": "6.1.0",

--- a/package.json
+++ b/package.json
@@ -115,6 +115,7 @@
     "re-resizable": "6.9.1",
     "react": "18.2.0",
     "react-dom": "18.2.0",
+    "react-drag-listview": "^2.0.0",
     "react-error-boundary": "^3.1.4",
     "react-grid-layout": "1.3.4",
     "react-helmet": "6.1.0",

--- a/schema.graphql
+++ b/schema.graphql
@@ -9586,6 +9586,38 @@ type Field {
   id: ID!
   key: String!
   name: String
+  nextSibling(
+    directed: Boolean = true
+    options: FieldOptions
+    where: FieldWhere
+  ): Field
+  nextSiblingAggregate(
+    directed: Boolean = true
+    where: FieldWhere
+  ): FieldFieldNextSiblingAggregationSelection
+  nextSiblingConnection(
+    after: String
+    directed: Boolean = true
+    first: Int
+    sort: [FieldNextSiblingConnectionSort!]
+    where: FieldNextSiblingConnectionWhere
+  ): FieldNextSiblingConnection!
+  prevSibling(
+    directed: Boolean = true
+    options: FieldOptions
+    where: FieldWhere
+  ): Field
+  prevSiblingAggregate(
+    directed: Boolean = true
+    where: FieldWhere
+  ): FieldFieldPrevSiblingAggregationSelection
+  prevSiblingConnection(
+    after: String
+    directed: Boolean = true
+    first: Int
+    sort: [FieldPrevSiblingConnectionSort!]
+    where: FieldPrevSiblingConnectionWhere
+  ): FieldPrevSiblingConnection!
   validationRules: String
 }
 
@@ -9710,6 +9742,8 @@ input FieldApiUpdateFieldInput {
 input FieldConnectInput {
   api: FieldApiConnectFieldInput
   fieldType: FieldFieldTypeConnectFieldInput
+  nextSibling: FieldNextSiblingConnectFieldInput
+  prevSibling: FieldPrevSiblingConnectFieldInput
 }
 
 input FieldConnectOrCreateInput {
@@ -9728,22 +9762,56 @@ input FieldCreateInput {
   id: ID!
   key: String!
   name: String
+  nextSibling: FieldNextSiblingFieldInput
+  prevSibling: FieldPrevSiblingFieldInput
   validationRules: String
 }
 
 input FieldDeleteInput {
   api: FieldApiDeleteFieldInput
   fieldType: FieldFieldTypeDeleteFieldInput
+  nextSibling: FieldNextSiblingDeleteFieldInput
+  prevSibling: FieldPrevSiblingDeleteFieldInput
 }
 
 input FieldDisconnectInput {
   api: FieldApiDisconnectFieldInput
   fieldType: FieldFieldTypeDisconnectFieldInput
+  nextSibling: FieldNextSiblingDisconnectFieldInput
+  prevSibling: FieldPrevSiblingDisconnectFieldInput
 }
 
 type FieldEdge {
   cursor: String!
   node: Field!
+}
+
+type FieldFieldNextSiblingAggregationSelection {
+  count: Int!
+  node: FieldFieldNextSiblingNodeAggregateSelection
+}
+
+type FieldFieldNextSiblingNodeAggregateSelection {
+  defaultValues: StringAggregateSelectionNullable!
+  description: StringAggregateSelectionNullable!
+  id: IDAggregateSelectionNonNullable!
+  key: StringAggregateSelectionNonNullable!
+  name: StringAggregateSelectionNullable!
+  validationRules: StringAggregateSelectionNullable!
+}
+
+type FieldFieldPrevSiblingAggregationSelection {
+  count: Int!
+  node: FieldFieldPrevSiblingNodeAggregateSelection
+}
+
+type FieldFieldPrevSiblingNodeAggregateSelection {
+  defaultValues: StringAggregateSelectionNullable!
+  description: StringAggregateSelectionNullable!
+  id: IDAggregateSelectionNonNullable!
+  key: StringAggregateSelectionNonNullable!
+  name: StringAggregateSelectionNullable!
+  validationRules: StringAggregateSelectionNullable!
 }
 
 input FieldFieldTypeConnectFieldInput {
@@ -9815,6 +9883,163 @@ type FieldInterfaceTypeApiNodeAggregateSelection {
   name: StringAggregateSelectionNonNullable!
 }
 
+input FieldNextSiblingAggregateInput {
+  AND: [FieldNextSiblingAggregateInput!]
+  NOT: FieldNextSiblingAggregateInput
+  OR: [FieldNextSiblingAggregateInput!]
+  count: Int
+  count_GT: Int
+  count_GTE: Int
+  count_LT: Int
+  count_LTE: Int
+  node: FieldNextSiblingNodeAggregationWhereInput
+}
+
+input FieldNextSiblingConnectFieldInput {
+  connect: FieldConnectInput
+
+  """
+  Whether or not to overwrite any matching relationship with the new properties. Will default to `false` in 4.0.0.
+  """
+  overwrite: Boolean! = true
+  where: FieldConnectWhere
+}
+
+type FieldNextSiblingConnection {
+  edges: [FieldNextSiblingRelationship!]!
+  pageInfo: PageInfo!
+  totalCount: Int!
+}
+
+input FieldNextSiblingConnectionSort {
+  node: FieldSort
+}
+
+input FieldNextSiblingConnectionWhere {
+  AND: [FieldNextSiblingConnectionWhere!]
+  NOT: FieldNextSiblingConnectionWhere
+  OR: [FieldNextSiblingConnectionWhere!]
+  node: FieldWhere
+}
+
+input FieldNextSiblingCreateFieldInput {
+  node: FieldCreateInput!
+}
+
+input FieldNextSiblingDeleteFieldInput {
+  delete: FieldDeleteInput
+  where: FieldNextSiblingConnectionWhere
+}
+
+input FieldNextSiblingDisconnectFieldInput {
+  disconnect: FieldDisconnectInput
+  where: FieldNextSiblingConnectionWhere
+}
+
+input FieldNextSiblingFieldInput {
+  connect: FieldNextSiblingConnectFieldInput
+  create: FieldNextSiblingCreateFieldInput
+}
+
+input FieldNextSiblingNodeAggregationWhereInput {
+  AND: [FieldNextSiblingNodeAggregationWhereInput!]
+  NOT: FieldNextSiblingNodeAggregationWhereInput
+  OR: [FieldNextSiblingNodeAggregationWhereInput!]
+  defaultValues_AVERAGE_LENGTH_EQUAL: Float
+  defaultValues_AVERAGE_LENGTH_GT: Float
+  defaultValues_AVERAGE_LENGTH_GTE: Float
+  defaultValues_AVERAGE_LENGTH_LT: Float
+  defaultValues_AVERAGE_LENGTH_LTE: Float
+  defaultValues_LONGEST_LENGTH_EQUAL: Int
+  defaultValues_LONGEST_LENGTH_GT: Int
+  defaultValues_LONGEST_LENGTH_GTE: Int
+  defaultValues_LONGEST_LENGTH_LT: Int
+  defaultValues_LONGEST_LENGTH_LTE: Int
+  defaultValues_SHORTEST_LENGTH_EQUAL: Int
+  defaultValues_SHORTEST_LENGTH_GT: Int
+  defaultValues_SHORTEST_LENGTH_GTE: Int
+  defaultValues_SHORTEST_LENGTH_LT: Int
+  defaultValues_SHORTEST_LENGTH_LTE: Int
+  description_AVERAGE_LENGTH_EQUAL: Float
+  description_AVERAGE_LENGTH_GT: Float
+  description_AVERAGE_LENGTH_GTE: Float
+  description_AVERAGE_LENGTH_LT: Float
+  description_AVERAGE_LENGTH_LTE: Float
+  description_LONGEST_LENGTH_EQUAL: Int
+  description_LONGEST_LENGTH_GT: Int
+  description_LONGEST_LENGTH_GTE: Int
+  description_LONGEST_LENGTH_LT: Int
+  description_LONGEST_LENGTH_LTE: Int
+  description_SHORTEST_LENGTH_EQUAL: Int
+  description_SHORTEST_LENGTH_GT: Int
+  description_SHORTEST_LENGTH_GTE: Int
+  description_SHORTEST_LENGTH_LT: Int
+  description_SHORTEST_LENGTH_LTE: Int
+  key_AVERAGE_LENGTH_EQUAL: Float
+  key_AVERAGE_LENGTH_GT: Float
+  key_AVERAGE_LENGTH_GTE: Float
+  key_AVERAGE_LENGTH_LT: Float
+  key_AVERAGE_LENGTH_LTE: Float
+  key_LONGEST_LENGTH_EQUAL: Int
+  key_LONGEST_LENGTH_GT: Int
+  key_LONGEST_LENGTH_GTE: Int
+  key_LONGEST_LENGTH_LT: Int
+  key_LONGEST_LENGTH_LTE: Int
+  key_SHORTEST_LENGTH_EQUAL: Int
+  key_SHORTEST_LENGTH_GT: Int
+  key_SHORTEST_LENGTH_GTE: Int
+  key_SHORTEST_LENGTH_LT: Int
+  key_SHORTEST_LENGTH_LTE: Int
+  name_AVERAGE_LENGTH_EQUAL: Float
+  name_AVERAGE_LENGTH_GT: Float
+  name_AVERAGE_LENGTH_GTE: Float
+  name_AVERAGE_LENGTH_LT: Float
+  name_AVERAGE_LENGTH_LTE: Float
+  name_LONGEST_LENGTH_EQUAL: Int
+  name_LONGEST_LENGTH_GT: Int
+  name_LONGEST_LENGTH_GTE: Int
+  name_LONGEST_LENGTH_LT: Int
+  name_LONGEST_LENGTH_LTE: Int
+  name_SHORTEST_LENGTH_EQUAL: Int
+  name_SHORTEST_LENGTH_GT: Int
+  name_SHORTEST_LENGTH_GTE: Int
+  name_SHORTEST_LENGTH_LT: Int
+  name_SHORTEST_LENGTH_LTE: Int
+  validationRules_AVERAGE_LENGTH_EQUAL: Float
+  validationRules_AVERAGE_LENGTH_GT: Float
+  validationRules_AVERAGE_LENGTH_GTE: Float
+  validationRules_AVERAGE_LENGTH_LT: Float
+  validationRules_AVERAGE_LENGTH_LTE: Float
+  validationRules_LONGEST_LENGTH_EQUAL: Int
+  validationRules_LONGEST_LENGTH_GT: Int
+  validationRules_LONGEST_LENGTH_GTE: Int
+  validationRules_LONGEST_LENGTH_LT: Int
+  validationRules_LONGEST_LENGTH_LTE: Int
+  validationRules_SHORTEST_LENGTH_EQUAL: Int
+  validationRules_SHORTEST_LENGTH_GT: Int
+  validationRules_SHORTEST_LENGTH_GTE: Int
+  validationRules_SHORTEST_LENGTH_LT: Int
+  validationRules_SHORTEST_LENGTH_LTE: Int
+}
+
+type FieldNextSiblingRelationship {
+  cursor: String!
+  node: Field!
+}
+
+input FieldNextSiblingUpdateConnectionInput {
+  node: FieldUpdateInput
+}
+
+input FieldNextSiblingUpdateFieldInput {
+  connect: FieldNextSiblingConnectFieldInput
+  create: FieldNextSiblingCreateFieldInput
+  delete: FieldNextSiblingDeleteFieldInput
+  disconnect: FieldNextSiblingDisconnectFieldInput
+  update: FieldNextSiblingUpdateConnectionInput
+  where: FieldNextSiblingConnectionWhere
+}
+
 input FieldOptions {
   limit: Int
   offset: Int
@@ -9825,9 +10050,168 @@ input FieldOptions {
   sort: [FieldSort!]
 }
 
+input FieldPrevSiblingAggregateInput {
+  AND: [FieldPrevSiblingAggregateInput!]
+  NOT: FieldPrevSiblingAggregateInput
+  OR: [FieldPrevSiblingAggregateInput!]
+  count: Int
+  count_GT: Int
+  count_GTE: Int
+  count_LT: Int
+  count_LTE: Int
+  node: FieldPrevSiblingNodeAggregationWhereInput
+}
+
+input FieldPrevSiblingConnectFieldInput {
+  connect: FieldConnectInput
+
+  """
+  Whether or not to overwrite any matching relationship with the new properties. Will default to `false` in 4.0.0.
+  """
+  overwrite: Boolean! = true
+  where: FieldConnectWhere
+}
+
+type FieldPrevSiblingConnection {
+  edges: [FieldPrevSiblingRelationship!]!
+  pageInfo: PageInfo!
+  totalCount: Int!
+}
+
+input FieldPrevSiblingConnectionSort {
+  node: FieldSort
+}
+
+input FieldPrevSiblingConnectionWhere {
+  AND: [FieldPrevSiblingConnectionWhere!]
+  NOT: FieldPrevSiblingConnectionWhere
+  OR: [FieldPrevSiblingConnectionWhere!]
+  node: FieldWhere
+}
+
+input FieldPrevSiblingCreateFieldInput {
+  node: FieldCreateInput!
+}
+
+input FieldPrevSiblingDeleteFieldInput {
+  delete: FieldDeleteInput
+  where: FieldPrevSiblingConnectionWhere
+}
+
+input FieldPrevSiblingDisconnectFieldInput {
+  disconnect: FieldDisconnectInput
+  where: FieldPrevSiblingConnectionWhere
+}
+
+input FieldPrevSiblingFieldInput {
+  connect: FieldPrevSiblingConnectFieldInput
+  create: FieldPrevSiblingCreateFieldInput
+}
+
+input FieldPrevSiblingNodeAggregationWhereInput {
+  AND: [FieldPrevSiblingNodeAggregationWhereInput!]
+  NOT: FieldPrevSiblingNodeAggregationWhereInput
+  OR: [FieldPrevSiblingNodeAggregationWhereInput!]
+  defaultValues_AVERAGE_LENGTH_EQUAL: Float
+  defaultValues_AVERAGE_LENGTH_GT: Float
+  defaultValues_AVERAGE_LENGTH_GTE: Float
+  defaultValues_AVERAGE_LENGTH_LT: Float
+  defaultValues_AVERAGE_LENGTH_LTE: Float
+  defaultValues_LONGEST_LENGTH_EQUAL: Int
+  defaultValues_LONGEST_LENGTH_GT: Int
+  defaultValues_LONGEST_LENGTH_GTE: Int
+  defaultValues_LONGEST_LENGTH_LT: Int
+  defaultValues_LONGEST_LENGTH_LTE: Int
+  defaultValues_SHORTEST_LENGTH_EQUAL: Int
+  defaultValues_SHORTEST_LENGTH_GT: Int
+  defaultValues_SHORTEST_LENGTH_GTE: Int
+  defaultValues_SHORTEST_LENGTH_LT: Int
+  defaultValues_SHORTEST_LENGTH_LTE: Int
+  description_AVERAGE_LENGTH_EQUAL: Float
+  description_AVERAGE_LENGTH_GT: Float
+  description_AVERAGE_LENGTH_GTE: Float
+  description_AVERAGE_LENGTH_LT: Float
+  description_AVERAGE_LENGTH_LTE: Float
+  description_LONGEST_LENGTH_EQUAL: Int
+  description_LONGEST_LENGTH_GT: Int
+  description_LONGEST_LENGTH_GTE: Int
+  description_LONGEST_LENGTH_LT: Int
+  description_LONGEST_LENGTH_LTE: Int
+  description_SHORTEST_LENGTH_EQUAL: Int
+  description_SHORTEST_LENGTH_GT: Int
+  description_SHORTEST_LENGTH_GTE: Int
+  description_SHORTEST_LENGTH_LT: Int
+  description_SHORTEST_LENGTH_LTE: Int
+  key_AVERAGE_LENGTH_EQUAL: Float
+  key_AVERAGE_LENGTH_GT: Float
+  key_AVERAGE_LENGTH_GTE: Float
+  key_AVERAGE_LENGTH_LT: Float
+  key_AVERAGE_LENGTH_LTE: Float
+  key_LONGEST_LENGTH_EQUAL: Int
+  key_LONGEST_LENGTH_GT: Int
+  key_LONGEST_LENGTH_GTE: Int
+  key_LONGEST_LENGTH_LT: Int
+  key_LONGEST_LENGTH_LTE: Int
+  key_SHORTEST_LENGTH_EQUAL: Int
+  key_SHORTEST_LENGTH_GT: Int
+  key_SHORTEST_LENGTH_GTE: Int
+  key_SHORTEST_LENGTH_LT: Int
+  key_SHORTEST_LENGTH_LTE: Int
+  name_AVERAGE_LENGTH_EQUAL: Float
+  name_AVERAGE_LENGTH_GT: Float
+  name_AVERAGE_LENGTH_GTE: Float
+  name_AVERAGE_LENGTH_LT: Float
+  name_AVERAGE_LENGTH_LTE: Float
+  name_LONGEST_LENGTH_EQUAL: Int
+  name_LONGEST_LENGTH_GT: Int
+  name_LONGEST_LENGTH_GTE: Int
+  name_LONGEST_LENGTH_LT: Int
+  name_LONGEST_LENGTH_LTE: Int
+  name_SHORTEST_LENGTH_EQUAL: Int
+  name_SHORTEST_LENGTH_GT: Int
+  name_SHORTEST_LENGTH_GTE: Int
+  name_SHORTEST_LENGTH_LT: Int
+  name_SHORTEST_LENGTH_LTE: Int
+  validationRules_AVERAGE_LENGTH_EQUAL: Float
+  validationRules_AVERAGE_LENGTH_GT: Float
+  validationRules_AVERAGE_LENGTH_GTE: Float
+  validationRules_AVERAGE_LENGTH_LT: Float
+  validationRules_AVERAGE_LENGTH_LTE: Float
+  validationRules_LONGEST_LENGTH_EQUAL: Int
+  validationRules_LONGEST_LENGTH_GT: Int
+  validationRules_LONGEST_LENGTH_GTE: Int
+  validationRules_LONGEST_LENGTH_LT: Int
+  validationRules_LONGEST_LENGTH_LTE: Int
+  validationRules_SHORTEST_LENGTH_EQUAL: Int
+  validationRules_SHORTEST_LENGTH_GT: Int
+  validationRules_SHORTEST_LENGTH_GTE: Int
+  validationRules_SHORTEST_LENGTH_LT: Int
+  validationRules_SHORTEST_LENGTH_LTE: Int
+}
+
+type FieldPrevSiblingRelationship {
+  cursor: String!
+  node: Field!
+}
+
+input FieldPrevSiblingUpdateConnectionInput {
+  node: FieldUpdateInput
+}
+
+input FieldPrevSiblingUpdateFieldInput {
+  connect: FieldPrevSiblingConnectFieldInput
+  create: FieldPrevSiblingCreateFieldInput
+  delete: FieldPrevSiblingDeleteFieldInput
+  disconnect: FieldPrevSiblingDisconnectFieldInput
+  update: FieldPrevSiblingUpdateConnectionInput
+  where: FieldPrevSiblingConnectionWhere
+}
+
 input FieldRelationInput {
   api: FieldApiCreateFieldInput
   fieldType: FieldFieldTypeCreateFieldInput
+  nextSibling: FieldNextSiblingCreateFieldInput
+  prevSibling: FieldPrevSiblingCreateFieldInput
 }
 
 """
@@ -9850,6 +10234,8 @@ input FieldUpdateInput {
   id: ID
   key: String
   name: String
+  nextSibling: FieldNextSiblingUpdateFieldInput
+  prevSibling: FieldPrevSiblingUpdateFieldInput
   validationRules: String
 }
 
@@ -9894,6 +10280,16 @@ input FieldWhere {
   name_IN: [String]
   name_MATCHES: String
   name_STARTS_WITH: String
+  nextSibling: FieldWhere
+  nextSiblingAggregate: FieldNextSiblingAggregateInput
+  nextSiblingConnection: FieldNextSiblingConnectionWhere
+  nextSiblingConnection_NOT: FieldNextSiblingConnectionWhere
+  nextSibling_NOT: FieldWhere
+  prevSibling: FieldWhere
+  prevSiblingAggregate: FieldPrevSiblingAggregateInput
+  prevSiblingConnection: FieldPrevSiblingConnectionWhere
+  prevSiblingConnection_NOT: FieldPrevSiblingConnectionWhere
+  prevSibling_NOT: FieldWhere
   validationRules: String
   validationRules_CONTAINS: String
   validationRules_ENDS_WITH: String

--- a/yarn.lock
+++ b/yarn.lock
@@ -14139,7 +14139,7 @@ __metadata:
     re-resizable: 6.9.1
     react: 18.2.0
     react-dom: 18.2.0
-    react-drag-listview: ^2.0.0
+    react-drag-listview: 2.0.0
     react-error-boundary: ^3.1.4
     react-grid-layout: 1.3.4
     react-helmet: 6.1.0
@@ -28781,7 +28781,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-drag-listview@npm:^2.0.0":
+"react-drag-listview@npm:2.0.0":
   version: 2.0.0
   resolution: "react-drag-listview@npm:2.0.0"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -12532,7 +12532,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"babel-runtime@npm:6.26.0":
+"babel-runtime@npm:6.26.0, babel-runtime@npm:^6.26.0":
   version: 6.26.0
   resolution: "babel-runtime@npm:6.26.0"
   dependencies:
@@ -14139,6 +14139,7 @@ __metadata:
     re-resizable: 6.9.1
     react: 18.2.0
     react-dom: 18.2.0
+    react-drag-listview: ^2.0.0
     react-error-boundary: ^3.1.4
     react-grid-layout: 1.3.4
     react-helmet: 6.1.0
@@ -27724,7 +27725,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"prop-types@npm:15.x, prop-types@npm:^15.6.0, prop-types@npm:^15.6.1, prop-types@npm:^15.6.2, prop-types@npm:^15.7.2, prop-types@npm:^15.8.1":
+"prop-types@npm:15.x, prop-types@npm:^15.5.8, prop-types@npm:^15.6.0, prop-types@npm:^15.6.1, prop-types@npm:^15.6.2, prop-types@npm:^15.7.2, prop-types@npm:^15.8.1":
   version: 15.8.1
   resolution: "prop-types@npm:15.8.1"
   dependencies:
@@ -28777,6 +28778,16 @@ __metadata:
   peerDependencies:
     react: ^18.2.0
   checksum: 7d323310bea3a91be2965f9468d552f201b1c27891e45ddc2d6b8f717680c95a75ae0bc1e3f5cf41472446a2589a75aed4483aee8169287909fcd59ad149e8cc
+  languageName: node
+  linkType: hard
+
+"react-drag-listview@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "react-drag-listview@npm:2.0.0"
+  dependencies:
+    babel-runtime: ^6.26.0
+    prop-types: ^15.5.8
+  checksum: 804c83b44ee7028b888e793facd0e98202d6e35a1c5f5463335bbb0c9078a35fc757283e348c593160c82edd850388f56043062d6e52af51086530563fbf6641
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!-- Please make sure that your commit message follows our format -->

<!-- Example: `fix(libs-ui-component): must begin with lowercase` -->

## Description
add prevSibling and NextSibling to fields and  drag Icon to enable order for fields table

<!-- This is a short description on the Pull Request -->

## Video or Image

https://user-images.githubusercontent.com/47860740/232375616-aeaa69e2-ad82-4de4-aa3a-84c3cbd628bb.mp4



<!-- Add video or image showing how the new feature works -->

## Related Issue(s)
#2447 enable order for api fields
<!-- Please link the issue being fixed so it gets closed when this is merged -->

Fixes #
