### PR TITLE
fix: don't apply "false" by default for bool props

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -13,4 +13,6 @@
 
 <!-- Please link the issue being fixed so it gets closed when this is merged -->
 
-Fixes #
+Fixes
+
+- #

--- a/libs/frontend/domain/type/src/interface-form/type-schema.factory.ts
+++ b/libs/frontend/domain/type/src/interface-form/type-schema.factory.ts
@@ -93,6 +93,7 @@ export class TypeSchemaFactory {
       label: field.name || compoundCaseToTitleCase(field.key),
       ...(field.description ? fieldDescription(field.description) : {}),
       ...this.transform(field.type.current, {
+        defaultValues: field.defaultValues,
         fieldName: field.name,
         validationRules: field.validationRules ?? undefined,
       }),
@@ -230,9 +231,10 @@ export class TypeSchemaFactory {
         }
         break
       case PrimitiveTypeKind.Boolean:
-        rulesSchema = {
-          default: false,
-        }
+        rulesSchema =
+          typeof context?.defaultValues === 'boolean'
+            ? { default: context.defaultValues }
+            : {}
         break
     }
 

--- a/libs/frontend/domain/type/src/interface-form/types.ts
+++ b/libs/frontend/domain/type/src/interface-form/types.ts
@@ -1,4 +1,5 @@
 import type {
+  IFieldDefaultValue,
   IInterfaceType,
   IPropData,
   IType,
@@ -32,6 +33,7 @@ export interface UiPropertiesContext {
    * for code mirror
    */
   autocomplete?: IPropData
+  defaultValues?: IFieldDefaultValue | null
   fieldName?: string | null
   validationRules?: IValidationRules
 }


### PR DESCRIPTION
<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(libs-ui-component): must begin with lowercase` -->

## Description

Once an element is created - no props are passed to it and it renders using default values only. But when the first property is specified on the Element Props Form - the form schema is validated and default values are applied. Previously the form schema was set up to set all boolean values to "false" values, which is not what we want.

Before:

https://user-images.githubusercontent.com/74900868/234360828-c2026965-1b92-4f27-b80e-4c76173124ed.mov

After:

https://user-images.githubusercontent.com/74900868/234360160-3cf532e0-5331-4802-b57b-4020dd0b3e2b.mov

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged -->

Fixes

- #2508 
