### PR TITLE
fix: use title case validation for component name

### DIFF
--- a/libs/frontend/domain/component/src/use-cases/create-component/CreateComponentModal.tsx
+++ b/libs/frontend/domain/component/src/use-cases/create-component/CreateComponentModal.tsx
@@ -1,10 +1,6 @@
-import type { IInterfaceType } from '@codelab/frontend/abstract/core'
-import { Store } from '@codelab/frontend/domain/store'
-import { InterfaceType, typeRef } from '@codelab/frontend/domain/type'
 import { useStore } from '@codelab/frontend/presenter/container'
 import { createNotificationHandler } from '@codelab/frontend/shared/utils'
 import { ModalForm } from '@codelab/frontend/view/components'
-import { ITypeKind } from '@codelab/shared/abstract/core'
 import { observer } from 'mobx-react-lite'
 import React from 'react'
 import tw from 'twin.macro'
@@ -14,16 +10,10 @@ import type { CreateComponentSchema } from './create-component.schema'
 import { createComponentSchema } from './create-component.schema'
 
 export const CreateComponentModal = observer(() => {
-  const { componentService, storeService, typeService, userService } =
-    useStore()
-
+  const { componentService, userService } = useStore()
   const user = userService.user
 
   const onSubmit = (componentData: CreateComponentSchema) => {
-    if (!user) {
-      return Promise.reject()
-    }
-
     const rootElement = { id: v4() }
 
     return componentService.create({
@@ -49,7 +39,7 @@ export const CreateComponentModal = observer(() => {
             id: v4(),
           },
           id: v4(),
-          owner: { auth0Id: user?.auth0Id },
+          owner: { auth0Id: user.auth0Id },
         }}
         onSubmit={onSubmit}
         onSubmitError={createNotificationHandler({

--- a/libs/frontend/domain/component/src/use-cases/create-component/create-component.schema.ts
+++ b/libs/frontend/domain/component/src/use-cases/create-component/create-component.schema.ts
@@ -1,8 +1,8 @@
 import type { ICreateComponentData } from '@codelab/frontend/abstract/core'
 import {
   idSchema,
-  nonEmptyString,
   ownerSchema,
+  titleCaseValidation,
 } from '@codelab/frontend/view/components'
 import type { JSONSchemaType } from 'ajv'
 
@@ -35,8 +35,9 @@ export const createComponentSchema: JSONSchemaType<CreateComponentSchema> = {
     },
     ...ownerSchema,
     name: {
+      type: 'string',
       autoFocus: true,
-      ...nonEmptyString,
+      ...titleCaseValidation,
     },
   },
   required: ['name', 'owner', 'childrenContainerElement'],

--- a/libs/frontend/domain/component/src/use-cases/update-component/update-component.schema.ts
+++ b/libs/frontend/domain/component/src/use-cases/update-component/update-component.schema.ts
@@ -1,6 +1,9 @@
 import type { IUpdateComponentData } from '@codelab/frontend/abstract/core'
 import { getSelectElementComponent } from '@codelab/frontend/domain/type'
-import { idSchema, nonEmptyString } from '@codelab/frontend/view/components'
+import {
+  idSchema,
+  titleCaseValidation,
+} from '@codelab/frontend/view/components'
 import { ElementTypeKind } from '@codelab/shared/abstract/codegen'
 import type { JSONSchemaType } from 'ajv'
 
@@ -22,8 +25,9 @@ export const updateComponentSchema: JSONSchemaType<IUpdateComponentData> = {
       type: 'object',
     },
     name: {
+      type: 'string',
       autoFocus: true,
-      ...nonEmptyString,
+      ...titleCaseValidation,
     },
   },
   required: ['name', 'childrenContainerElement'],


### PR DESCRIPTION
<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(libs-ui-component): must begin with lowercase` -->

## Description
Element uses Title Case validation pattern for name. When creating a component its root element name is not validated, which causes the form submission to fail in case of invalid Element names.  

This PR adds Title Case validation for the component name as well. 

<!-- This is a short description on the Pull Request -->

## Video or Image

<!-- Add video or image showing how the new feature works -->

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged -->

Fixes #2527 
