### PR TITLE
fix: non-existing selector in e2e

### DIFF
--- a/apps/platform-e2e/src/e2e/component.cy.ts
+++ b/apps/platform-e2e/src/e2e/component.cy.ts
@@ -147,7 +147,7 @@ describe('Component CRUD', () => {
             { parseSpecialCharSequences: false },
           )
 
-          cy.get('#Builder').findByText('text null').should('exist')
+          cy.get('#render-root').findByText('text null').should('exist')
         })
     })
 
@@ -230,10 +230,10 @@ describe('Component CRUD', () => {
         COMPONENT_INSTANCE_TEXT,
       )
 
-      cy.get('#Builder')
+      cy.get('#render-root')
         .findByText(`text ${COMPONENT_PROP_VALUE}`)
         .should('exist')
-      cy.get('#Builder').findByText(COMPONENT_INSTANCE_TEXT).should('exist')
+      cy.get('#render-root').findByText(COMPONENT_INSTANCE_TEXT).should('exist')
     })
   })
 })

--- a/apps/platform-e2e/src/e2e/hooks/useQueryPages/useQueryPage.cy.ignore.ts
+++ b/apps/platform-e2e/src/e2e/hooks/useQueryPages/useQueryPage.cy.ignore.ts
@@ -31,6 +31,6 @@ describe('useQueryPageHook', () => {
     cy.selectOptionItem(pageName).click()
     cy.getOpenedModal().findByText('Add hook').click()
     // // Assert the mapper value
-    cy.get('#Builder').findByText('root').should('exist')
+    cy.get('#render-root').findByText('root').should('exist')
   })
 })

--- a/apps/platform-e2e/src/e2e/hooks/useQueryPages/useQueryPages.cy.ignore.ts
+++ b/apps/platform-e2e/src/e2e/hooks/useQueryPages/useQueryPages.cy.ignore.ts
@@ -19,6 +19,6 @@ describe('useQueryPagesHook', () => {
 
     cy.getOpenedModal().findByText('Add hook').click()
     // // Assert the mapper value
-    cy.get('#Builder').findByText(pageName).should('exist')
+    cy.get('#render-root').findByText(pageName).should('exist')
   })
 })

--- a/apps/platform-e2e/src/e2e/providers-page.cy.ts
+++ b/apps/platform-e2e/src/e2e/providers-page.cy.ts
@@ -99,7 +99,7 @@ describe('_app page', () => {
   })
 
   it('should render the input inside isnide the card in builder and viewer', () => {
-    cy.get('#Builder .ant-card-body input').should('not.be.disabled')
+    cy.get('#render-root .ant-card-body input').should('not.be.disabled')
 
     cy.get('header .anticon-eye').click()
     cy.get('header .anticon-tool', { timeout: 30000 }).should('be.visible')


### PR DESCRIPTION
<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(libs-ui-component): must begin with lowercase` -->

## Description
After the builder container was wrapped with antd Panel component, `#Builder` started to be prefixed with antd prefix, and the final id appeared to be `data-panel-id-Builder`. Instead of relying on antd prefix that may change, update the selector to rely on a different node id, which we fully control

## Video or Image

<!-- Add video or image showing how the new feature works -->

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged -->

Fixes #2612 
