### PR TITLE
fix: e2e by reducing re-renders

### DIFF
--- a/apps/platform/pages/apps/[appId]/pages/[pageId]/builder.tsx
+++ b/apps/platform/pages/apps/[appId]/pages/[pageId]/builder.tsx
@@ -24,7 +24,7 @@ import { auth0Instance } from '@codelab/shared/adapter/auth0'
 import { useMountEffect } from '@react-hookz/web'
 import { observer } from 'mobx-react-lite'
 import Head from 'next/head'
-import React, { useMemo } from 'react'
+import React, { useCallback, useMemo } from 'react'
 
 const PageBuilder: CodelabPage<BuilderTabsProps> = observer(
   ({ error, isLoading, page, renderer }) => {
@@ -69,16 +69,22 @@ PageBuilder.Layout = observer(({ children }) => {
   const page = renderer?.elementTree.current
   const contentStyles = useMemo(() => ({ paddingTop: '0rem' }), [])
 
-  const ConfigPaneComponent = () => (
-    <Spinner isLoading={isLoading}>
-      <ConfigPane renderService={renderer} />
-    </Spinner>
+  const ConfigPaneComponent = useCallback(
+    () => (
+      <Spinner isLoading={isLoading}>
+        <ConfigPane renderService={renderer} />
+      </Spinner>
+    ),
+    [isLoading, renderer],
   )
 
-  const ExplorerPaneComponent = () => (
-    <Spinner isLoading={isLoading}>
-      <BuilderExplorerPane pageId={pageId} />
-    </Spinner>
+  const ExplorerPaneComponent = useCallback(
+    () => (
+      <Spinner isLoading={isLoading}>
+        <BuilderExplorerPane pageId={pageId} />
+      </Spinner>
+    ),
+    [isLoading, pageId],
   )
 
   return (

--- a/libs/frontend/domain/builder/src/sections/content/Builder-Component.tsx
+++ b/libs/frontend/domain/builder/src/sections/content/Builder-Component.tsx
@@ -1,4 +1,3 @@
-import type { IStore } from '@codelab/frontend/abstract/core'
 import { RendererType } from '@codelab/frontend/abstract/core'
 import { useStore } from '@codelab/frontend/presenter/container'
 import { observer } from 'mobx-react-lite'
@@ -9,7 +8,6 @@ import type { BaseBuilderProps } from './BaseBuilder'
 interface BuilderComponentProps {
   // Pass in BaseBuilder so we don't have to initialize props again
   BaseBuilder: JSXElementConstructor<BaseBuilderProps>
-  appStore: IStore
   componentId: string
 }
 
@@ -17,7 +15,7 @@ interface BuilderComponentProps {
  * Since the component builder tree changes based on which component id is active, we move the component id dependency to a wrapper we create for the main Builder
  */
 export const BuilderComponent = observer<BuilderComponentProps>(
-  ({ appStore, BaseBuilder, componentId }) => {
+  ({ BaseBuilder, componentId }) => {
     const { builderRenderService, builderService, componentService } =
       useStore()
 

--- a/libs/frontend/domain/builder/src/sections/content/Builder.tsx
+++ b/libs/frontend/domain/builder/src/sections/content/Builder.tsx
@@ -18,7 +18,7 @@ import { useDroppable } from '@dnd-kit/core'
 import styled from '@emotion/styled'
 import { motion } from 'framer-motion'
 import { observer } from 'mobx-react-lite'
-import React from 'react'
+import React, { useMemo } from 'react'
 import tw from 'twin.macro'
 import { useBuilderHotkeys, useBuilderHoverHandlers } from '../../hooks'
 import { useBuilderResize } from '../../hooks/useBuilderResize'
@@ -86,11 +86,15 @@ export const Builder = observer<BuilderProps>(
       }
     }
 
-    const rootStyle = isOver
-      ? makeDropIndicatorStyle(DragPosition.Inside, {
-          backgroundColor: 'rgba(0, 255, 255, 0.2)',
-        })
-      : {}
+    const rootStyle = useMemo(
+      () =>
+        isOver
+          ? makeDropIndicatorStyle(DragPosition.Inside, {
+              backgroundColor: 'rgba(0, 255, 255, 0.2)',
+            })
+          : {},
+      [isOver],
+    )
 
     return (
       <StyledBuilderResizeContainer

--- a/libs/frontend/domain/builder/src/sections/content/BuilderTabs.tsx
+++ b/libs/frontend/domain/builder/src/sections/content/BuilderTabs.tsx
@@ -54,7 +54,6 @@ export const BuilderTabs = observer<BuilderTabsProps>(
           ) : builderService.activeComponent && store ? (
             <BuilderComponent
               BaseBuilder={BaseBuilder}
-              appStore={store}
               componentId={builderService.activeComponent.id}
             />
           ) : null}

--- a/libs/frontend/domain/renderer/src/Renderer.tsx
+++ b/libs/frontend/domain/renderer/src/Renderer.tsx
@@ -42,14 +42,19 @@ export const Renderer = observer<WithStyleProp<RendererRoot>, HTMLDivElement>(
     // this prevents re-rendering too much
     const renderedRoot = useMemo(() => renderRoot(), [])
 
+    const containerStyle = useMemo(
+      () => ({
+        minHeight: '100%',
+        transform: 'translatex(0)',
+        ...style,
+      }),
+      [style],
+    )
+
     return (
       <ErrorBoundary>
         <CacheProvider value={emotionCache}>
-          <div
-            id={ROOT_RENDER_CONTAINER_ID}
-            ref={ref}
-            style={{ minHeight: '100%', transform: 'translatex(0)', ...style }}
-          >
+          <div id={ROOT_RENDER_CONTAINER_ID} ref={ref} style={containerStyle}>
             {renderedRoot}
           </div>
         </CacheProvider>


### PR DESCRIPTION
<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(libs-ui-component): must begin with lowercase` -->

## Description
The remaining issues with e2e were caused by re-rendering on the builder page. The test was trying to type/click on a node that no longer exists in the DOM because of re-rendering. This PR reduces amount of re-renders and increases stability of e2e tests

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged -->

Fixes #2499 
