### PR TITLE
fix: mistake in condition statement

### DIFF
--- a/apps/platform-e2e/src/e2e/css.cy.ts
+++ b/apps/platform-e2e/src/e2e/css.cy.ts
@@ -5,6 +5,7 @@ import { loginSession } from '../support/nextjs-auth0/commands/login'
 const ELEMENT_BUTTON = 'Button'
 const backgroundColor1 = 'rgb(48, 182, 99)'
 const backgroundColor2 = 'rgb(182, 99, 48)'
+const display = 'none'
 const elementName = `Element ${ELEMENT_BUTTON}`
 
 const createBackgroundColorStyle = (backgroundColorValue: string) =>
@@ -40,8 +41,8 @@ describe('CSS CRUD', () => {
       })
   })
 
-  describe('Add css', () => {
-    it('should be able to add some css styling', () => {
+  describe('Add css string', () => {
+    it('should be able to add styling through css string', () => {
       cy.getSpinner().should('not.exist')
       cy.findByText(elementName).click()
 
@@ -57,8 +58,8 @@ describe('CSS CRUD', () => {
     })
   })
 
-  describe('Update css', () => {
-    it('should be able to update the css styling', () => {
+  describe('Update css string', () => {
+    it('should be able to update styling through css string', () => {
       clickEditor()
         .clear({ force: true })
         .type(createBackgroundColorStyle(backgroundColor2), { delay: 100 })
@@ -71,8 +72,8 @@ describe('CSS CRUD', () => {
     })
   })
 
-  describe('Remove css', () => {
-    it('should be able to remove the css styling', () => {
+  describe('Remove css string', () => {
+    it('should be able to remove the css string', () => {
       clickEditor().clear({ force: true }).type(' ', { delay: 100 })
 
       cy.get('#render-root .ant-btn', { timeout: 30000 }).should(
@@ -85,6 +86,37 @@ describe('CSS CRUD', () => {
         'not.have.css',
         'background-color',
         backgroundColor2,
+      )
+    })
+  })
+
+  describe('Add GUI style', () => {
+    it('should be able to add styling through GUI', () => {
+      cy.getSpinner().should('not.exist')
+
+      cy.get('.ant-collapse-item-active .ant-btn').click()
+      cy.findByText(display).click()
+
+      cy.get('#render-root .ant-btn', { timeout: 30000 }).should(
+        'have.css',
+        'display',
+        display,
+      )
+
+      cy.waitForApiCalls()
+    })
+  })
+
+  describe('Css and GUI style persistance', () => {
+    it('should persist styles after reload', () => {
+      cy.reload()
+      cy.getSpinner().should('not.exist')
+      cy.findByText(elementName).click()
+
+      cy.get('#render-root .ant-btn', { timeout: 30000 }).should(
+        'have.css',
+        'display',
+        display,
       )
     })
   })

--- a/libs/frontend/domain/element/src/css-editor/ElementCssEditor.tsx
+++ b/libs/frontend/domain/element/src/css-editor/ElementCssEditor.tsx
@@ -51,7 +51,7 @@ export const ElementCssEditor = observer<ElementCssEditorInternalProps>(
         const { customCss: lastCustomCss, guiCss: lastGuiCss } = lastState
 
         // do not send request if value was not changed
-        if (customCss === lastCustomCss && guiCss === lastGuiCss) {
+        if (customCss !== lastCustomCss || guiCss !== lastGuiCss) {
           lastStateRef.current = { customCss, guiCss }
 
           void elementService.update({ ...elementModel, customCss, guiCss })


### PR DESCRIPTION
<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(libs-ui-component): must begin with lowercase` -->

## Description

While refactoring `ElementCssEditor` I made a mistake and used an inverted condition which caused invalid logic (css to be applied on the client but not to be saved to DB).
This is fixed not as well as automated

<!-- This is a short description on the Pull Request -->

## Video or Image

<!-- Add video or image showing how the new feature works -->

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged -->

Fixes #2558 
