### PR TITLE
fix: apply global css fix

### DIFF
--- a/apps/landing/pages/_app.tsx
+++ b/apps/landing/pages/_app.tsx
@@ -1,6 +1,11 @@
 // import '../src/wdyr'
 import 'reflect-metadata'
 import '../styles/app.css'
+// apply fix for common css problems:
+// - remove default padding/margin from html and body
+// - set 100% width and height for html and body
+// - set box-sizing, remove outlines, etc
+import 'antd/dist/reset.css'
 // https://www.elvisduru.com/blog/how-to-customize-ant-design-theme-in-nextjs
 import { UserProvider } from '@auth0/nextjs-auth0'
 import type { IAppProps } from '@codelab/frontend/abstract/core'

--- a/apps/platform-e2e/src/e2e/component.cy.ts
+++ b/apps/platform-e2e/src/e2e/component.cy.ts
@@ -22,6 +22,25 @@ const componentChildren: Array<ComponentChildData> = [
   { atom: IAtomType.AntDesignTypographyText, name: COMPONENT_CHILD_TYPOGRAPHY },
 ]
 
+const setElementNameInModal = (value: string) => {
+  cy.getModal()
+    .getFormField({
+      label: 'Name',
+    })
+    .within(() => {
+      // Need to wait for the name to automatically be set first (after the
+      // atom is set) because it would override the name otherwise
+      cy.get('input')
+        .should('not.have.value', '')
+        .getModal()
+        .setFormFieldValue({
+          label: 'Name',
+          type: FIELD_TYPE.INPUT,
+          value,
+        })
+    })
+}
+
 let testApp: any
 describe('Component CRUD', () => {
   before(() => {
@@ -112,10 +131,8 @@ describe('Component CRUD', () => {
             type: FIELD_TYPE.SELECT,
             value: child.atom,
           })
-          cy.getModal().setFormFieldValue({
-            label: 'Name',
-            value: child.name,
-          })
+
+          setElementNameInModal(child.name)
 
           cy.getModal()
             .getModalAction(/Create/)
@@ -164,10 +181,8 @@ describe('Component CRUD', () => {
         type: FIELD_TYPE.SELECT,
         value: COMPONENT_NAME,
       })
-      cy.getModal().setFormFieldValue({
-        label: 'Name',
-        value: COMPONENT_INSTANCE_NAME,
-      })
+
+      setElementNameInModal(COMPONENT_INSTANCE_NAME)
 
       cy.getModal()
         .getModalAction(/Create/)
@@ -202,10 +217,8 @@ describe('Component CRUD', () => {
         type: FIELD_TYPE.SELECT,
         value: IAtomType.AntDesignTypographyText,
       })
-      cy.getModal().setFormFieldValue({
-        label: 'Name',
-        value: COMPONENT_INSTANCE_TEXT,
-      })
+
+      setElementNameInModal(COMPONENT_INSTANCE_TEXT)
 
       cy.getModal()
         .getModalAction(/Create/)

--- a/apps/platform/pages/_app.tsx
+++ b/apps/platform/pages/_app.tsx
@@ -5,6 +5,11 @@ import 'react-quill/dist/quill.snow.css'
 import '../src/styles/quill.snow.override.css'
 import 'react-grid-layout/css/styles.css'
 import 'react-resizable/css/styles.css'
+// apply fix for common css problems:
+// - remove default padding/margin from html and body
+// - set 100% width and height for html and body
+// - set box-sizing, remove outlines, etc
+import 'antd/dist/reset.css'
 // https://www.elvisduru.com/blog/how-to-customize-ant-design-theme-in-nextjs
 import { UserProvider } from '@auth0/nextjs-auth0'
 import type { IAppProps, IPageProps } from '@codelab/frontend/abstract/core'

--- a/apps/websites/pages/_app.tsx
+++ b/apps/websites/pages/_app.tsx
@@ -2,6 +2,11 @@ import 'react-quill/dist/quill.snow.css'
 // This stylesheet is used to override some of the default Quill editor's styles.
 import '../src/styles/quill.snow.override.css'
 import 'react-grid-layout/css/styles.css'
+// apply fix for common css problems:
+// - remove default padding/margin from html and body
+// - set 100% width and height for html and body
+// - set box-sizing, remove outlines, etc
+import 'antd/dist/reset.css'
 import type { IAppProps, IPageProps } from '@codelab/frontend/abstract/core'
 import { initializeStore } from '@codelab/frontend/model/infra/mobx'
 import { StoreProvider } from '@codelab/frontend/presenter/container'


### PR DESCRIPTION
<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(libs-ui-component): must begin with lowercase` -->

## Description

Apply `antd/dist/reset.css` to fix common CSS problems.
Also stabilize e2e test that failed on this PR.

This fixes the scrolling problem described in the current issue:


https://user-images.githubusercontent.com/74900868/233830592-35c64a8f-b1df-4b1e-8e46-3dc70b7e57c3.mov

And also some other issues with sizing, padding, margins:

Before             |  After
:-------------------------:|:-------------------------:
<img width="1728" alt="Screenshot 2023-04-23 at 11 06 09" src="https://user-images.githubusercontent.com/74900868/233830428-d436337d-c501-49b2-bb6c-9bc358065426.png">|<img width="1728" alt="Screenshot 2023-04-23 at 11 03 05" src="https://user-images.githubusercontent.com/74900868/233830260-bfe04680-9f0c-4662-8f2c-878e4787fcb4.png">

Before             |  After
:-------------------------:|:-------------------------:
<img width="1728" alt="Screenshot 2023-04-23 at 11 05 46" src="https://user-images.githubusercontent.com/74900868/233830407-9ccdccb3-466c-4299-af50-49b931c272ae.png">|<img width="1728" alt="Screenshot 2023-04-23 at 11 03 44" src="https://user-images.githubusercontent.com/74900868/233830291-a01b0387-8b6e-4abe-b2c1-5a5495a3a26e.png">

Before             |  After
:-------------------------:|:-------------------------:
<img width="1728" alt="Screenshot 2023-04-23 at 11 05 10" src="https://user-images.githubusercontent.com/74900868/233830373-0ca037f6-82af-4d4c-9235-14a1fa3369e5.png">|<img width="1728" alt="Screenshot 2023-04-23 at 11 04 26" src="https://user-images.githubusercontent.com/74900868/233830320-0c5b9379-b902-4d4e-b84a-09381549fbd7.png">


## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged -->

Fixes #2523 
