### PR TITLE
fix: do not replace component root atom with span

### DIFF
--- a/libs/frontend/domain/renderer/src/element/wrapper.utils.ts
+++ b/libs/frontend/domain/renderer/src/element/wrapper.utils.ts
@@ -19,11 +19,13 @@ export const extractValidProps = (
     : renderOutput.props
 
 export const getReactComponent = (renderOutput: IRenderOutput) => {
+  // if component does not have atom assigned to the root element
   // use span to hold the component's elements together and it is an html
   // element with the least effect on its child and can be used for dnd
-  const atomType = renderOutput.props?.[DATA_COMPONENT_ID]
-    ? IAtomType.HtmlSpan
-    : renderOutput.atomType
+  const atomType =
+    !renderOutput.atomType && renderOutput.props?.[DATA_COMPONENT_ID]
+      ? IAtomType.HtmlSpan
+      : renderOutput.atomType
 
   // Render the atom if it exists, otherwise use fragment
   return atomType ? getAtom(atomType) ?? Fragment : Fragment


### PR DESCRIPTION
<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(libs-ui-component): must begin with lowercase` -->

## Description
If an atom is assigned to the component root element - it was replaced with `span` during rendering in order to group all component children under a single DOM node. The logic is updated to do so only if no atom is assigned (e.g. render span instead of Fragment)

<!-- This is a short description on the Pull Request -->

## Video or Image

Before

https://user-images.githubusercontent.com/74900868/233795508-9b1213b5-41e9-4d0a-b78a-8a508e462f52.mov

After

https://user-images.githubusercontent.com/74900868/233795417-3553cf1f-212a-4cfc-a47c-c5102b4e7dab.mov


## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged -->

Fixes #2501 
