### PR TITLE
fix: do not include GlobalStyles twice on page

### DIFF
--- a/libs/frontend/presentation/view/templates/ExplorerPaneTemplate.tsx
+++ b/libs/frontend/presentation/view/templates/ExplorerPaneTemplate.tsx
@@ -4,7 +4,7 @@ import { css } from '@emotion/react'
 import type { ReactJSXElement } from '@emotion/react/types/jsx-namespace'
 import styled from '@emotion/styled'
 import React from 'react'
-import tw, { GlobalStyles } from 'twin.macro'
+import tw from 'twin.macro'
 
 export type MainPaneTemplateProps = React.PropsWithChildren<{
   containerProps?: Pick<
@@ -63,7 +63,6 @@ export const ExplorerPaneTemplate = ({
       data-testid={dataTestId}
       onClick={containerProps?.onClick}
     >
-      <GlobalStyles />
       <PageHeader
         extra={header}
         onBack={headerProps?.onBack}


### PR DESCRIPTION
<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(libs-ui-component): must begin with lowercase` -->

## Description
- `GlobalStyles` already included in _app.tsx page for the `platforms` app. No need to include it a second time in a child component. This fixed script errors described in the issue.

## Video or Image

https://github.com/codelab-app/platform/assets/74900868/b3dd4be0-8ba1-40cb-9abc-39a43dd18c93

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged -->

Fixes #2637 
