### PR TITLE
feat: Pages left panel

### DIFF
--- a/apps/platform/pages/apps/[appId]/pages/[pageId]/builder.tsx
+++ b/apps/platform/pages/apps/[appId]/pages/[pageId]/builder.tsx
@@ -1,6 +1,6 @@
 import { RendererType } from '@codelab/frontend/abstract/core'
 import type { CodelabPage } from '@codelab/frontend/abstract/types'
-import { PageType } from '@codelab/frontend/abstract/types'
+import { ExplorerPaneType } from '@codelab/frontend/abstract/types'
 import {
   BuilderContext,
   BuilderExplorerPane,
@@ -51,14 +51,14 @@ const PageBuilder: CodelabPage = observer(() => {
     <DashboardTemplate
       ConfigPane={() => <ConfigPane isLoading={isLoading} />}
       ExplorerPane={{
-        default: PageType.PageBuilder,
+        default: ExplorerPaneType.Explorer,
         items: [
           {
-            key: PageType.PageBuilder,
+            key: ExplorerPaneType.Explorer,
             render: () => <BuilderExplorerPane isLoading={isLoading} />,
           },
           {
-            key: PageType.PageList,
+            key: ExplorerPaneType.PageList,
             render: () => <ExplorerPanePage appId={appId} />,
           },
         ],

--- a/apps/platform/pages/apps/[appId]/pages/[pageId]/builder.tsx
+++ b/apps/platform/pages/apps/[appId]/pages/[pageId]/builder.tsx
@@ -16,28 +16,34 @@ import {
   useCurrentPageId,
   useRemainingPages,
   useRenderedPage,
+  useStore,
 } from '@codelab/frontend/presentation/container'
 import {
   DashboardTemplate,
   sidebarNavigation,
 } from '@codelab/frontend/presentation/view'
 import { auth0Instance } from '@codelab/shared/infra/auth0'
-import { useMountEffect } from '@react-hookz/web'
+import { useAsync, useMountEffect } from '@react-hookz/web'
 import { observer } from 'mobx-react-lite'
 import Head from 'next/head'
 import React, { useMemo } from 'react'
 
 const PageBuilder: CodelabPage = observer(() => {
-  const [{ error, result, status }, loadCurrentPage] = useRenderedPage({
-    rendererType: RendererType.PageBuilder,
-  })
-
+  const { appService } = useStore()
   const [, lazilyLoadRemainingPages] = useRemainingPages()
   const appId = useCurrentAppId()
   const pageId = useCurrentPageId()
 
+  const [{ error, result, status }, loadCurrentPage] = useRenderedPage({
+    rendererType: RendererType.PageBuilder,
+  })
+
+  const [{ result: apps, status: appsLoadingStatus }, actions] = useAsync(() =>
+    appService.loadAppsWithNestedPreviews({ id: appId }),
+  )
+
   useMountEffect(() => {
-    void loadCurrentPage.execute()
+    void loadCurrentPage.execute().finally(actions.execute)
     void lazilyLoadRemainingPages.execute()
   })
 
@@ -56,7 +62,15 @@ const PageBuilder: CodelabPage = observer(() => {
           },
           {
             key: PageType.PageList,
-            render: () => <ExplorerPanePage loading={false} />,
+            render: () => (
+              <ExplorerPanePage
+                app={apps?.[0]}
+                loading={
+                  appsLoadingStatus === 'loading' ||
+                  appsLoadingStatus === 'not-executed'
+                }
+              />
+            ),
           },
         ],
       }}

--- a/apps/platform/pages/apps/[appId]/pages/[pageId]/builder.tsx
+++ b/apps/platform/pages/apps/[appId]/pages/[pageId]/builder.tsx
@@ -1,12 +1,16 @@
 import { RendererType } from '@codelab/frontend/abstract/core'
 import type { CodelabPage } from '@codelab/frontend/abstract/types'
+import { PageType } from '@codelab/frontend/abstract/types'
 import {
   BuilderContext,
   BuilderExplorerPane,
   BuilderTabs,
   ConfigPane,
 } from '@codelab/frontend/domain/builder'
-import { PageDetailHeader } from '@codelab/frontend/domain/page'
+import {
+  ExplorerPanePage,
+  PageDetailHeader,
+} from '@codelab/frontend/domain/page'
 import {
   useCurrentAppId,
   useCurrentPageId,
@@ -43,7 +47,19 @@ const PageBuilder: CodelabPage = observer(() => {
   return (
     <DashboardTemplate
       ConfigPane={() => <ConfigPane isLoading={isLoading} />}
-      ExplorerPane={() => <BuilderExplorerPane isLoading={isLoading} />}
+      ExplorerPane={{
+        default: PageType.PageBuilder,
+        items: [
+          {
+            key: PageType.PageBuilder,
+            render: () => <BuilderExplorerPane isLoading={isLoading} />,
+          },
+          {
+            key: PageType.PageList,
+            render: () => <ExplorerPanePage loading={false} />,
+          },
+        ],
+      }}
       Header={PageDetailHeader}
       contentStyles={contentStyles}
       headerHeight={48}

--- a/apps/platform/pages/apps/[appId]/pages/index.tsx
+++ b/apps/platform/pages/apps/[appId]/pages/index.tsx
@@ -1,6 +1,6 @@
 import type { IApp } from '@codelab/frontend/abstract/core'
 import type { CodelabPage } from '@codelab/frontend/abstract/types'
-import { PageType } from '@codelab/frontend/abstract/types'
+import { ExplorerPaneType } from '@codelab/frontend/abstract/types'
 import { ExplorerPanePage } from '@codelab/frontend/domain/page'
 import {
   useCurrentAppId,
@@ -52,10 +52,10 @@ Pages.Layout = observer(({ children }) => {
   return (
     <DashboardTemplate
       ExplorerPane={{
-        default: PageType.PageList,
+        default: ExplorerPaneType.PageList,
         items: [
           {
-            key: PageType.PageList,
+            key: ExplorerPaneType.PageList,
             render: () => <ExplorerPanePage appId={appId} />,
           },
         ],

--- a/apps/platform/pages/apps/[appId]/pages/index.tsx
+++ b/apps/platform/pages/apps/[appId]/pages/index.tsx
@@ -1,5 +1,6 @@
 import type { IApp } from '@codelab/frontend/abstract/core'
 import type { CodelabPage } from '@codelab/frontend/abstract/types'
+import { PageType } from '@codelab/frontend/abstract/types'
 import { ExplorerPanePage } from '@codelab/frontend/domain/page'
 import {
   useCurrentAppId,
@@ -50,11 +51,19 @@ Pages.Layout = observer(({ children }) => {
 
   return (
     <DashboardTemplate
-      ExplorerPane={() => (
-        <ExplorerPanePage
-          loading={status === 'loading' || status === 'not-executed'}
-        />
-      )}
+      ExplorerPane={{
+        default: PageType.PageList,
+        items: [
+          {
+            key: PageType.PageList,
+            render: () => (
+              <ExplorerPanePage
+                loading={status === 'loading' || status === 'not-executed'}
+              />
+            ),
+          },
+        ],
+      }}
       sidebarNavigation={sidebarNavigation({ appId, pageId })}
     >
       {children({ app: apps?.[0] })}

--- a/apps/platform/pages/apps/[appId]/pages/index.tsx
+++ b/apps/platform/pages/apps/[appId]/pages/index.tsx
@@ -43,7 +43,7 @@ Pages.Layout = observer(({ children }) => {
   const pageId = useCurrentPageId()
   const { appService } = useStore()
 
-  const [{ result: apps, status }, actions] = useAsync(() =>
+  const [{ result: apps }, actions] = useAsync(() =>
     appService.loadAppsWithNestedPreviews({ id: appId }),
   )
 
@@ -56,12 +56,7 @@ Pages.Layout = observer(({ children }) => {
         items: [
           {
             key: PageType.PageList,
-            render: () => (
-              <ExplorerPanePage
-                app={apps?.[0]}
-                loading={status === 'loading' || status === 'not-executed'}
-              />
-            ),
+            render: () => <ExplorerPanePage appId={appId} />,
           },
         ],
       }}

--- a/apps/platform/pages/apps/[appId]/pages/index.tsx
+++ b/apps/platform/pages/apps/[appId]/pages/index.tsx
@@ -58,6 +58,7 @@ Pages.Layout = observer(({ children }) => {
             key: PageType.PageList,
             render: () => (
               <ExplorerPanePage
+                app={apps?.[0]}
                 loading={status === 'loading' || status === 'not-executed'}
               />
             ),

--- a/apps/platform/pages/tags/index.tsx
+++ b/apps/platform/pages/tags/index.tsx
@@ -1,5 +1,6 @@
 import { PageHeader } from '@ant-design/pro-components/lib'
 import type { CodelabPage } from '@codelab/frontend/abstract/types'
+import { PageType } from '@codelab/frontend/abstract/types'
 import {
   CreateTagButton,
   CreateTagModal,
@@ -73,7 +74,10 @@ TagPage.Layout = observer(({ children }) => {
 
   return (
     <DashboardTemplate
-      ExplorerPane={() => <GetTagsTree />}
+      ExplorerPane={{
+        default: PageType.Tag,
+        items: [{ key: PageType.Tag, render: () => <GetTagsTree /> }],
+      }}
       Header={TagPageHeader}
       sidebarNavigation={sidebarNavigation({ appId, pageId })}
     >

--- a/apps/platform/pages/tags/index.tsx
+++ b/apps/platform/pages/tags/index.tsx
@@ -1,6 +1,6 @@
 import { PageHeader } from '@ant-design/pro-components/lib'
 import type { CodelabPage } from '@codelab/frontend/abstract/types'
-import { PageType } from '@codelab/frontend/abstract/types'
+import { ExplorerPaneType } from '@codelab/frontend/abstract/types'
 import {
   CreateTagButton,
   CreateTagModal,
@@ -28,7 +28,7 @@ import Head from 'next/head'
 import React from 'react'
 
 const TagPage: CodelabPage<DashboardTemplateProps> = observer(() => {
-  const { tagService, userService } = useStore()
+  const { tagService } = useStore()
 
   const [{ status }, loadTagTree] = useAsync(() => {
     tagService.loadTagTree()
@@ -75,8 +75,8 @@ TagPage.Layout = observer(({ children }) => {
   return (
     <DashboardTemplate
       ExplorerPane={{
-        default: PageType.Tag,
-        items: [{ key: PageType.Tag, render: () => <GetTagsTree /> }],
+        default: ExplorerPaneType.Tag,
+        items: [{ key: ExplorerPaneType.Tag, render: () => <GetTagsTree /> }],
       }}
       Header={TagPageHeader}
       sidebarNavigation={sidebarNavigation({ appId, pageId })}

--- a/libs/frontend/abstract/core/src/domain/app/app.fragment.graphql
+++ b/libs/frontend/abstract/core/src/domain/app/app.fragment.graphql
@@ -39,6 +39,7 @@ fragment PageBuilderApp on App {
         { kind: Provider }
         { kind: NotFound }
         { kind: InternalServerError }
+        { kind: Regular }
       ]
     }
   ) {

--- a/libs/frontend/abstract/core/src/domain/app/app.fragment.graphql.gen.ts
+++ b/libs/frontend/abstract/core/src/domain/app/app.fragment.graphql.gen.ts
@@ -88,6 +88,7 @@ export const PageBuilderAppFragmentDoc = gql`
           { kind: Provider }
           { kind: NotFound }
           { kind: InternalServerError }
+          { kind: Regular }
         ]
       }
     ) {

--- a/libs/frontend/abstract/types/src/ExplorerPaneType.ts
+++ b/libs/frontend/abstract/types/src/ExplorerPaneType.ts
@@ -1,0 +1,5 @@
+export enum ExplorerPaneType {
+  PageList = 'pageList',
+  Explorer = 'explorer',
+  Tag = 'tag',
+}

--- a/libs/frontend/abstract/types/src/index.ts
+++ b/libs/frontend/abstract/types/src/index.ts
@@ -1,6 +1,7 @@
 export * from './children'
 export * from './crud'
 export * from './dragAndDrop'
+export * from './ExplorerPaneType'
 export * from './form/form'
 export * from './form/modal'
 export * from './keys'

--- a/libs/frontend/domain/app/src/store/app.service.ts
+++ b/libs/frontend/domain/app/src/store/app.service.ts
@@ -252,13 +252,24 @@ export class AppService
   add({ domains, id, name, owner, pages }: IAppDTO) {
     domains?.forEach((domain) => this.domainService.add(domain as IDomainDTO))
 
-    const app = App.create({
-      domains,
-      id,
-      name,
-      owner,
-      pages,
-    })
+    let app = this.apps.get(id)
+
+    if (app) {
+      app.writeCache({
+        domains,
+        name,
+        owner,
+        pages,
+      })
+    } else {
+      app = App.create({
+        domains,
+        id,
+        name,
+        owner,
+        pages,
+      })
+    }
 
     this.apps.set(app.id, app)
 

--- a/libs/frontend/domain/app/src/use-cases/get-apps/GetAppsItem.tsx
+++ b/libs/frontend/domain/app/src/use-cases/get-apps/GetAppsItem.tsx
@@ -13,7 +13,11 @@ export interface GetAppsItemProps {
 }
 
 export const GetAppsItem = observer<GetAppsItemProps>(({ app }) => {
-  const href = { pathname: PageType.PageList, query: { appId: app.id } }
+  const href = {
+    pathname: PageType.PageBuilder,
+    query: { appId: app.id, pageId: app.pages[0]?.id },
+  }
+
   const domains = app.domains.map((domain) => domain.current)
   const Title = <Link href={href}>{app.name}</Link>
   const Dropdown = <ItemDropdown app={app} domains={domains} />

--- a/libs/frontend/domain/app/src/use-cases/get-apps/GetAppsItem.tsx
+++ b/libs/frontend/domain/app/src/use-cases/get-apps/GetAppsItem.tsx
@@ -17,7 +17,7 @@ export const GetAppsItem = observer<GetAppsItemProps>(({ app }) => {
     pathname: PageType.PageBuilder,
     query: {
       appId: app.id,
-      explorerPaneKey: ExplorerPaneType.Explorer,
+      explorerPaneKey: ExplorerPaneType.PageList,
       pageId: app.pages[0]?.id,
     },
   }

--- a/libs/frontend/domain/app/src/use-cases/get-apps/GetAppsItem.tsx
+++ b/libs/frontend/domain/app/src/use-cases/get-apps/GetAppsItem.tsx
@@ -1,5 +1,5 @@
 import type { IApp, IDomain } from '@codelab/frontend/abstract/core'
-import { PageType } from '@codelab/frontend/abstract/types'
+import { ExplorerPaneType, PageType } from '@codelab/frontend/abstract/types'
 import { Card } from 'antd'
 import { observer } from 'mobx-react-lite'
 import Link from 'next/link'
@@ -15,7 +15,11 @@ export interface GetAppsItemProps {
 export const GetAppsItem = observer<GetAppsItemProps>(({ app }) => {
   const href = {
     pathname: PageType.PageBuilder,
-    query: { appId: app.id, pageId: app.pages[0]?.id },
+    query: {
+      appId: app.id,
+      explorerPaneKey: ExplorerPaneType.Explorer,
+      pageId: app.pages[0]?.id,
+    },
   }
 
   const domains = app.domains.map((domain) => domain.current)

--- a/libs/frontend/domain/builder/src/sections/content/Builder.tsx
+++ b/libs/frontend/domain/builder/src/sections/content/Builder.tsx
@@ -68,10 +68,6 @@ export const Builder = observer(() => {
     [isOver],
   )
 
-  if (!elementTree || !renderer) {
-    return null
-  }
-
   const defaultSize = useMemo(() => {
     if (
       builderContainerWidth > 0 &&
@@ -129,6 +125,10 @@ export const Builder = observer(() => {
       )
     }
   }, [selectedBuilderWidth, builderContainerWidth])
+
+  if (!elementTree || !renderer) {
+    return null
+  }
 
   return (
     <StyledBuilderContainer ref={containerRef}>

--- a/libs/frontend/domain/page/src/use-cases/get-pages/GetPagesItem.tsx
+++ b/libs/frontend/domain/page/src/use-cases/get-pages/GetPagesItem.tsx
@@ -1,6 +1,6 @@
 import { FileOutlined } from '@ant-design/icons'
 import type { IDomain, IPage } from '@codelab/frontend/abstract/core'
-import { PageType } from '@codelab/frontend/abstract/types'
+import { ExplorerPaneType, PageType } from '@codelab/frontend/abstract/types'
 import { regeneratePages } from '@codelab/frontend/domain/domain'
 import { useStore } from '@codelab/frontend/presentation/container'
 import {
@@ -27,7 +27,11 @@ export const GetPagesItem = observer<GetPagesItemProps>(({ domains, page }) => {
 
   const href = {
     pathname: PageType.PageBuilder,
-    query: { ...router.query, pageId: page.id },
+    query: {
+      ...router.query,
+      explorerPaneKey: ExplorerPaneType.Explorer,
+      pageId: page.id,
+    },
   }
 
   const [rebuildButtonLoading, setRebuildButtonLoading] = useState(false)

--- a/libs/frontend/domain/page/src/use-cases/get-pages/PageList.tsx
+++ b/libs/frontend/domain/page/src/use-cases/get-pages/PageList.tsx
@@ -1,24 +1,21 @@
-import {
-  useCurrentAppId,
-  useStore,
-} from '@codelab/frontend/presentation/container'
+import type { IApp } from '@codelab/frontend/abstract/core'
 import { List } from 'antd'
 import { observer } from 'mobx-react-lite'
 import React from 'react'
 import { GetPagesItem } from './GetPagesItem'
 
-export const PageList = observer(() => {
-  const appId = useCurrentAppId()
-  const { appService } = useStore()
-  const app = appService.apps.get(appId)
+interface PageListProps {
+  app: IApp
+}
 
+export const PageList = observer(({ app }: PageListProps) => {
   return (
     <List
-      dataSource={app?.pages.map((page) => page.current)}
+      dataSource={app.pages.map((page) => page.current)}
       loading={!app}
       renderItem={(page) => (
         <GetPagesItem
-          domains={app?.domains.map((domain) => domain.current)}
+          domains={app.domains.map((domain) => domain.current)}
           key={page.id}
           page={page}
         />

--- a/libs/frontend/domain/page/src/view/ExplorerPanePage.tsx
+++ b/libs/frontend/domain/page/src/view/ExplorerPanePage.tsx
@@ -1,8 +1,6 @@
-import { PageType } from '@codelab/frontend/abstract/types'
 import { ExplorerPaneTemplate } from '@codelab/frontend/presentation/view'
 import { Spin } from 'antd'
 import { observer } from 'mobx-react-lite'
-import { useRouter } from 'next/router'
 import React from 'react'
 import {
   CreatePageButton,
@@ -14,18 +12,8 @@ import {
 
 export const ExplorerPanePage = observer(
   ({ loading }: { loading: boolean }) => {
-    const router = useRouter()
-
-    const headerProps = {
-      onBack: () => router.push({ pathname: PageType.AppList }),
-    }
-
     return (
-      <ExplorerPaneTemplate
-        header={<CreatePageButton key={0} />}
-        headerProps={headerProps}
-        title="Pages"
-      >
+      <ExplorerPaneTemplate header={<CreatePageButton key={0} />} title="Pages">
         {loading ? <Spin /> : <PageList />}
 
         <CreatePageModal />

--- a/libs/frontend/domain/page/src/view/ExplorerPanePage.tsx
+++ b/libs/frontend/domain/page/src/view/ExplorerPanePage.tsx
@@ -1,4 +1,6 @@
+import type { IApp } from '@codelab/frontend/abstract/core'
 import { ExplorerPaneTemplate } from '@codelab/frontend/presentation/view'
+import type { Nullish } from '@codelab/shared/abstract/types'
 import { Spin } from 'antd'
 import { observer } from 'mobx-react-lite'
 import React from 'react'
@@ -10,11 +12,16 @@ import {
   UpdatePageModal,
 } from '../use-cases'
 
+interface ExplorerPanePageProps {
+  app: Nullish<IApp>
+  loading: boolean
+}
+
 export const ExplorerPanePage = observer(
-  ({ loading }: { loading: boolean }) => {
+  ({ app, loading }: ExplorerPanePageProps) => {
     return (
       <ExplorerPaneTemplate header={<CreatePageButton key={0} />} title="Pages">
-        {loading ? <Spin /> : <PageList />}
+        {loading || !app ? <Spin /> : <PageList app={app} />}
 
         <CreatePageModal />
         <UpdatePageModal />

--- a/libs/frontend/domain/page/src/view/PageDetailHeader.tsx
+++ b/libs/frontend/domain/page/src/view/PageDetailHeader.tsx
@@ -10,7 +10,7 @@ import {
   BuilderWidthBreakPoints,
   defaultBuilderWidthBreakPoints,
 } from '@codelab/frontend/abstract/core'
-import { PageType } from '@codelab/frontend/abstract/types'
+import { ExplorerPaneType, PageType } from '@codelab/frontend/abstract/types'
 import {
   useCurrentAppId,
   useCurrentPageId,
@@ -66,7 +66,11 @@ export const PageDetailHeader = observer(() => {
           router.push(
             {
               pathname: PageType.PageBuilder,
-              query: { ...router.query, pageId: page.id },
+              query: {
+                ...router.query,
+                explorerPaneKey: ExplorerPaneType.Explorer,
+                pageId: page.id,
+              },
             },
             undefined,
             { shallow: false },

--- a/libs/frontend/presentation/view/sections/Menu/commonMenuItems.tsx
+++ b/libs/frontend/presentation/view/sections/Menu/commonMenuItems.tsx
@@ -5,7 +5,7 @@ import {
   ExpandOutlined,
   FileOutlined,
 } from '@ant-design/icons'
-import { PageType } from '@codelab/frontend/abstract/types'
+import { ExplorerPaneType, PageType } from '@codelab/frontend/abstract/types'
 import type { Nullish } from '@codelab/shared/abstract/types'
 import type { ItemType } from 'antd/lib/menu/hooks/useItems'
 import Link from 'next/link'
@@ -37,7 +37,12 @@ export const allPagesMenuItem = (
   icon: <FileOutlined title="Pages" />,
   key: PageType.PageList,
   label: (
-    <Link href={{ pathname: PageType.PageBuilder, query: { appId, pageId } }}>
+    <Link
+      href={{
+        pathname: PageType.PageBuilder,
+        query: { appId, explorerPaneKey: ExplorerPaneType.PageList, pageId },
+      }}
+    >
       Pages
     </Link>
   ),
@@ -51,7 +56,12 @@ export const pageBuilderMenuItem = (
   icon: <BuildOutlined title="Builder" />,
   key: PageType.PageBuilder,
   label: (
-    <Link href={{ pathname: PageType.PageBuilder, query: { appId, pageId } }}>
+    <Link
+      href={{
+        pathname: PageType.PageBuilder,
+        query: { appId, explorerPaneKey: ExplorerPaneType.Explorer, pageId },
+      }}
+    >
       Builder
     </Link>
   ),

--- a/libs/frontend/presentation/view/sections/Menu/commonMenuItems.tsx
+++ b/libs/frontend/presentation/view/sections/Menu/commonMenuItems.tsx
@@ -35,7 +35,7 @@ export const allPagesMenuItem = (
 ): ItemType => ({
   disabled: !appId,
   icon: <FileOutlined title="Pages" />,
-  key: PageType.PageList,
+  key: ExplorerPaneType.PageList,
   label: (
     <Link
       href={{
@@ -54,7 +54,7 @@ export const pageBuilderMenuItem = (
 ): ItemType => ({
   disabled: !appId || !pageId,
   icon: <BuildOutlined title="Builder" />,
-  key: PageType.PageBuilder,
+  key: ExplorerPaneType.Explorer,
   label: (
     <Link
       href={{

--- a/libs/frontend/presentation/view/sections/Menu/commonMenuItems.tsx
+++ b/libs/frontend/presentation/view/sections/Menu/commonMenuItems.tsx
@@ -29,12 +29,17 @@ export const componentMenuItem: ItemType = {
   label: <Link href={PageType.Components}>Components</Link>,
 }
 
-export const allPagesMenuItem = (appId: Nullish<string>): ItemType => ({
+export const allPagesMenuItem = (
+  appId: Nullish<string>,
+  pageId: Nullish<string>,
+): ItemType => ({
   disabled: !appId,
   icon: <FileOutlined title="Pages" />,
   key: PageType.PageList,
   label: (
-    <Link href={{ pathname: PageType.PageList, query: { appId } }}>Pages</Link>
+    <Link href={{ pathname: PageType.PageBuilder, query: { appId, pageId } }}>
+      Pages
+    </Link>
   ),
 })
 

--- a/libs/frontend/presentation/view/templates/Dashboard/DashboardTemplate.tsx
+++ b/libs/frontend/presentation/view/templates/Dashboard/DashboardTemplate.tsx
@@ -1,8 +1,10 @@
+import type { Nullable } from '@codelab/shared/abstract/types'
 import { Layout } from 'antd'
 import { observer } from 'mobx-react-lite'
-import React from 'react'
+import React, { useCallback, useState } from 'react'
 import { Panel, PanelGroup } from 'react-resizable-panels'
 import tw from 'twin.macro'
+import type { SidebarNavigationProps } from '../SidebarNavigation'
 import { SidebarNavigation } from '../SidebarNavigation'
 import { sidebarWidth } from './constants'
 import { DashboardTemplateConfigPane } from './DashboardTemplate-ConfigPane'
@@ -21,11 +23,27 @@ export const DashboardTemplateSSR = observer(
     Header,
     sidebarNavigation,
   }: React.PropsWithChildren<DashboardTemplateProps>) => {
+    const [activeTabKey, setActiveTabKey] = useState<Nullable<React.Key>>(
+      ExplorerPane?.default || null,
+    )
+
+    const handleSidebarClick: SidebarNavigationProps['onClick'] = (info) => {
+      setActiveTabKey(info.key)
+    }
+
+    const getActiveExplorerPane = useCallback(() => {
+      return ExplorerPane?.items.find((item) => item.key === activeTabKey)
+        ?.render
+    }, [ExplorerPane?.items, activeTabKey])
+
+    const activeExplorerPane = getActiveExplorerPane()
+
     return (
       <Layout css={tw`max-h-full min-h-full`}>
         <Sider collapsed collapsedWidth={sidebarWidth} theme="light">
           {sidebarNavigation && (
             <SidebarNavigation
+              onClick={handleSidebarClick}
               primaryItems={sidebarNavigation.primaryItems}
               secondaryItems={sidebarNavigation.secondaryItems}
             />
@@ -41,11 +59,11 @@ export const DashboardTemplateSSR = observer(
 
           <Layout style={contentStyles}>
             <PanelGroup direction="horizontal">
-              {ExplorerPane && (
+              {activeExplorerPane && (
                 <>
                   <Panel defaultSize={20} order={1}>
                     <DashboardTemplateExplorerPane
-                      ExplorerPane={ExplorerPane}
+                      ExplorerPane={activeExplorerPane}
                     />
                   </Panel>
                   <ResizeHandle />

--- a/libs/frontend/presentation/view/templates/Dashboard/DashboardTemplate.tsx
+++ b/libs/frontend/presentation/view/templates/Dashboard/DashboardTemplate.tsx
@@ -1,10 +1,9 @@
-import type { Nullable } from '@codelab/shared/abstract/types'
 import { Layout } from 'antd'
 import { observer } from 'mobx-react-lite'
-import React, { useCallback, useState } from 'react'
+import { useRouter } from 'next/router'
+import React from 'react'
 import { Panel, PanelGroup } from 'react-resizable-panels'
 import tw from 'twin.macro'
-import type { SidebarNavigationProps } from '../SidebarNavigation'
 import { SidebarNavigation } from '../SidebarNavigation'
 import { sidebarWidth } from './constants'
 import { DashboardTemplateConfigPane } from './DashboardTemplate-ConfigPane'
@@ -23,27 +22,20 @@ export const DashboardTemplateSSR = observer(
     Header,
     sidebarNavigation,
   }: React.PropsWithChildren<DashboardTemplateProps>) => {
-    const [activeTabKey, setActiveTabKey] = useState<Nullable<React.Key>>(
-      ExplorerPane?.default || null,
-    )
+    const { explorerPaneKey } = useRouter().query
 
-    const handleSidebarClick: SidebarNavigationProps['onClick'] = (info) => {
-      setActiveTabKey(info.key)
-    }
+    const activeTabKey =
+      (explorerPaneKey as React.Key) || ExplorerPane?.default || null
 
-    const getActiveExplorerPane = useCallback(() => {
-      return ExplorerPane?.items.find((item) => item.key === activeTabKey)
-        ?.render
-    }, [ExplorerPane?.items, activeTabKey])
-
-    const activeExplorerPane = getActiveExplorerPane()
+    const activeExplorerPane = ExplorerPane?.items.find(
+      (item) => item.key === activeTabKey,
+    )?.render
 
     return (
       <Layout css={tw`max-h-full min-h-full`}>
         <Sider collapsed collapsedWidth={sidebarWidth} theme="light">
           {sidebarNavigation && (
             <SidebarNavigation
-              onClick={handleSidebarClick}
               primaryItems={sidebarNavigation.primaryItems}
               secondaryItems={sidebarNavigation.secondaryItems}
             />

--- a/libs/frontend/presentation/view/templates/Dashboard/Sidebar/SidebarNavigation.tsx
+++ b/libs/frontend/presentation/view/templates/Dashboard/Sidebar/SidebarNavigation.tsx
@@ -15,7 +15,7 @@ interface SidebarNavigation {
 export const sidebarNavigation = ({ appId, pageId }: SidebarNavigation) => ({
   primaryItems: [
     appMenuItem,
-    allPagesMenuItem(appId),
+    allPagesMenuItem(appId, pageId),
     pageBuilderMenuItem(appId, pageId),
     resourceMenuItem,
     componentMenuItem,

--- a/libs/frontend/presentation/view/templates/Dashboard/types.tsx
+++ b/libs/frontend/presentation/view/templates/Dashboard/types.tsx
@@ -1,6 +1,16 @@
 import type { MenuProps } from 'antd'
 import type { JSXElementConstructor } from 'react'
 
+export interface PaneItem {
+  key: React.Key
+  render: JSXElementConstructor<unknown>
+}
+
+export interface ExplorerPane {
+  default?: React.Key
+  items: Array<PaneItem>
+}
+
 export type DashboardTemplateProps<T = unknown> = T & {
   /**
    * The right panel used for configuration element settings
@@ -9,7 +19,7 @@ export type DashboardTemplateProps<T = unknown> = T & {
   /**
    * The left panel used for navigating tree data, naming taken from VSCode's explorer pane
    */
-  ExplorerPane?: JSXElementConstructor<unknown>
+  ExplorerPane?: ExplorerPane
   Header?: JSXElementConstructor<unknown>
   contentStyles?: React.CSSProperties
   headerHeight?: number

--- a/libs/frontend/presentation/view/templates/SidebarNavigation/SidebarNavigation.tsx
+++ b/libs/frontend/presentation/view/templates/SidebarNavigation/SidebarNavigation.tsx
@@ -1,7 +1,7 @@
 import type { MenuProps } from 'antd'
 import { Menu } from 'antd'
 import { useRouter } from 'next/router'
-import React from 'react'
+import React, { useState } from 'react'
 import tw from 'twin.macro'
 import { sidebarWidth } from '../Dashboard'
 
@@ -9,6 +9,7 @@ export interface SidebarNavigationProps {
   // Home icon
   // homeItem: MenuProps['items']
   // Default menu items
+  onClick?: Parameters<typeof Menu>[0]['onClick']
   primaryItems?: MenuProps['items']
   // Menu items at the bottom
   secondaryItems?: MenuProps['items']
@@ -25,10 +26,17 @@ export const transformSelectedKeys = (keys: Array<string>) => {
 }
 
 export const SidebarNavigation = ({
+  onClick,
   primaryItems,
   secondaryItems,
 }: SidebarNavigationProps) => {
   const router = useRouter()
+  const [selectedKey, setSelectedKey] = useState<string>(router.pathname)
+
+  const handleClick: Parameters<typeof Menu>[0]['onClick'] = (info) => {
+    onClick && onClick(info)
+    setSelectedKey(info.key.toString())
+  }
 
   return (
     <div
@@ -44,7 +52,8 @@ export const SidebarNavigation = ({
         // defaultSelectedKeys={[PageType.AppList]}
         items={primaryItems}
         mode="inline"
-        selectedKeys={transformSelectedKeys([router.pathname])}
+        onClick={handleClick}
+        selectedKeys={transformSelectedKeys([selectedKey])}
       />
       <Menu
         css={tw`border-none box-border`}
@@ -52,7 +61,8 @@ export const SidebarNavigation = ({
         // defaultSelectedKeys={[PageType.AppList]}
         items={secondaryItems}
         mode="inline"
-        selectedKeys={transformSelectedKeys([router.pathname])}
+        onClick={handleClick}
+        selectedKeys={transformSelectedKeys([selectedKey])}
       />
     </div>
   )

--- a/libs/frontend/presentation/view/templates/SidebarNavigation/SidebarNavigation.tsx
+++ b/libs/frontend/presentation/view/templates/SidebarNavigation/SidebarNavigation.tsx
@@ -1,7 +1,7 @@
 import type { MenuProps } from 'antd'
 import { Menu } from 'antd'
 import { useRouter } from 'next/router'
-import React, { useState } from 'react'
+import React from 'react'
 import tw from 'twin.macro'
 import { sidebarWidth } from '../Dashboard'
 
@@ -31,12 +31,8 @@ export const SidebarNavigation = ({
   secondaryItems,
 }: SidebarNavigationProps) => {
   const router = useRouter()
-  const [selectedKey, setSelectedKey] = useState<string>(router.pathname)
-
-  const handleClick: Parameters<typeof Menu>[0]['onClick'] = (info) => {
-    onClick && onClick(info)
-    setSelectedKey(info.key.toString())
-  }
+  const { explorerPaneKey } = router.query
+  const selectedKey = (explorerPaneKey as string) || router.pathname
 
   return (
     <div
@@ -52,7 +48,6 @@ export const SidebarNavigation = ({
         // defaultSelectedKeys={[PageType.AppList]}
         items={primaryItems}
         mode="inline"
-        onClick={handleClick}
         selectedKeys={transformSelectedKeys([selectedKey])}
       />
       <Menu

--- a/libs/frontend/presentation/view/templates/SidebarNavigation/SidebarNavigation.tsx
+++ b/libs/frontend/presentation/view/templates/SidebarNavigation/SidebarNavigation.tsx
@@ -1,7 +1,7 @@
 import type { MenuProps } from 'antd'
 import { Menu } from 'antd'
 import { useRouter } from 'next/router'
-import React from 'react'
+import React, { useState } from 'react'
 import tw from 'twin.macro'
 import { sidebarWidth } from '../Dashboard'
 
@@ -26,10 +26,17 @@ export const transformSelectedKeys = (keys: Array<string>) => {
 }
 
 export const SidebarNavigation = ({
+  onClick,
   primaryItems,
   secondaryItems,
 }: SidebarNavigationProps) => {
   const router = useRouter()
+  const [selectedKey, setSelectedKey] = useState<string>(router.pathname)
+
+  const handleClick: Parameters<typeof Menu>[0]['onClick'] = (info) => {
+    onClick && onClick(info)
+    setSelectedKey(info.key.toString())
+  }
 
   return (
     <div
@@ -45,7 +52,8 @@ export const SidebarNavigation = ({
         // defaultSelectedKeys={[PageType.AppList]}
         items={primaryItems}
         mode="inline"
-        selectedKeys={transformSelectedKeys([router.pathname])}
+        onClick={handleClick}
+        selectedKeys={transformSelectedKeys([selectedKey])}
       />
       <Menu
         css={tw`border-none box-border`}
@@ -53,7 +61,7 @@ export const SidebarNavigation = ({
         // defaultSelectedKeys={[PageType.AppList]}
         items={secondaryItems}
         mode="inline"
-        selectedKeys={transformSelectedKeys([router.pathname])}
+        selectedKeys={transformSelectedKeys([selectedKey])}
       />
     </div>
   )

--- a/libs/frontend/presentation/view/templates/SidebarNavigation/SidebarNavigation.tsx
+++ b/libs/frontend/presentation/view/templates/SidebarNavigation/SidebarNavigation.tsx
@@ -1,7 +1,7 @@
 import type { MenuProps } from 'antd'
 import { Menu } from 'antd'
 import { useRouter } from 'next/router'
-import React, { useState } from 'react'
+import React from 'react'
 import tw from 'twin.macro'
 import { sidebarWidth } from '../Dashboard'
 
@@ -26,17 +26,10 @@ export const transformSelectedKeys = (keys: Array<string>) => {
 }
 
 export const SidebarNavigation = ({
-  onClick,
   primaryItems,
   secondaryItems,
 }: SidebarNavigationProps) => {
   const router = useRouter()
-  const [selectedKey, setSelectedKey] = useState<string>(router.pathname)
-
-  const handleClick: Parameters<typeof Menu>[0]['onClick'] = (info) => {
-    onClick && onClick(info)
-    setSelectedKey(info.key.toString())
-  }
 
   return (
     <div
@@ -52,8 +45,7 @@ export const SidebarNavigation = ({
         // defaultSelectedKeys={[PageType.AppList]}
         items={primaryItems}
         mode="inline"
-        onClick={handleClick}
-        selectedKeys={transformSelectedKeys([selectedKey])}
+        selectedKeys={transformSelectedKeys([router.pathname])}
       />
       <Menu
         css={tw`border-none box-border`}
@@ -61,8 +53,7 @@ export const SidebarNavigation = ({
         // defaultSelectedKeys={[PageType.AppList]}
         items={secondaryItems}
         mode="inline"
-        onClick={handleClick}
-        selectedKeys={transformSelectedKeys([selectedKey])}
+        selectedKeys={transformSelectedKeys([router.pathname])}
       />
     </div>
   )


### PR DESCRIPTION
## Description

This PR changes the behaviour of the ExplorerPane and make it accept a list of options to be viewed in it.

This is the new interface:

```
interface PaneItem {
  key: React.Key
  render: JSXElementConstructor<unknown>
}

interface ExplorerPane {
  default?: React.Key
  items: Array<PaneItem>
}
```

#### TODO

- [x] Fix: switching between pages is problematic. the link changed, but builder sometimes doesn't render page.
- [x] Fix: page title is not updated.
- [x] use query params
- [x] fix e2e

## Video or Image


## Related Issue(s)

Fixes #2585
