### PR TITLE
fix: script error on second child element deleting

### DIFF
--- a/libs/frontend/domain/element/src/use-cases/element/delete-element/DeleteElementModal.tsx
+++ b/libs/frontend/domain/element/src/use-cases/element/delete-element/DeleteElementModal.tsx
@@ -21,7 +21,8 @@ export const DeleteElementModal = observer(() => {
   const elementToDelete = elementService.deleteModal.element
 
   const onSubmit = ({ element }: DeleteElementData) => {
-    // Get parent or previous sibling before we delete the current element
+    // Get parent before we delete the current element
+    const parentElement = elementToDelete.closestParent
 
     const newSelectedNode =
       elementToDelete.prevSibling?.current ?? elementToDelete.parent?.current


### PR DESCRIPTION
<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(libs-ui-component): must begin with lowercase` -->

## Description
<!-- This is a short description on the Pull Request -->

Fixed `Rendered fewer hooks than expected.` script error because an early return statement existed before other hooks.

Another part of the issue was when the `parent` property was used to set the parent of the delete element as the currently selected builder node, but `parent` exists only for the first child. `closestParent` is used instead, which first will traverse to the first child and then get `parent`.

## Video or Image

<!-- Add video or image showing how the new feature works -->

https://github.com/codelab-app/platform/assets/74900868/cd6ec5e9-2e97-4c46-b60d-bbc452d3829b



## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged -->

Fixes #2602 
