### PR TITLE
fix: issue when renderComponentType was missing

### DIFF
--- a/examples/portfolio-website/user-data.json
+++ b/examples/portfolio-website/user-data.json
@@ -15,7 +15,6 @@
       ],
       "pages": [
         {
-          "components": [],
           "elements": [
             {
               "id": "19d80737-acf9-46db-8337-104c1b66b689",
@@ -503,7 +502,6 @@
           }
         },
         {
-          "components": [],
           "elements": [
             {
               "id": "d89d88dc-34ff-4067-b370-65bc51252300",
@@ -552,7 +550,6 @@
           "url": "/404"
         },
         {
-          "components": [],
           "elements": [
             {
               "id": "2e04cfb6-842b-420f-85bf-e4fb4d6f0c5a",
@@ -601,63 +598,6 @@
           "url": "/500"
         },
         {
-          "components": [
-            {
-              "id": "fd462921-8775-45cc-911e-8763ba7f756b",
-              "name": "Page Title",
-              "rootElement": {
-                "id": "808fbaec-4683-49a2-98b5-5d9deb9f02db",
-                "name": "Page Title"
-              },
-              "owner": { "auth0Id": "google-oauth2|103532353421614768841" },
-              "props": {
-                "id": "0483e8c9-e47f-455b-9ce7-60f563ebb103",
-                "data": "{\"label\":\"Link Label\",\"href\":\"/\"}"
-              },
-              "store": {
-                "id": "0e632c0e-8963-4975-a39a-e8fe31108cfe",
-                "name": "NavLink Store",
-                "api": {
-                  "__typename": "InterfaceType",
-                  "id": "bc6ef412-0f85-4951-924a-49a978e4ef34",
-                  "kind": "InterfaceType",
-                  "name": "NavLink Store API",
-                  "owner": { "auth0Id": "google-oauth2|103532353421614768841" },
-                  "fields": []
-                },
-                "actions": []
-              },
-              "api": {
-                "__typename": "InterfaceType",
-                "id": "40d0de0c-eb90-4dde-afdc-f4ed64088168",
-                "kind": "InterfaceType",
-                "name": "NavLink API",
-                "owner": { "auth0Id": "google-oauth2|103532353421614768841" },
-                "fields": [
-                  {
-                    "id": "48932cc8-b8ce-4e65-8d94-7c7811384cae",
-                    "key": "text",
-                    "name": null,
-                    "description": null,
-                    "validationRules": "{}",
-                    "defaultValues": "\"Title Text\"",
-                    "prevSibling": null,
-                    "nextSibling": null,
-                    "fieldType": {
-                      "__typename": "PrimitiveType",
-                      "id": "3a0d0fc6-c51e-4f05-85b4-cde709fe5625",
-                      "kind": "PrimitiveType",
-                      "name": "String"
-                    },
-                    "api": { "id": "40d0de0c-eb90-4dde-afdc-f4ed64088168" }
-                  }
-                ]
-              },
-              "childrenContainerElement": {
-                "id": "808fbaec-4683-49a2-98b5-5d9deb9f02db"
-              }
-            }
-          ],
           "elements": [
             {
               "id": "b1ba1591-c439-4249-9228-952cede73674",
@@ -767,63 +707,6 @@
           "url": "/about"
         },
         {
-          "components": [
-            {
-              "id": "fd462921-8775-45cc-911e-8763ba7f756b",
-              "name": "Page Title",
-              "rootElement": {
-                "id": "808fbaec-4683-49a2-98b5-5d9deb9f02db",
-                "name": "Page Title"
-              },
-              "owner": { "auth0Id": "google-oauth2|103532353421614768841" },
-              "props": {
-                "id": "0483e8c9-e47f-455b-9ce7-60f563ebb103",
-                "data": "{\"label\":\"Link Label\",\"href\":\"/\"}"
-              },
-              "store": {
-                "id": "0e632c0e-8963-4975-a39a-e8fe31108cfe",
-                "name": "NavLink Store",
-                "api": {
-                  "__typename": "InterfaceType",
-                  "id": "bc6ef412-0f85-4951-924a-49a978e4ef34",
-                  "kind": "InterfaceType",
-                  "name": "NavLink Store API",
-                  "owner": { "auth0Id": "google-oauth2|103532353421614768841" },
-                  "fields": []
-                },
-                "actions": []
-              },
-              "api": {
-                "__typename": "InterfaceType",
-                "id": "40d0de0c-eb90-4dde-afdc-f4ed64088168",
-                "kind": "InterfaceType",
-                "name": "NavLink API",
-                "owner": { "auth0Id": "google-oauth2|103532353421614768841" },
-                "fields": [
-                  {
-                    "id": "48932cc8-b8ce-4e65-8d94-7c7811384cae",
-                    "key": "text",
-                    "name": null,
-                    "description": null,
-                    "validationRules": "{}",
-                    "defaultValues": "\"Title Text\"",
-                    "prevSibling": null,
-                    "nextSibling": null,
-                    "fieldType": {
-                      "__typename": "PrimitiveType",
-                      "id": "3a0d0fc6-c51e-4f05-85b4-cde709fe5625",
-                      "kind": "PrimitiveType",
-                      "name": "String"
-                    },
-                    "api": { "id": "40d0de0c-eb90-4dde-afdc-f4ed64088168" }
-                  }
-                ]
-              },
-              "childrenContainerElement": {
-                "id": "808fbaec-4683-49a2-98b5-5d9deb9f02db"
-              }
-            }
-          ],
           "elements": [
             {
               "id": "1f237cb8-a5b2-4cf6-b7c2-c697a8cd710b",
@@ -933,63 +816,6 @@
           "url": "/blog"
         },
         {
-          "components": [
-            {
-              "id": "fd462921-8775-45cc-911e-8763ba7f756b",
-              "name": "Page Title",
-              "rootElement": {
-                "id": "808fbaec-4683-49a2-98b5-5d9deb9f02db",
-                "name": "Page Title"
-              },
-              "owner": { "auth0Id": "google-oauth2|103532353421614768841" },
-              "props": {
-                "id": "0483e8c9-e47f-455b-9ce7-60f563ebb103",
-                "data": "{\"label\":\"Link Label\",\"href\":\"/\"}"
-              },
-              "store": {
-                "id": "0e632c0e-8963-4975-a39a-e8fe31108cfe",
-                "name": "NavLink Store",
-                "api": {
-                  "__typename": "InterfaceType",
-                  "id": "bc6ef412-0f85-4951-924a-49a978e4ef34",
-                  "kind": "InterfaceType",
-                  "name": "NavLink Store API",
-                  "owner": { "auth0Id": "google-oauth2|103532353421614768841" },
-                  "fields": []
-                },
-                "actions": []
-              },
-              "api": {
-                "__typename": "InterfaceType",
-                "id": "40d0de0c-eb90-4dde-afdc-f4ed64088168",
-                "kind": "InterfaceType",
-                "name": "NavLink API",
-                "owner": { "auth0Id": "google-oauth2|103532353421614768841" },
-                "fields": [
-                  {
-                    "id": "48932cc8-b8ce-4e65-8d94-7c7811384cae",
-                    "key": "text",
-                    "name": null,
-                    "description": null,
-                    "validationRules": "{}",
-                    "defaultValues": "\"Title Text\"",
-                    "prevSibling": null,
-                    "nextSibling": null,
-                    "fieldType": {
-                      "__typename": "PrimitiveType",
-                      "id": "3a0d0fc6-c51e-4f05-85b4-cde709fe5625",
-                      "kind": "PrimitiveType",
-                      "name": "String"
-                    },
-                    "api": { "id": "40d0de0c-eb90-4dde-afdc-f4ed64088168" }
-                  }
-                ]
-              },
-              "childrenContainerElement": {
-                "id": "808fbaec-4683-49a2-98b5-5d9deb9f02db"
-              }
-            }
-          ],
           "elements": [
             {
               "id": "bc07ca6c-04b0-488d-9b26-80a158d7f853",
@@ -1099,63 +925,6 @@
           "url": "/guestbook"
         },
         {
-          "components": [
-            {
-              "id": "fd462921-8775-45cc-911e-8763ba7f756b",
-              "name": "Page Title",
-              "rootElement": {
-                "id": "808fbaec-4683-49a2-98b5-5d9deb9f02db",
-                "name": "Page Title"
-              },
-              "owner": { "auth0Id": "google-oauth2|103532353421614768841" },
-              "props": {
-                "id": "0483e8c9-e47f-455b-9ce7-60f563ebb103",
-                "data": "{\"label\":\"Link Label\",\"href\":\"/\"}"
-              },
-              "store": {
-                "id": "0e632c0e-8963-4975-a39a-e8fe31108cfe",
-                "name": "NavLink Store",
-                "api": {
-                  "__typename": "InterfaceType",
-                  "id": "bc6ef412-0f85-4951-924a-49a978e4ef34",
-                  "kind": "InterfaceType",
-                  "name": "NavLink Store API",
-                  "owner": { "auth0Id": "google-oauth2|103532353421614768841" },
-                  "fields": []
-                },
-                "actions": []
-              },
-              "api": {
-                "__typename": "InterfaceType",
-                "id": "40d0de0c-eb90-4dde-afdc-f4ed64088168",
-                "kind": "InterfaceType",
-                "name": "NavLink API",
-                "owner": { "auth0Id": "google-oauth2|103532353421614768841" },
-                "fields": [
-                  {
-                    "id": "48932cc8-b8ce-4e65-8d94-7c7811384cae",
-                    "key": "text",
-                    "name": null,
-                    "description": null,
-                    "validationRules": "{}",
-                    "defaultValues": "\"Title Text\"",
-                    "prevSibling": null,
-                    "nextSibling": null,
-                    "fieldType": {
-                      "__typename": "PrimitiveType",
-                      "id": "3a0d0fc6-c51e-4f05-85b4-cde709fe5625",
-                      "kind": "PrimitiveType",
-                      "name": "String"
-                    },
-                    "api": { "id": "40d0de0c-eb90-4dde-afdc-f4ed64088168" }
-                  }
-                ]
-              },
-              "childrenContainerElement": {
-                "id": "808fbaec-4683-49a2-98b5-5d9deb9f02db"
-              }
-            }
-          ],
           "elements": [
             {
               "id": "1a0d8356-0567-4d5c-b2f0-b0b6cebcc716",
@@ -1265,6 +1034,63 @@
           "url": "/"
         }
       ]
+    }
+  ],
+  "components": [
+    {
+      "id": "fd462921-8775-45cc-911e-8763ba7f756b",
+      "name": "Page Title",
+      "rootElement": {
+        "id": "808fbaec-4683-49a2-98b5-5d9deb9f02db",
+        "name": "Page Title"
+      },
+      "owner": { "auth0Id": "google-oauth2|103532353421614768841" },
+      "props": {
+        "id": "0483e8c9-e47f-455b-9ce7-60f563ebb103",
+        "data": "{\"label\":\"Link Label\",\"href\":\"/\"}"
+      },
+      "store": {
+        "id": "0e632c0e-8963-4975-a39a-e8fe31108cfe",
+        "name": "NavLink Store",
+        "api": {
+          "__typename": "InterfaceType",
+          "id": "bc6ef412-0f85-4951-924a-49a978e4ef34",
+          "kind": "InterfaceType",
+          "name": "NavLink Store API",
+          "owner": { "auth0Id": "google-oauth2|103532353421614768841" },
+          "fields": []
+        },
+        "actions": []
+      },
+      "api": {
+        "__typename": "InterfaceType",
+        "id": "40d0de0c-eb90-4dde-afdc-f4ed64088168",
+        "kind": "InterfaceType",
+        "name": "NavLink API",
+        "owner": { "auth0Id": "google-oauth2|103532353421614768841" },
+        "fields": [
+          {
+            "id": "48932cc8-b8ce-4e65-8d94-7c7811384cae",
+            "key": "text",
+            "name": null,
+            "description": null,
+            "validationRules": "{}",
+            "defaultValues": "\"Title Text\"",
+            "prevSibling": null,
+            "nextSibling": null,
+            "fieldType": {
+              "__typename": "PrimitiveType",
+              "id": "3a0d0fc6-c51e-4f05-85b4-cde709fe5625",
+              "kind": "PrimitiveType",
+              "name": "String"
+            },
+            "api": { "id": "40d0de0c-eb90-4dde-afdc-f4ed64088168" }
+          }
+        ]
+      },
+      "childrenContainerElement": {
+        "id": "808fbaec-4683-49a2-98b5-5d9deb9f02db"
+      }
     }
   ],
   "resources": [],

--- a/libs/backend/application/app/src/use-case/import-apps.ts
+++ b/libs/backend/application/app/src/use-case/import-apps.ts
@@ -1,10 +1,7 @@
 import type { IAppExport } from '@codelab/backend/abstract/core'
 import { importDomains } from '@codelab/backend/application/domain'
 import { createApp } from '@codelab/backend/domain/app'
-import type {
-  IAuth0Owner,
-  IComponentExport,
-} from '@codelab/frontend/abstract/core'
+import type { IAuth0Owner } from '@codelab/frontend/abstract/core'
 import { logSection, logTask } from '@codelab/shared/utils'
 
 export const importApps = async (

--- a/libs/backend/application/app/src/use-case/import-components.ts
+++ b/libs/backend/application/app/src/use-case/import-components.ts
@@ -1,4 +1,6 @@
+import type { IAppExport } from '@codelab/backend/abstract/core'
 import { createComponents } from '@codelab/backend/domain/app'
+import { updateImportedElement } from '@codelab/backend/domain/element'
 import type {
   IAuth0Owner,
   IComponentExport,
@@ -7,8 +9,23 @@ import { logSection } from '@codelab/shared/utils'
 
 export const importComponents = async (
   components: Array<IComponentExport>,
+  apps: Array<IAppExport>,
   owner: IAuth0Owner,
 ) => {
   logSection('Importing components')
   await createComponents(components, owner)
+
+  // after all the components and elements are created,
+  // we can link the element's renderComponentType
+  for (const app of apps) {
+    for (const page of app.pages) {
+      for (const element of page.elements) {
+        if (element.renderComponentType === null) {
+          continue
+        }
+
+        await updateImportedElement(element)
+      }
+    }
+  }
 }

--- a/libs/backend/application/user/src/use-case/import-user-data.ts
+++ b/libs/backend/application/user/src/use-case/import-user-data.ts
@@ -14,5 +14,5 @@ export const importUserData = async (
 
   await importApps(apps, owner)
 
-  await importComponents(components, owner)
+  await importComponents(components, apps, owner)
 }

--- a/libs/backend/domain/app/src/repository/app.repo.ts
+++ b/libs/backend/domain/app/src/repository/app.repo.ts
@@ -136,7 +136,7 @@ export const createApp = async (app: IAppExport, owner: IAuth0Owner) => {
 
   for (const { elements, store } of pages) {
     for (const element of elements) {
-      await importElementInitial(element, owner)
+      await importElementInitial(element)
     }
 
     for (const element of elements) {

--- a/libs/backend/domain/element/src/repository/element.repo.old.ts
+++ b/libs/backend/domain/element/src/repository/element.repo.old.ts
@@ -1,5 +1,4 @@
 import { Repository } from '@codelab/backend/infra/adapter/neo4j'
-import type { IAuth0Owner } from '@codelab/frontend/abstract/core'
 import type { OGM_TYPES } from '@codelab/shared/abstract/codegen'
 import { connectNodeId } from '@codelab/shared/domain/mapper'
 import { compoundCaseToTitleCase } from '@codelab/shared/utils'
@@ -19,7 +18,6 @@ const label = (element: OGM_TYPES.Element) =>
 
 export const importElementInitial = async (
   element: OGM_TYPES.Element,
-  owner: IAuth0Owner,
 ): Promise<OGM_TYPES.Element> => {
   const Element = await Repository.instance.Element
 


### PR DESCRIPTION
<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(libs-ui-component): must begin with lowercase` -->

## Description
`renderComponentType` on elements was lost during import since the component did not exist when the element was imported. This resulted in such elements being rendered as blank instead of the component instance.

## Video or Image
After the fix component instances rendered properly

https://user-images.githubusercontent.com/74900868/235602821-f632b099-32e2-471f-aacb-aa88ebe18d3a.mov


## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged -->

Fixes #2576 
