### PR TITLE
fix: script error because of missing types

### DIFF
--- a/libs/frontend/domain/element/src/use-cases/element/update-element-props/UpdateElementPropsForm.tsx
+++ b/libs/frontend/domain/element/src/use-cases/element/update-element-props/UpdateElementPropsForm.tsx
@@ -6,7 +6,10 @@ import {
 } from '@codelab/frontend/abstract/core'
 import { AdminPropsPanel } from '@codelab/frontend/domain/admin'
 import { PropsForm } from '@codelab/frontend/domain/type'
-import { useStore } from '@codelab/frontend/presentation/container'
+import {
+  loadAllTypesForElements,
+  useStore,
+} from '@codelab/frontend/presentation/container'
 import { ReactQuillField, Spinner } from '@codelab/frontend/presentation/view'
 import { filterEmptyStrings, mergeProps } from '@codelab/shared/utils'
 import { useAsync } from '@react-hookz/web'
@@ -41,12 +44,23 @@ const withCustomTextSchema: JSONSchemaType<{
 
 export const UpdateElementPropsForm = observer<UpdateElementPropsFormProps>(
   ({ element }) => {
-    const { propService, typeService } = useStore()
+    const { builderService, componentService, propService, typeService } =
+      useStore()
+
     const currentElement = element.current
     const apiId = currentElement.renderType?.current.api.id
 
-    const [{ result: interfaceType, status }, getInterface] = useAsync(() =>
-      typeService.getInterface(apiId!),
+    const [{ result: interfaceType, status }, getInterface] = useAsync(
+      async () => {
+        await loadAllTypesForElements(
+          componentService,
+          typeService,
+          builderService.activeElementTree?.rootElement.current
+            .descendantElements ?? [],
+        )
+
+        return typeService.getInterface(apiId!)
+      },
     )
 
     useEffect(() => {


### PR DESCRIPTION
<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(libs-ui-component): must begin with lowercase` -->

## Description
After types loading refactoring - types were not loaded anymore for components tabs. This caused a script error in an attempt to render the Props form for the element in the component builder because the field type was missing.
Reuse types loading logic that is used for rendering pages to load only required types when the form is loaded.

## Video or Image

<!-- Add video or image showing how the new feature works -->

## Related Issue(s)

Fixes #2671 
