### PR TITLE
fix: reset component children container on delete

### DIFF
--- a/libs/frontend/domain/element/src/store/element.service.ts
+++ b/libs/frontend/domain/element/src/store/element.service.ts
@@ -170,6 +170,23 @@ export class ElementService
     console.debug('deleteElementSubgraph', subRoot)
 
     const subRootElement = this.element(subRoot.id)
+    const parentComponent = subRootElement.parentComponent?.current
+    const childrenContainer = parentComponent?.childrenContainerElement.current
+
+    // Check if the element is linked as a children container in parent component
+    // and replace this link to component root before element is deleted
+    if (parentComponent && childrenContainer?.id === subRootElement.id) {
+      yield* _await(
+        this.componentService.update({
+          childrenContainerElement: {
+            id: parentComponent.rootElement.current.id,
+          },
+          id: parentComponent.id,
+          name: parentComponent.name,
+        }),
+      )
+    }
+
     const affectedNodeIds = this.detachElementFromElementTree(subRootElement.id)
 
     const allElementsToDelete = [


### PR DESCRIPTION
<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(libs-ui-component): must begin with lowercase` -->

## Description
If the element that is about to be deleted is linked as a children container in a component - replace this link to the component root

## Video or Image


https://user-images.githubusercontent.com/74900868/233367358-5fc3869e-e467-48cd-97c1-d43436f5e021.mov



## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged -->

Fixes #2503 
