### PR TITLE
fix: allow to use antd icon atom

### DIFF
--- a/data/export/admin/atoms/AntDesignIcon.json
+++ b/data/export/admin/atoms/AntDesignIcon.json
@@ -12,6 +12,9 @@
         "id": "5f34a1f4-38e2-4bfe-a43e-f46901792a7b"
       },
       {
+        "id": "9f28cc92-2e53-4b8b-8b7f-0ef5734f2c86"
+      },
+      {
         "id": "de6b3607-bfbe-41d3-9ad0-5e2d4a12450e"
       }
     ]
@@ -46,6 +49,23 @@
       "description": null,
       "validationRules": null,
       "defaultValues": null,
+      "fieldType": {
+        "__typename": "PrimitiveType",
+        "id": "3a0d0fc6-c51e-4f05-85b4-cde709fe5625",
+        "kind": "PrimitiveType",
+        "name": "String"
+      },
+      "api": {
+        "id": "9a1fb9ff-df8c-4377-9b10-d1f7425c0ff4"
+      }
+    },
+    {
+      "id": "9f28cc92-2e53-4b8b-8b7f-0ef5734f2c86",
+      "key": "name",
+      "name": "Icon Name",
+      "description": null,
+      "validationRules": "{\"general\":{\"nullable\":false}}",
+      "defaultValues": "\"PictureOutlined\"",
       "fieldType": {
         "__typename": "PrimitiveType",
         "id": "3a0d0fc6-c51e-4f05-85b4-cde709fe5625",

--- a/libs/frontend/application/atoms/src/ant-design/icon/AntdIcon.ts
+++ b/libs/frontend/application/atoms/src/ant-design/icon/AntdIcon.ts
@@ -7,18 +7,15 @@ type _IconProps = IconProps & {
   /**
    * Name of destructured icon to use
    */
-  name: string
+  name: keyof typeof AntdIcons | null
 }
 
 export const AntdIcon = ({ name, ...props }: _IconProps) => {
-  if (!name) {
+  const icon = name && AntdIcons[name]
+
+  if (!icon) {
     return null
   }
 
-  return React.createElement(
-    AntdIcons[name as keyof typeof AntdIcons] as (
-      props: IconProps,
-    ) => ReactElement,
-    props,
-  )
+  return React.createElement(icon as (props: IconProps) => ReactElement, props)
 }


### PR DESCRIPTION
<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(libs-ui-component): must begin with lowercase` -->

## Description
AntDesignIcon atom was missing the `name` property, making it impossible to use. I tried to add the `name` property as an `Enum` type, but there were ~1000 options, and currently our db can't handle that many entities and it crashed during import with an errror:
`Error: There is not enough memory to perform the current task. Please try increasing 'server.memory.heap.max_size' in the neo4j configuration (normally in 'conf/neo4j.conf' or, if you are using Neo4j Desktop, found through the user interface) or if you are running an embedded installation increase the heap by using '-Xmx' command line flag, and then restart the database.
    at Model.create (/Users/vladyslav/Desktop/builder/node_modules/@neo4j/graphql-ogm/dist/classes/Model.js:124:19)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)`

So for now added the ability to manually specify the icon name as a plain string.

## Video or Image


https://github.com/codelab-app/platform/assets/74900868/fe025134-221a-429e-9069-10662d9f3916



## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged -->

Fixes #2609 
