### PR TITLE
refactor: get base types cypher query optional pagination

### DIFF
--- a/libs/backend/infra/adapter/neo4j/src/cypher/type/getBaseTypes.cypher
+++ b/libs/backend/infra/adapter/neo4j/src/cypher/type/getBaseTypes.cypher
@@ -1,17 +1,13 @@
-CALL apoc.cypher.run(
-  '
-  MATCH (type:Type)
-  WHERE type.name =~ $name
-  WITH count(type) as totalCount
+WITH '(?i).*' + $name + '.*' AS name
 
-  MATCH (type:Type)-[:OWNED_BY]-(owner:User)
-  WHERE type.name =~ $name
-  RETURN type, owner, totalCount
-  ORDER by type.name
-  '
-  + CASE WHEN $skip IS NOT NULL THEN ' SKIP $skip' ELSE '' END
-  + CASE WHEN $limit IS NOT NULL THEN ' LIMIT $limit'  ELSE '' END,
-  { name: '(?i).*' + $name + '.*', skip: $skip, limit: $limit }
-) yield value
+MATCH (type:Type)
+WHERE type.name =~ name
+WITH name, count(type) as totalCount
 
-RETURN value.type as type, value.owner as owner, value.totalCount as totalCount
+MATCH (type:Type)-[:OWNED_BY]-(owner:User)
+WHERE type.name =~ name
+RETURN type, owner, totalCount
+
+ORDER by type.name
+SKIP CASE WHEN $skip IS NOT NULL THEN $skip ELSE 0 END
+LIMIT CASE WHEN $limit IS NOT NULL THEN $limit ELSE 999999 END

--- a/libs/backend/infra/adapter/neo4j/src/cypher/type/getBaseTypes.cypher
+++ b/libs/backend/infra/adapter/neo4j/src/cypher/type/getBaseTypes.cypher
@@ -1,11 +1,17 @@
-MATCH (type:Type)
-WHERE type.name =~ $name
-WITH count(type) as totalCount
+CALL apoc.cypher.run(
+  '
+  MATCH (type:Type)
+  WHERE type.name =~ $name
+  WITH count(type) as totalCount
 
-MATCH (type:Type)-[:OWNED_BY]-(owner:User)
-WHERE type.name =~ $name
-RETURN type, owner, totalCount
+  MATCH (type:Type)-[:OWNED_BY]-(owner:User)
+  WHERE type.name =~ $name
+  RETURN type, owner, totalCount
+  ORDER by type.name
+  '
+  + CASE WHEN $skip IS NOT NULL THEN ' SKIP $skip' ELSE '' END
+  + CASE WHEN $limit IS NOT NULL THEN ' LIMIT $limit'  ELSE '' END,
+  { name: '(?i).*' + $name + '.*', skip: $skip, limit: $limit }
+) yield value
 
-ORDER by type.name
-SKIP $skip
-LIMIT $limit
+RETURN value.type as type, value.owner as owner, value.totalCount as totalCount

--- a/libs/backend/infra/adapter/neo4j/src/cypher/type/getBaseTypes.cypher
+++ b/libs/backend/infra/adapter/neo4j/src/cypher/type/getBaseTypes.cypher
@@ -9,5 +9,5 @@ WHERE type.name =~ name
 RETURN type, owner, totalCount
 
 ORDER by type.name
-SKIP CASE WHEN $skip IS NOT NULL THEN $skip ELSE 0 END
-LIMIT CASE WHEN $limit IS NOT NULL THEN $limit ELSE 999999 END
+SKIP $skip
+LIMIT $limit

