### PR TITLE
fix: context menu error on deleted element

### DIFF
--- a/libs/frontend/domain/builder/src/sections/explorer-pane/ElementContextMenu.tsx
+++ b/libs/frontend/domain/builder/src/sections/explorer-pane/ElementContextMenu.tsx
@@ -43,9 +43,10 @@ export const ElementContextMenu = observer<ElementContextMenuProps>(
     const { builderService, componentService } = useStore()
     const { user } = useUser()
     const componentInstance = isComponentInstance(element.renderType)
-    const elementTree = element.closestContainerNode
 
     const onAddChild = () => {
+      const elementTree = element.closestContainerNode
+
       return createModal.open({
         elementOptions: elementTree.elements.map(mapElementOption),
         elementTree: elementTreeRef(elementTree.id),


### PR DESCRIPTION
<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(libs-ui-component): must begin with lowercase` -->

## Description
When an element that is selected in the builder is deleted - the context menu for it is still rendered before the element is fully detached and `closestContainerNode` computed property throws an error. Move this computed property execution to where it is used instead of being on the root level of the context menu component.

## Related Issue(s)

Fixes #2500 
