### PR TITLE
fix: use overrides to ignore pages from name conventions

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -9,7 +9,6 @@ public
 *.d.ts
 *.mp4
 *.log
-**/pages
 **/*.gen.ts
 jest.config.ts
 

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -485,7 +485,15 @@
             ]
           }
         ]
-      }
+      },
+      "overrides": [
+        {
+          "files": ["**/pages/**/*.tsx"],
+          "rules": {
+            "unicorn/filename-case": "off"
+          }
+        }
+      ]
     },
     {
       "files": ["*.hook.ts", "*.hook.tsx"],


### PR DESCRIPTION
<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(libs-ui-component): must begin with lowercase` -->

## Description
use overrides to ignore pages from name conventions 
<!-- This is a short description on the Pull Request -->

## Video or Image

<!-- Add video or image showing how the new feature works -->

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged -->

Fixes #2660
