### PR TITLE
fix: skip Vercel build cache for production deployments

### DIFF
--- a/libs/shared/config/src/env/env-platform.ts
+++ b/libs/shared/config/src/env/env-platform.ts
@@ -1,5 +1,5 @@
 import * as env from 'env-var'
-import { isProduction, isVercelPreview } from '../flags'
+import { isVercelPreview } from '../flags'
 
 /**
  * This can't be imported by Vercel due to edge middleware
@@ -33,24 +33,9 @@ interface EnvPlatform {
 }
 
 export const EnvPlatform = (): EnvPlatform => {
-  console.log('isProduction', isProduction, 'isVercelPreview', isVercelPreview)
-
   const auth0baseUrl = isVercelPreview
     ? env.get('VERCEL_URL').required().asString()
     : env.get('NEXT_PUBLIC_PLATFORM_HOST').required().asString()
-
-  console.log('auth0baseUrl', auth0baseUrl)
-
-  console.log(
-    '1',
-    process.env['VERCEL_ENV']?.split(' '),
-    '2',
-    process.env['NEXT_PUBLIC_VERCEL_ENV']?.split(' '),
-    '3',
-    env.get('VERCEL_ENV').asString()?.split(' '),
-    '4',
-    env.get('NEXT_PUBLIC_VERCEL_ENV').asString()?.split(' '),
-  )
 
   const isDev = auth0baseUrl.startsWith('127.0.0.1')
   const protocol = isDev ? 'http' : 'https'

--- a/terraform/modules/vercel-platform/project.tf
+++ b/terraform/modules/vercel-platform/project.tf
@@ -98,6 +98,11 @@ resource "vercel_project" "platform" {
       key    = "VERCEL_TEAM_ID"
       value  = var.vercel_team_id
     },
+    {
+      target = ["production"]
+      key    = "VERCEL_FORCE_NO_BUILD_CACHE"
+      value  = "1"
+    }
   ]
 }
 

--- a/terraform/modules/vercel-websites/project.tf
+++ b/terraform/modules/vercel-websites/project.tf
@@ -68,6 +68,11 @@ resource "vercel_project" "websites" {
       target = ["production", "preview"]
       key    = "NEO4J_PASSWORD"
       value  = var.neo4j_password
+    },
+    {
+      target = ["production"]
+      key    = "VERCEL_FORCE_NO_BUILD_CACHE"
+      value  = "1"
     }
   ]
 }


### PR DESCRIPTION
<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(libs-ui-component): must begin with lowercase` -->

## Description
The problem is that when PR gets merged and a new production build is triggered after the merge - the production build uses a cache from the preview build (preview of the PR that is merged) and produces invalid artifacts. The login issue (but this is not the only problem because of the same root cause) occurs because the production build used the values for system environment variables from preview deployment of merged PR, like NEXT_PUBLIC_VERCEL_ENV, VERCEL_URL. For example, NEXT_PUBLIC_VERCEL_ENV was `preview` instead of `production`, and VERCEL_URL pointed to the previous deployment (to deployment of the source branch).
Also when opening production - because of invalid Environment variable values, client makes request to a preview back-end:
<img width="1208" alt="Screenshot 2023-05-26 at 17 44 27" src="https://github.com/codelab-app/platform/assets/74900868/fe2242f4-4eb4-490d-a4ba-2d8112956241">

<img width="1321" alt="Screenshot 2023-05-26 at 17 46 18" src="https://github.com/codelab-app/platform/assets/74900868/474cd90b-eea8-4886-9dad-f31eae872636">

The login issue occurs because the invalid value for auth0 base url is used.

As a fix - trying to use special VERCEL_FORCE_NO_BUILD_CACHE env variable to skip cache for production deployments, so that each production build does not rely on any caching. Let see if this helps

## Video or Image

<!-- Add video or image showing how the new feature works -->

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged -->

Fixes #2659 