--- a/libs/backend/infra/adapter/neo4j/src/resolver/pure-resolver/type/query/base-types.ts
+++ b/libs/backend/infra/adapter/neo4j/src/resolver/pure-resolver/type/query/base-types.ts
@@ -12,20 +12,11 @@ export const baseTypes: IFieldResolver<
 > = (_, params) =>
   withReadTransaction(async (txn) => {
     const { options } = params
-    const limit = options?.limit ?? 10
-    const offset = options?.offset ?? 0
-
-    const where = options?.where?.name
-      ? options.where
-      : {
-          name: '',
-        }
 
     const { records: getTypesRecords } = await txn.run(getBaseTypes, {
-      limit: int(limit),
-      // this makes the search case insensitive and work like `CONTAINS`
-      name: `(?i).*${where.name}.*`,
-      skip: int(offset),
+      limit: options?.limit ? int(options.limit) : null,
+      name: options?.where?.name ?? '',
+      skip: options?.offset ? int(options.offset) : null,
     })
 
     const totalCountRecord = getTypesRecords[0]?.get('totalCount')

--- a/libs/backend/infra/adapter/neo4j/src/resolver/pure-resolver/type/query/base-types.ts
+++ b/libs/backend/infra/adapter/neo4j/src/resolver/pure-resolver/type/query/base-types.ts
@@ -12,11 +12,14 @@ export const baseTypes: IFieldResolver<
 > = (_, params) =>
   withReadTransaction(async (txn) => {
     const { options } = params
+    const limit = options?.limit ?? 99999
+    const skip = options?.offset ?? 0
+    const name = options?.where?.name ?? ''
 
     const { records: getTypesRecords } = await txn.run(getBaseTypes, {
-      limit: options?.limit ? int(options.limit) : null,
-      name: options?.where?.name ?? '',
-      skip: options?.offset ? int(options.offset) : null,
+      limit: int(limit),
+      name,
+      skip: int(skip),
     })
 
     const totalCountRecord = getTypesRecords[0]?.get('totalCount')

--- a/libs/frontend/domain/element/src/use-cases/element/update-element-prop-transformation/UpdateElementPropTransformationForm.tsx
+++ b/libs/frontend/domain/element/src/use-cases/element/update-element-prop-transformation/UpdateElementPropTransformationForm.tsx
@@ -1,6 +1,6 @@
 import type { IElement, IElementService } from '@codelab/frontend/abstract/core'
+import { CodeMirrorEditor } from '@codelab/frontend/presentation/view'
 import { useDebouncedState } from '@codelab/frontend/shared/utils'
-import { CodeMirrorEditor } from '@codelab/frontend/view/components'
 import { ICodeMirrorLanguage } from '@codelab/shared/abstract/core'
 import isString from 'lodash/isString'
 import { observer } from 'mobx-react-lite'

--- a/libs/frontend/domain/type/src/graphql/get-type.endpoints.graphql
+++ b/libs/frontend/domain/type/src/graphql/get-type.endpoints.graphql
@@ -155,8 +155,6 @@ query GetCodeMirrorTypes(
 }
 
 query GetTypeOptions {
-  # needs hardcoded limit here since the cypher query for base types requires a limit
-  # and it is set to 10 by default in the backend and is safer to just hardcode here
   baseTypes {
     items {
       id

--- a/libs/frontend/domain/type/src/graphql/get-type.endpoints.graphql
+++ b/libs/frontend/domain/type/src/graphql/get-type.endpoints.graphql
@@ -157,7 +157,7 @@ query GetCodeMirrorTypes(
 query GetTypeOptions {
   # needs hardcoded limit here since the cypher query for base types requires a limit
   # and it is set to 10 by default in the backend and is safer to just hardcode here
-  baseTypes(options: { limit: 99999 }) {
+  baseTypes {
     items {
       id
       name

--- a/libs/frontend/domain/type/src/graphql/get-type.endpoints.graphql.gen.ts
+++ b/libs/frontend/domain/type/src/graphql/get-type.endpoints.graphql.gen.ts
@@ -376,7 +376,7 @@ export const GetCodeMirrorTypesDocument = gql`
 `
 export const GetTypeOptionsDocument = gql`
   query GetTypeOptions {
-    baseTypes(options: { limit: 99999 }) {
+    baseTypes {
       items {
         id
         name


### PR DESCRIPTION
<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(libs-ui-component): must begin with lowercase` -->

## Description

<!-- This is a short description on the Pull Request -->
- refactor the getBaseTypes cypher query so that if the `$limit` and `$skip` is null, it will still work and will execute the query without the LIMIT and SKIP
- the implementation uses the [apoc.cypher.run](https://neo4j.com/labs/apoc/4.1/overview/apoc.cypher/apoc.cypher.run/) to be able to conditionally add the LIMIT and SKIP clause into the whole query
- removed the hard coded limit of 99999 to query "all" the base types

## Video or Image

<!-- Add video or image showing how the new feature works -->

Testing base types query to see its still working

https://user-images.githubusercontent.com/27695022/234055640-605587c0-102e-4808-ac67-b8d99e0cb812.mp4



## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged -->

Fixes #2514 
