### PR TITLE
refactor: reduce hooks usage

### DIFF
--- a/libs/frontend/abstract/core/src/domain/element/element.model.interface.ts
+++ b/libs/frontend/abstract/core/src/domain/element/element.model.interface.ts
@@ -106,6 +106,7 @@ export interface IElement
   detachAsFirstChild(): void
   detachFromParent(): void
   executePropTransformJs(props: IPropData): IPropData
+  setCustomCss(css: string): void
   setFirstChild(firstChild: Ref<IElement>): void
   setName(name: string): void
   setNextSibling(nextSibling: Ref<IElement>): void


### PR DESCRIPTION
<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(libs-ui-component): must begin with lowercase` -->

## Description

Reduce the number of hooks used in `ElementCssEditor` from 18 to just 5.

A bit different approach was used: all the changes were immediately applied from the editor to the `element` model, instead of saving it to the component state. And then either by debouncer or on component unmount these changes are saved to DB (depending on what happens earlier)

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged -->

Fixes #2530 
