### PR TITLE
fix: failing e2e specs

### DIFF
--- a/apps/platform-e2e/src/e2e/component.cy.ts
+++ b/apps/platform-e2e/src/e2e/component.cy.ts
@@ -72,7 +72,9 @@ describe('Component CRUD', () => {
         cy.waitForApiCalls()
         cy.getSpinner().should('not.exist')
 
-        cy.get('#rc-tabs-2-tab-custom-components').click({ force: true })
+        cy.get('[data-node-key="custom-components"] .ant-tabs-tab-btn').click({
+          force: true,
+        })
         // GetComponents
         cy.waitForApiCalls()
         cy.getSpinner().should('not.exist')

--- a/libs/frontend/domain/page/src/view/PageDetailHeader.tsx
+++ b/libs/frontend/domain/page/src/view/PageDetailHeader.tsx
@@ -164,7 +164,7 @@ export const PageDetailHeader = observer(() => {
   ]
 
   return (
-    <div css={tw`bg-white relative`}>
+    <header css={tw`bg-white relative`}>
       <div
         css={tw`absolute left-3 flex items-center flex-row h-full cursor-pointer`}
         onClick={navigatePagesPanel}
@@ -186,6 +186,6 @@ export const PageDetailHeader = observer(() => {
         theme="light"
         triggerSubMenuAction="click"
       />
-    </div>
+    </header>
   )
 })


### PR DESCRIPTION
<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(libs-ui-component): must begin with lowercase` -->

## Description

- Fix providersPage spec by updating the builder header. Before headers refactoring the root node of it was `header`, but after refactoring it became `div`, and the selector in e2e spec started to fail. Since semantically it is more valid to use `header` in this case - instead of updating e2e I decided to update platform code.
- Fix components spec selector to rely on data-id attribute instead of id, because tab ids are sensetive to the initialization order (if the tabs component is initialized first on the component tree - antd includes `0` in the id, for the second tab - `1` and so forth). So previously the selector was `#rc-tabs-2-tab-custom-components` but after refactoring in past PRs the id changed to `#rc-tabs-6-tab-custom-components`. I think new selector is less sensetive and unlikely is going to change with further refactorings

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged -->

Fixes #2646
