### PR TITLE
fix: allow to nullify renderType for elements

### DIFF
--- a/libs/frontend/abstract/core/src/domain/element/element.dto.interface.ts
+++ b/libs/frontend/abstract/core/src/domain/element/element.dto.interface.ts
@@ -29,16 +29,14 @@ export interface ICreateElementData {
   renderType?: Nullable<RenderType>
 }
 
-export type IUpdateElementData = Partial<
-  Pick<
-    ICreateElementData,
-    | 'customCss'
-    | 'guiCss'
-    | 'name'
-    | 'postRenderAction'
-    | 'preRenderAction'
-    | 'renderType'
-  >
+export type IUpdateElementData = Pick<
+  ICreateElementData,
+  | 'customCss'
+  | 'guiCss'
+  | 'name'
+  | 'postRenderAction'
+  | 'preRenderAction'
+  | 'renderType'
 > &
   Pick<ICreateElementData, 'id'> & {
     propTransformationJs?: Nullish<string>

--- a/libs/frontend/domain/element/src/css-editor/ElementCssEditor.tsx
+++ b/libs/frontend/domain/element/src/css-editor/ElementCssEditor.tsx
@@ -12,6 +12,7 @@ import { Col, Collapse, Row } from 'antd'
 import isString from 'lodash/isString'
 import { observer } from 'mobx-react-lite'
 import React, { useCallback, useEffect, useRef, useState } from 'react'
+import { getElementModel } from '../utils/getElementModel'
 import { BackgroundEditor } from './css-background-editor/BackgroundEditor'
 import { BordersEditor } from './css-borders-editor/BordersEditor'
 import { EffectsEditor } from './css-effects-editor/EffectsEditor'
@@ -58,9 +59,11 @@ export const ElementCssEditor = observer<ElementCssEditorInternalProps>(
 
     const updateCustomCss = useCallback(
       (newCustomCss: string) => {
+        const elementModel = getElementModel(element)
+
         const promise = elementService.update({
+          ...elementModel,
           customCss: newCustomCss,
-          id: element.id,
         })
 
         return trackPromise?.(promise) ?? promise
@@ -95,9 +98,11 @@ export const ElementCssEditor = observer<ElementCssEditorInternalProps>(
 
     const updateGuiCss = useCallback(
       (newGuiCss: string) => {
+        const elementModel = getElementModel(element)
+
         const promise = elementService.update({
+          ...elementModel,
           guiCss: newGuiCss,
-          id: element.id,
         })
 
         return trackPromise?.(promise) ?? promise

--- a/libs/frontend/domain/element/src/store/element.model.ts
+++ b/libs/frontend/domain/element/src/store/element.model.ts
@@ -625,7 +625,7 @@ export class Element
       propTransformationJs ?? this.propTransformationJs
     this.renderIfExpression = renderIfExpression ?? null
     this.renderForEachPropKey = renderForEachPropKey ?? null
-    this.renderType = elementRenderType ?? this.renderType
+    this.renderType = elementRenderType ?? null
     this.props = props?.id ? propRef(props.id) : this.props
     this.parent = parent?.id ? elementRef(parent.id) : this.parent
     this.nextSibling = nextSibling?.id

--- a/libs/frontend/domain/element/src/use-cases/element/update-element-prop-transformation/UpdateElementPropTransformationForm.tsx
+++ b/libs/frontend/domain/element/src/use-cases/element/update-element-prop-transformation/UpdateElementPropTransformationForm.tsx
@@ -5,6 +5,7 @@ import TextArea from 'antd/lib/input/TextArea'
 import isString from 'lodash/isString'
 import { observer } from 'mobx-react-lite'
 import React, { useCallback, useEffect, useRef, useState } from 'react'
+import { getElementModel } from '../../../utils/getElementModel'
 
 export interface UpdateElementPropTransformationFormProp {
   element: IElement
@@ -38,8 +39,10 @@ export const UpdateElementPropTransformationForm =
             return
           }
 
+          const elementModel = getElementModel(element)
+
           const promise = elementService.update({
-            id: element.id,
+            ...elementModel,
             propTransformationJs: newValue,
           })
 

--- a/libs/frontend/domain/element/src/use-cases/element/update-element/UpdateElementForm.tsx
+++ b/libs/frontend/domain/element/src/use-cases/element/update-element/UpdateElementForm.tsx
@@ -4,15 +4,11 @@ import type {
   IRenderer,
   IUpdateBaseElementData,
   IUpdateElementData,
-  RenderType,
 } from '@codelab/frontend/abstract/core'
 import {
   DATA_COMPONENT_ID,
   DATA_ELEMENT_ID,
-  IRenderTypeKind,
-  isComponentInstance,
 } from '@codelab/frontend/abstract/core'
-import { isAtomInstance } from '@codelab/frontend/domain/atom'
 import { SelectAction } from '@codelab/frontend/domain/type'
 import { useStore } from '@codelab/frontend/presenter/container'
 import { createNotificationHandler } from '@codelab/frontend/shared/utils'
@@ -32,6 +28,7 @@ import React from 'react'
 import { AutoField, AutoFields } from 'uniforms-antd'
 import { AutoComputedElementNameField } from '../../../components/auto-computed-element-name'
 import RenderTypeCompositeField from '../../../components/RenderTypeCompositeField'
+import { getElementModel } from '../../../utils/getElementModel'
 import { updateElementSchema } from './update-element.schema'
 
 export interface UpdateElementFormProps {
@@ -41,40 +38,12 @@ export interface UpdateElementFormProps {
   trackPromises?: UseTrackLoadingPromises
 }
 
-const makeCurrentModel = (element: IElement) => {
-  let renderType: RenderType | null = null
-
-  if (isAtomInstance(element.renderType)) {
-    renderType = {
-      id: element.renderType.id,
-      kind: IRenderTypeKind.Atom,
-    }
-  }
-
-  if (isComponentInstance(element.renderType)) {
-    renderType = {
-      id: element.renderType.id,
-      kind: IRenderTypeKind.Component,
-    }
-  }
-
-  return {
-    id: element.id,
-    name: element.name,
-    // postRenderAction: element.postRenderAction,
-    // preRenderAction: element.preRenderAction,
-    renderForEachPropKey: element.renderForEachPropKey,
-    renderIfExpression: element.renderIfExpression,
-    renderType,
-  }
-}
-
 /** Not intended to be used in a modal */
 export const UpdateElementForm = observer<UpdateElementFormProps>(
   ({ element, elementService, renderer, trackPromises }) => {
     const { builderService } = useStore()
     const { trackPromise } = trackPromises ?? {}
-    const model = makeCurrentModel(element)
+    const model = getElementModel(element)
     const parentComponent = builderService.activeComponent?.current
 
     const onSubmit = (data: IUpdateElementData) => {

--- a/libs/frontend/domain/element/src/use-cases/element/update-element/update-element.schema.ts
+++ b/libs/frontend/domain/element/src/use-cases/element/update-element/update-element.schema.ts
@@ -11,7 +11,6 @@ export const updateElementSchema: JSONSchemaType<IUpdateBaseElementData> = {
     ...idSchema,
     name: {
       autoFocus: true,
-      nullable: true,
       type: 'string',
       ...titleCaseValidation,
     },

--- a/libs/frontend/domain/element/src/utils/getElementModel.ts
+++ b/libs/frontend/domain/element/src/utils/getElementModel.ts
@@ -1,0 +1,34 @@
+import type { IElement, RenderType } from '@codelab/frontend/abstract/core'
+import {
+  IRenderTypeKind,
+  isComponentInstance,
+} from '@codelab/frontend/abstract/core'
+import { isAtomInstance } from '@codelab/frontend/domain/atom'
+
+export const getElementModel = (element: IElement) => {
+  let renderType: RenderType | null = null
+
+  if (isAtomInstance(element.renderType)) {
+    renderType = {
+      id: element.renderType.id,
+      kind: IRenderTypeKind.Atom,
+    }
+  }
+
+  if (isComponentInstance(element.renderType)) {
+    renderType = {
+      id: element.renderType.id,
+      kind: IRenderTypeKind.Component,
+    }
+  }
+
+  return {
+    id: element.id,
+    name: element.name,
+    // postRenderAction: element.postRenderAction,
+    // preRenderAction: element.preRenderAction,
+    renderForEachPropKey: element.renderForEachPropKey,
+    renderIfExpression: element.renderIfExpression,
+    renderType,
+  }
+}


### PR DESCRIPTION
<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(libs-ui-component): must begin with lowercase` -->

## Description
Allow to nullify `renderType` in `element.writeCache` function. As a side effect updated all places that use `elementService.update` function to include all the props from `IUpdateElementData` instead of partially including them. Otherwise, it is impossible to distinguish when the property just was not passed and does not need to be updated from the case when it needs to be nullified.


https://user-images.githubusercontent.com/74900868/232804612-fe625410-de23-4b55-93a7-a2b0571440bd.mov



## Related Issue(s)

Fixes #2484 
