### PR TITLE
fix: make props form use field order

### DIFF
--- a/libs/frontend/domain/type/src/shared/index.ts
+++ b/libs/frontend/domain/type/src/shared/index.ts
@@ -1,2 +1,3 @@
+export * from './sortFields'
 export * from './TypeSelect'
 export * from './typeSelectOptions'

--- a/libs/frontend/domain/type/src/shared/sortFields.ts
+++ b/libs/frontend/domain/type/src/shared/sortFields.ts
@@ -1,26 +1,19 @@
 import { type IField } from '@codelab/frontend/abstract/core'
+import sortBy from 'lodash/sortBy'
 
 export const sortFieldsArray = (fields: Array<IField>) => {
-  const compareNodes = (field1: IField, field2: IField) => {
-    let node1 = field1
-    let node2 = field2
-    const pathA = [field1.id]
-    const pathB = [field2.id]
+  const nodes = new Map(fields.map((field) => [field.id, field]))
 
-    while (node1.prevSibling) {
-      node1 = fields.find((node) => node.id === node1.prevSibling?.id) as IField
-      pathA.unshift(node1.id)
+  const getPath = (field: IField) => {
+    const path = [field.id]
+
+    while (field.prevSibling) {
+      field = nodes.get(field.prevSibling.id) as IField
+      path.unshift(field.id)
     }
 
-    while (node2.prevSibling) {
-      node2 = fields.find((node) => node.id === node2.prevSibling?.id) as IField
-      pathB.unshift(node2.id)
-    }
-
-    const result = pathA.join().localeCompare(pathB.join())
-
-    return result !== 0 ? result : field1.id.localeCompare(field2.id)
+    return path.join()
   }
 
-  return fields.sort(compareNodes)
+  return sortBy(fields, [(field) => getPath(field), 'id'])
 }

--- a/libs/frontend/domain/type/src/shared/sortFields.ts
+++ b/libs/frontend/domain/type/src/shared/sortFields.ts
@@ -1,0 +1,26 @@
+import { type IField } from '@codelab/frontend/abstract/core'
+
+export const sortFieldsArray = (fields: Array<IField>) => {
+  const compareNodes = (field1: IField, field2: IField) => {
+    let node1 = field1
+    let node2 = field2
+    const pathA = [field1.id]
+    const pathB = [field2.id]
+
+    while (node1.prevSibling) {
+      node1 = fields.find((node) => node.id === node1.prevSibling?.id) as IField
+      pathA.unshift(node1.id)
+    }
+
+    while (node2.prevSibling) {
+      node2 = fields.find((node) => node.id === node2.prevSibling?.id) as IField
+      pathB.unshift(node2.id)
+    }
+
+    const result = pathA.join().localeCompare(pathB.join())
+
+    return result !== 0 ? result : field1.id.localeCompare(field2.id)
+  }
+
+  return fields.sort(compareNodes)
+}

--- a/libs/frontend/domain/type/src/store/models/interface-type.model.ts
+++ b/libs/frontend/domain/type/src/store/models/interface-type.model.ts
@@ -19,6 +19,7 @@ import {
   prop,
 } from 'mobx-keystone'
 import { v4 } from 'uuid'
+import { sortFieldsArray } from '../../shared'
 import { createBaseType } from './base-type.model'
 import { fieldRef } from './field.model'
 
@@ -68,7 +69,9 @@ export class InterfaceType
 {
   @computed
   get fields() {
-    return [...this._fields.values()].map((field) => field.current)
+    const fields = [...this._fields.values()].map((field) => field.current)
+
+    return sortFieldsArray(fields)
   }
 
   @computed

--- a/libs/frontend/domain/type/src/use-cases/types/create-type/CreateTypeModal.tsx
+++ b/libs/frontend/domain/type/src/use-cases/types/create-type/CreateTypeModal.tsx
@@ -42,7 +42,7 @@ export const CreateTypeModal = observer(() => {
       <ModalForm.Form<ICreateTypeData>
         model={{
           id: v4(),
-          owner: { auth0Id: userService.user?.auth0Id },
+          owner: { auth0Id: userService.user.auth0Id },
         }}
         onSubmit={onSubmit}
         onSubmitError={createNotificationHandler({

--- a/libs/frontend/domain/type/src/use-cases/types/get-types/tables/FieldsTable.tsx
+++ b/libs/frontend/domain/type/src/use-cases/types/get-types/tables/FieldsTable.tsx
@@ -1,5 +1,4 @@
 import type {
-  IField,
   IFieldRecord,
   IFieldService,
   IInterfaceType,
@@ -163,34 +162,8 @@ export const FieldsTable = observer<FieldsTableProps>(
       },
     ]
 
-    const compareNodes = (field1: IField, field2: IField) => {
-      let node1 = field1
-      let node2 = field2
-      const pathA = [field1.id]
-      const pathB = [field2.id]
-
-      while (node1.prevSibling) {
-        node1 = interfaceType.fields.find(
-          (node) => node.id === node1.prevSibling?.id,
-        ) as IField
-        pathA.unshift(node1.id)
-      }
-
-      while (node2.prevSibling) {
-        node2 = interfaceType.fields.find(
-          (node) => node.id === node2.prevSibling?.id,
-        ) as IField
-        pathB.unshift(node2.id)
-      }
-
-      const result = pathA.join().localeCompare(pathB.join())
-
-      return result !== 0 ? result : field1.id.localeCompare(field2.id)
-    }
-
-    const dataSource: Array<IFieldRecord> = interfaceType.fields
-      .sort(compareNodes)
-      .map((field) => {
+    const dataSource: Array<IFieldRecord> = interfaceType.fields.map(
+      (field) => {
         return {
           dependentTypes: [],
           description: field.description || '',
@@ -206,7 +179,8 @@ export const FieldsTable = observer<FieldsTableProps>(
           },
           validationRules: getValidationRuleTagsArray(field.validationRules),
         }
-      })
+      },
+    )
 
     const onDragEnd = async (fromIndex: number, toIndex: number) => {
       if (fromIndex === toIndex) {


### PR DESCRIPTION
<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(libs-ui-component): must begin with lowercase` -->

## Description
make props field follow the fields order 
<!-- This is a short description on the Pull Request -->

## Video o

https://user-images.githubusercontent.com/47860740/233812381-eee3672e-eed8-4615-9c90-93fafd3e42ed.mp4

r Image

<!-- Add video or image showing how the new feature works -->

## Related Issue(s)
#2495 Make sure props form uses field order
<!-- Please link the issue being fixed so it gets closed when this is merged -->

Fixes #
#2495  Make sure props form uses field order