### PR TITLE
fix: script error on page with component instance

### DIFF
--- a/apps/platform/pages/apps/index.tsx
+++ b/apps/platform/pages/apps/index.tsx
@@ -48,7 +48,7 @@ const AppsPageHeader = observer(() => {
     },
     {
       icon: <LogoutOutlined />,
-      key: '1',
+      key: '2',
       onClick: () => {
         // redirect to /api/auth/logout
         window.location.href = '/api/auth/logout'

--- a/libs/backend/application/admin/src/use-case/import-admin-data/import-admin-data.service.ts
+++ b/libs/backend/application/admin/src/use-case/import-admin-data/import-admin-data.service.ts
@@ -53,11 +53,11 @@ export class ImportAdminDataService extends UseCase<IAuth0Owner, void> {
       this.importSystemTypes(owner),
     )()
 
-    // await this.importTags(owner)
+    await this.importTags(owner)
 
-    // await this.importAtoms(owner)
+    await this.importAtoms(owner)
 
-    // await this.importComponents(owner)
+    await this.importComponents(owner)
   }
 
   private async importSystemTypes(owner: IAuth0Owner) {

--- a/libs/frontend/domain/element/src/store/element.model.ts
+++ b/libs/frontend/domain/element/src/store/element.model.ts
@@ -335,11 +335,11 @@ export class Element
   get label() {
     return (
       this.name ||
-      this.renderType?.current.name ||
+      this.renderType?.maybeCurrent?.name ||
       (isAtomInstance(this.renderType)
         ? compoundCaseToTitleCase((this.renderType.current as IAtom).type)
         : undefined) ||
-      this.parentComponent?.current.name ||
+      this.parentComponent?.maybeCurrent?.name ||
       ''
     )
   }
@@ -349,7 +349,7 @@ export class Element
     return {
       primary: this.label,
       secondary:
-        this.renderType?.current.name ||
+        this.renderType?.maybeCurrent?.name ||
         (isAtomInstance(this.renderType)
           ? compoundCaseToTitleCase((this.renderType.current as IAtom).type)
           : undefined),

--- a/libs/frontend/presentation/codelab-ui/src/views/CuiHeaderToolbar/CuiHeaderToolbarItem.tsx
+++ b/libs/frontend/presentation/codelab-ui/src/views/CuiHeaderToolbar/CuiHeaderToolbarItem.tsx
@@ -7,14 +7,13 @@ type CuiHeaderToolbarItemProps = ToolbarItem
 
 export const CuiHeaderToolbarItem = ({
   icon,
-  key,
   label,
   onClick,
   title,
 }: CuiHeaderToolbarItemProps) => {
   return (
     <div css={tw`w-full h-full`} data-cy={`codelabui-toolbar-item-${title}`}>
-      <Tooltip key={key} title={title}>
+      <Tooltip title={title}>
         <Button css={tw`px-2 py-1 h-8`} onClick={onClick}>
           <Space>
             {icon}


### PR DESCRIPTION
<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(libs-ui-component): must begin with lowercase` -->

## Description
The request for components is not a part of the request for page elements, as a result, page data is loaded first and only then request for components is made. And the UI crashed because of `.current` throw an error (the component did not exist in the store yet). Replace `.current` with `.maybeCurrent` to avoid errors while components being loaded

## Video or Image

<!-- Add video or image showing how the new feature works -->

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged -->

Fixes #2718 
