### PR TITLE
wip: fix: stabilize e2e specs

### DIFF
--- a/apps/platform-e2e/src/e2e/builder.cy.ts
+++ b/apps/platform-e2e/src/e2e/builder.cy.ts
@@ -54,12 +54,9 @@ describe('Elements CRUD', () => {
   before(() => {
     cy.resetDatabase()
     loginSession()
-    cy.getCurrentOwner()
-      .then((owner) => {
-        return cy.request('/api/cypress/atom').then(() => {
-          return cy.request<IAppDTO>('/api/cypress/app')
-        })
-      })
+
+    cy.request('/api/cypress/atom')
+      .then(() => cy.request<IAppDTO>('/api/cypress/app'))
       .then((apps) => {
         const app = apps.body
         const pageId = app.pages?.[0]?.id

--- a/apps/platform-e2e/src/e2e/component.cy.ts
+++ b/apps/platform-e2e/src/e2e/component.cy.ts
@@ -27,13 +27,12 @@ describe('Component CRUD', () => {
   before(() => {
     cy.resetDatabase()
     loginSession()
-    cy.getCurrentOwner()
-      .then((owner) => {
-        cy.request('/api/cypress/type')
 
-        return cy.request('/api/cypress/atom').then(() => {
-          return cy.request<IAppDTO>('/api/cypress/app')
-        })
+    cy.request('/api/cypress/type')
+
+    cy.request('/api/cypress/atom')
+      .then(() => {
+        return cy.request<IAppDTO>('/api/cypress/app')
       })
       .then((apps) => {
         testApp = apps

--- a/apps/platform-e2e/src/e2e/pages.cy.ts
+++ b/apps/platform-e2e/src/e2e/pages.cy.ts
@@ -9,19 +9,15 @@ describe('Pages CRUD', () => {
     cy.resetDatabase()
     loginSession()
 
-    cy.getCurrentOwner()
-      .then((owner) => {
-        return cy.request<IAppDTO>('/api/cypress/app')
-      })
-      .then((res) => {
-        const app = res.body
+    cy.request<IAppDTO>('/api/cypress/app').then((res) => {
+      const app = res.body
 
-        cy.visit(`/apps/${app.id}/pages`)
-        cy.getSpinner().should('not.exist')
-        cy.findAllByText(IPageKindName.Provider).should('exist')
-        cy.findAllByText(IPageKindName.NotFound).should('exist')
-        cy.findAllByText(IPageKindName.InternalServerError).should('exist')
-      })
+      cy.visit(`/apps/${app.id}/pages`)
+      cy.getSpinner().should('not.exist')
+      cy.findAllByText(IPageKindName.Provider).should('exist')
+      cy.findAllByText(IPageKindName.NotFound).should('exist')
+      cy.findAllByText(IPageKindName.InternalServerError).should('exist')
+    })
   })
 
   describe('create', () => {

--- a/apps/platform-e2e/src/e2e/providers-page.cy.ts
+++ b/apps/platform-e2e/src/e2e/providers-page.cy.ts
@@ -1,4 +1,3 @@
-import type { IAuth0Owner } from '@codelab/frontend/abstract/core'
 import { ROOT_ELEMENT_NAME } from '@codelab/frontend/abstract/core'
 import { IAtomType, IPageKindName } from '@codelab/shared/abstract/core'
 import { FIELD_TYPE } from '../support/antd/form'
@@ -35,9 +34,7 @@ describe('_app page', () => {
     cy.resetDatabase()
     loginSession()
 
-    cy.getCurrentOwner().then((owner: IAuth0Owner) => {
-      cy.request('/api/cypress/atom')
-    })
+    cy.request('/api/cypress/atom')
   })
 
   it('should create _app page when app is created', () => {

--- a/apps/platform-e2e/src/e2e/tag.cy.ts
+++ b/apps/platform-e2e/src/e2e/tag.cy.ts
@@ -11,13 +11,9 @@ describe('Tag CRUD', () => {
     cy.resetDatabase()
     loginSession()
 
-    cy.getCurrentOwner()
-      .then((owner) => {
-        cy.request('/api/cypress/tag')
-      })
-      .then(() => {
-        cy.visit('/tags')
-      })
+    cy.request('/api/cypress/tag').then(() => {
+      cy.visit('/tags')
+    })
   })
 
   describe('create', () => {

--- a/apps/platform-e2e/src/support/entities/tag/tag.command.ts
+++ b/apps/platform-e2e/src/support/entities/tag/tag.command.ts
@@ -29,7 +29,7 @@ export const createTagByUI = (name: string, parentName?: string) => {
 export const deleteTagInTableByUI = (name: string) => {
   cy.searchTableRow({
     header: 'Name',
-    row: name,
+    row: new RegExp(`^${name}$`),
   })
     .getButton({ icon: 'delete' })
     .click()


### PR DESCRIPTION
<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(libs-ui-component): must begin with lowercase` -->

## Description

- remove redundant calls to user endpoint (/me)
- stabilize tag.cy spec by using more specific RegExp. Tag table has a different order of tags and the test sometimes was selecting `Delete-tag-0-1` instead of `Delete-tag-0`, because they have the common part in the name (`Delete-tag-0`), and depending on the table order, the spec was sometimes deleting the wrong tag.

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged -->

Fixes #2499 
