### PR TITLE
fix: state expression not working in ReactNodeType

### DIFF
--- a/libs/frontend/domain/renderer/src/abstract/ITypedValueTransformer.ts
+++ b/libs/frontend/domain/renderer/src/abstract/ITypedValueTransformer.ts
@@ -1,7 +1,9 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
 import type {
   IBaseRenderPipe,
   IComponentService,
   IElementService,
+  IPropData,
   TypedValue,
 } from '@codelab/frontend/abstract/core'
 import type { ITypeKind } from '@codelab/shared/abstract/core'
@@ -16,6 +18,9 @@ export interface ITypedValueTransformer extends IBaseRenderPipe {
   canHandleTypeKind(typeKind: ITypeKind): boolean
   canHandleValue(value: TypedValue<unknown>): boolean
   // TODO: Create better typing
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  transform(typedValue: TypedValue<unknown>, typeKind: ITypeKind): any
+  transform(
+    typedValue: TypedValue<unknown>,
+    typeKind: ITypeKind,
+    context: IPropData,
+  ): any
 }

--- a/libs/frontend/domain/renderer/src/element/ElementWrapper.ts
+++ b/libs/frontend/domain/renderer/src/element/ElementWrapper.ts
@@ -22,7 +22,7 @@ export interface ElementWrapperProps {
    * Props passed in from outside the component
    */
   extraProps?: IPropData
-  renderService: IRenderer
+  renderer: IRenderer
 }
 
 /**
@@ -31,7 +31,7 @@ export interface ElementWrapperProps {
  * It is in this wrapper that the children are rendered
  */
 export const ElementWrapper = observer<ElementWrapperProps>(
-  ({ element, extraProps = {}, renderService, ...rest }) => {
+  ({ element, extraProps = {}, renderer, ...rest }) => {
     const onRefChange = useCallback((node: Nullable<HTMLElement>) => {
       if (node !== null) {
         // FIXME:
@@ -45,12 +45,12 @@ export const ElementWrapper = observer<ElementWrapperProps>(
     }, [])
 
     // Render the element to an intermediate output
-    const renderOutputs = renderService.renderIntermediateElement(
+    const renderOutputs = renderer.renderIntermediateElement(
       element,
       extraProps,
     )
 
-    renderService.logRendered(element, renderOutputs)
+    renderer.logRendered(element, renderOutputs)
 
     // TODO: re-work on implementation for the draggable elements and allowable children on the droppable elements.
     // Render the elements normally for now since the DnD is currently not properly working and
@@ -61,7 +61,7 @@ export const ElementWrapper = observer<ElementWrapperProps>(
         element,
         mergeProps(renderOutput.props, {}),
       )
-        ? renderService.renderChildren({
+        ? renderer.renderChildren({
             extraProps,
             parentOutput: renderOutput,
           })
@@ -75,7 +75,7 @@ export const ElementWrapper = observer<ElementWrapperProps>(
           element.renderType.current.type === IAtomType.GridLayout
         ) {
           renderOutput.props['static'] =
-            renderService.rendererType === RendererType.Preview
+            renderer.rendererType === RendererType.Preview
         }
       }
 

--- a/libs/frontend/domain/renderer/src/renderer.model.ts
+++ b/libs/frontend/domain/renderer/src/renderer.model.ts
@@ -285,15 +285,14 @@ export class Renderer
    * Parses and transforms the props for a given element, so they are ready for rendering
    */
   private processPropsForRender = (props: IPropData, element: IElement) => {
-    props = this.applyPropTypeTransformers(props)
-    props = element.executePropTransformJs(props)
-
     // FIXME:
     const context =
       this.rendererType === RendererType.ComponentBuilder
         ? props
         : mergeProps(element.store.state, props)
 
+    props = this.applyPropTypeTransformers(props, context)
+    props = element.executePropTransformJs(props)
     props = replaceStateInProps(props, context)
 
     return props
@@ -302,7 +301,7 @@ export class Renderer
   /**
    * Applies all the type transformers to the props
    */
-  private applyPropTypeTransformers = (props: IPropData) =>
+  private applyPropTypeTransformers = (props: IPropData, context: IPropData) =>
     mapDeep(props, (value) => {
       value = preTransformPropTypeValue(value)
 
@@ -324,7 +323,7 @@ export class Renderer
           continue
         }
 
-        return propTransformer.transform(value, typeKind)
+        return propTransformer.transform(value, typeKind, context)
       }
 
       /*

--- a/libs/frontend/domain/renderer/src/renderer.model.ts
+++ b/libs/frontend/domain/renderer/src/renderer.model.ts
@@ -150,7 +150,7 @@ export class Renderer
       element,
       extraProps,
       key: `element-wrapper-${element.id}`,
-      renderService: this,
+      renderer: this,
     }
 
     return React.createElement(ElementWrapper, wrapperProps)

--- a/libs/frontend/domain/renderer/src/typedValueTransformers/ReactNodeTypedValueTransformer.ts
+++ b/libs/frontend/domain/renderer/src/typedValueTransformers/ReactNodeTypedValueTransformer.ts
@@ -1,4 +1,4 @@
-import type { TypedValue } from '@codelab/frontend/abstract/core'
+import type { IPropData, TypedValue } from '@codelab/frontend/abstract/core'
 import {
   expressionTransformer,
   hasStateExpression,
@@ -50,7 +50,11 @@ export class ReactNodeTypedValueTransformer
     )
   }
 
-  public transform(value: TypedValue<string>) {
+  public transform(
+    value: TypedValue<string>,
+    _: ITypeKind,
+    context: IPropData,
+  ) {
     if (hasStateExpression(value.value)) {
       // const { values } = this.renderer.appStore.current.state
 
@@ -65,6 +69,7 @@ export class ReactNodeTypedValueTransformer
       const evaluationContext = {
         atoms,
         React,
+        ...context,
         // ...values
       }
 


### PR DESCRIPTION
## Description

The issue was that when transforming the `ReactNodeType` in `ReactNodeTypedValueTransformer` we aren't passing the render props as part of the context, hence the created component has no access to that data.

## Video or Image

https://user-images.githubusercontent.com/51242349/234057965-5b3ce540-85ca-42a3-8cc3-4185d31aac5f.mp4

## Related Issue(s)

Fixes #2285