### PR TITLE
fix: missing labels on array types of interface types

### DIFF
--- a/libs/frontend/presentation/view/components/form/fields/WrappedListField.tsx
+++ b/libs/frontend/presentation/view/components/form/fields/WrappedListField.tsx
@@ -4,8 +4,15 @@ import { connectField } from 'uniforms'
 import type { ListFieldProps } from 'uniforms-antd'
 import { ListField, wrapField } from 'uniforms-antd'
 
+// `label` here needs to be null so that if the array's items has nested fields (e.g. interface type)
+// their labels will be displayed. This is based on the uniforms documentation for the `label` prop
+// https://uniforms.tools/docs/api-fields/#common-props
+// We have a custom component that will render the label for the array field
 const WrappedListFieldInternal = (props: ListFieldProps) =>
-  wrapField(props as Omit<ListFieldProps, 'onReset'>, <ListField {...props} />)
+  wrapField(
+    props as Omit<ListFieldProps, 'onReset'>,
+    <ListField {...props} label={null} />,
+  )
 
 /**
  * The same as uniforms-antd `ListField`, but wrapped with `wrapField`

--- a/libs/frontend/presentation/view/components/form/fields/WrappedListField.tsx
+++ b/libs/frontend/presentation/view/components/form/fields/WrappedListField.tsx
@@ -8,11 +8,8 @@ import { ListField, wrapField } from 'uniforms-antd'
 // their labels will be displayed. This is based on the uniforms documentation for the `label` prop
 // https://uniforms.tools/docs/api-fields/#common-props
 // We have a custom component that will render the label for the array field
-const WrappedListFieldInternal = (props: ListFieldProps) =>
-  wrapField(
-    props as Omit<ListFieldProps, 'onReset'>,
-    <ListField {...props} label={null} />,
-  )
+const WrappedListFieldInternal = (props: Omit<ListFieldProps, 'onReset'>) =>
+  wrapField(props, <ListField {...props} label={null} />)
 
 /**
  * The same as uniforms-antd `ListField`, but wrapped with `wrapField`


### PR DESCRIPTION
<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(libs-ui-component): must begin with lowercase` -->

## Description

<!-- This is a short description on the Pull Request -->
This PR fixes the labels not showing on the interface types when they are inside an array type prop

| Before | After |
|-----------|---------|
| ![image](https://user-images.githubusercontent.com/27695022/235437780-431e0bed-f85f-4a5f-b75b-f5b41f6cc136.png) |  ![image](https://user-images.githubusercontent.com/27695022/235437953-83b954b0-1995-4dad-b517-86d94ae312ea.png) |
| ![image](https://user-images.githubusercontent.com/27695022/235438023-162077d5-3c34-46b0-a8ae-0717d257280c.png) | ![image](https://user-images.githubusercontent.com/27695022/235438047-87aaaaf2-565c-45c8-9ef1-384b641317ba.png) |

## Video or Image

<!-- Add video or image showing how the new feature works -->

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged -->

Fixes #2540 
