### PR TITLE
feat: allow actions access props

### DIFF
--- a/libs/frontend/abstract/core/src/domain/action/base-action.interface.ts
+++ b/libs/frontend/abstract/core/src/domain/action/base-action.interface.ts
@@ -3,7 +3,6 @@ import type { Maybe } from '@codelab/shared/abstract/types'
 import type { Ref } from 'mobx-keystone'
 import type { IElement } from '../element'
 import type { IStore } from '../store'
-import type { IAction } from './action.interface'
 
 export interface IBaseAction {
   element: Maybe<Ref<IElement>>
@@ -11,9 +10,6 @@ export interface IBaseAction {
   name: string
   store: Ref<IStore>
   type: IActionKind
-
-  clone(storeId: string): IAction
-  runner(...args: Array<unknown>): unknown
 }
 
 export type IActionRef = string

--- a/libs/frontend/abstract/core/src/domain/action/base-action.interface.ts
+++ b/libs/frontend/abstract/core/src/domain/action/base-action.interface.ts
@@ -13,7 +13,7 @@ export interface IBaseAction {
   type: IActionKind
 
   clone(storeId: string): IAction
-  createRunner(): (...args: Array<unknown>) => unknown
+  runner(...args: Array<unknown>): unknown
 }
 
 export type IActionRef = string

--- a/libs/frontend/abstract/core/src/domain/render/action.runner.model.interface.ts
+++ b/libs/frontend/abstract/core/src/domain/render/action.runner.model.interface.ts
@@ -1,0 +1,10 @@
+import type { Ref } from 'mobx-keystone'
+import type { IAction } from '../action'
+import type { IPropData } from '../prop'
+
+export interface IActionRunner {
+  actionRef: Ref<IAction>
+  props: IPropData
+
+  runner(...args: Array<unknown>): void
+}

--- a/libs/frontend/abstract/core/src/domain/render/action.runner.model.interface.ts
+++ b/libs/frontend/abstract/core/src/domain/render/action.runner.model.interface.ts
@@ -8,3 +8,6 @@ export interface IActionRunner {
 
   runner(...args: Array<unknown>): void
 }
+
+export const getRunnerId = (storeId: string, actionId: string) =>
+  `${storeId}${actionId}`

--- a/libs/frontend/abstract/core/src/domain/render/index.ts
+++ b/libs/frontend/abstract/core/src/domain/render/index.ts
@@ -1,3 +1,4 @@
+export * from './action.runner.model.interface'
 export * from './render.interface'
 export * from './render.service.context'
 export * from './render.service.interface'

--- a/libs/frontend/abstract/core/src/domain/render/renderer.model.interface.ts
+++ b/libs/frontend/abstract/core/src/domain/render/renderer.model.interface.ts
@@ -5,6 +5,7 @@ import type { ArrayOrSingle } from 'ts-essentials'
 import type { IExpressionTransformer } from '../builder'
 import type { IElement, IElementTree } from '../element'
 import type { IPageNode, IPageNodeRef } from '../page'
+import type { IActionRunner } from './action.runner.model.interface'
 import type { IRenderOutput } from './render.interface'
 import type {
   IComponentRuntimeProp,
@@ -19,6 +20,7 @@ export const enum RendererType {
   Preview = 'preview',
 }
 export interface IRenderer {
+  actionRunners: ObjectMap<IActionRunner>
   debugMode: boolean
   elementTree: Ref<IElementTree>
   expressionTransformer: IExpressionTransformer

--- a/libs/frontend/domain/builder/src/sections/explorer-pane/BuilderPrimarySidebar.tsx
+++ b/libs/frontend/domain/builder/src/sections/explorer-pane/BuilderPrimarySidebar.tsx
@@ -17,13 +17,7 @@ import {
   DeleteElementModal,
   mapElementOption,
 } from '@codelab/frontend/domain/element'
-import {
-  ActionsTreeView,
-  CreateActionModal,
-  DeleteActionModal,
-  StateTreeView,
-  UpdateActionModal,
-} from '@codelab/frontend/domain/store'
+import { ActionsTreeView, StateTreeView } from '@codelab/frontend/domain/store'
 import type { InterfaceType } from '@codelab/frontend/domain/type'
 import {
   CreateFieldForm,
@@ -224,10 +218,6 @@ export const BuilderPrimarySidebar = observer<{ isLoading?: boolean }>(
         <CreateFieldModal />
         <UpdateFieldModal />
         <DeleteFieldModal />
-
-        <CreateActionModal store={store} />
-        <UpdateActionModal />
-        <DeleteActionModal />
       </>
     )
   },

--- a/libs/frontend/domain/builder/src/sections/explorer-pane/ComponentsExplorerPane.tsx
+++ b/libs/frontend/domain/builder/src/sections/explorer-pane/ComponentsExplorerPane.tsx
@@ -1,11 +1,6 @@
 import { DeleteComponentModal } from '@codelab/frontend/domain/component'
 import { DeleteElementModal } from '@codelab/frontend/domain/element'
 import {
-  CreateActionModal,
-  DeleteActionModal,
-  UpdateActionModal,
-} from '@codelab/frontend/domain/store'
-import {
   CreateFieldModal,
   DeleteFieldModal,
   UpdateFieldModal,
@@ -79,9 +74,6 @@ export const ComponentsExplorerPane = observer<ComponentsExplorerPaneProps>(
         <CreateFieldModal />
         <UpdateFieldModal />
         <DeleteFieldModal />
-        <CreateActionModal />
-        <UpdateActionModal />
-        <DeleteActionModal />
       </>
     )
   },

--- a/libs/frontend/domain/builder/src/sections/explorer-pane/StorePane.tsx
+++ b/libs/frontend/domain/builder/src/sections/explorer-pane/StorePane.tsx
@@ -2,7 +2,10 @@ import type { IStore } from '@codelab/frontend/abstract/core'
 import {
   ActionsTreeView,
   CreateActionButton,
+  CreateActionModal,
+  DeleteActionModal,
   StateTreeView,
+  UpdateActionModal,
 } from '@codelab/frontend/domain/store'
 import { CreateFieldButton } from '@codelab/frontend/domain/type'
 import {
@@ -32,48 +35,55 @@ export const StorePane = observer<{ store: Maybe<IStore>; isLoading: boolean }>(
   ({ isLoading, store }) => (
     <SkeletonWrapper isLoading={isLoading}>
       {store ? (
-        <Collapse css={tw`w-full mb-2`} defaultActiveKey={['1']} ghost>
-          <Collapse.Panel
-            header={
-              <StoreHeader
-                extra={
-                  <CreateFieldButton
-                    interfaceId={store.api.id}
-                    useModal={false}
-                  />
-                }
-              >
-                State
-              </StoreHeader>
-            }
-            key="store-state"
-          >
-            <StateTreeView store={store} />
-          </Collapse.Panel>
-          <Collapse.Panel
-            header={
-              <StoreHeader extra={<CreateActionButton />}>Actions</StoreHeader>
-            }
-            key="store-actions"
-          >
-            <ActionsTreeView store={store} />
-          </Collapse.Panel>
-          <Collapse.Panel
-            header={<StoreHeader>Inspector</StoreHeader>}
-            key="store-inspector"
-          >
-            <CodeMirrorEditor
-              language={CodeMirrorLanguage.Json}
-              onChange={() => undefined}
-              overrideStyles={css`
-                ${tw`mt-1`}
-              `}
-              singleLine={false}
-              title="Current props"
-              value={store.jsonString}
-            />
-          </Collapse.Panel>
-        </Collapse>
+        <>
+          <Collapse css={tw`w-full mb-2`} defaultActiveKey={['1']} ghost>
+            <Collapse.Panel
+              header={
+                <StoreHeader
+                  extra={
+                    <CreateFieldButton
+                      interfaceId={store.api.id}
+                      useModal={false}
+                    />
+                  }
+                >
+                  State
+                </StoreHeader>
+              }
+              key="store-state"
+            >
+              <StateTreeView store={store} />
+            </Collapse.Panel>
+            <Collapse.Panel
+              header={
+                <StoreHeader extra={<CreateActionButton />}>
+                  Actions
+                </StoreHeader>
+              }
+              key="store-actions"
+            >
+              <ActionsTreeView store={store} />
+            </Collapse.Panel>
+            <Collapse.Panel
+              header={<StoreHeader>Inspector</StoreHeader>}
+              key="store-inspector"
+            >
+              <CodeMirrorEditor
+                language={CodeMirrorLanguage.Json}
+                onChange={() => undefined}
+                overrideStyles={css`
+                  ${tw`mt-1`}
+                `}
+                singleLine={false}
+                title="Current props"
+                value={store.jsonString}
+              />
+            </Collapse.Panel>
+          </Collapse>
+          <CreateActionModal store={store} />
+          <UpdateActionModal />
+          <DeleteActionModal />
+        </>
       ) : null}
     </SkeletonWrapper>
   ),

--- a/libs/frontend/domain/renderer/src/action-runner.model.ts
+++ b/libs/frontend/domain/renderer/src/action-runner.model.ts
@@ -1,0 +1,157 @@
+import type {
+  IAction,
+  IActionRunner,
+  IApiAction,
+  IBaseResourceConfigData,
+  ICodeAction,
+  IGraphQLActionConfig,
+  IPropData,
+  IRestActionConfig,
+} from '@codelab/frontend/abstract/core'
+import { IProp } from '@codelab/frontend/abstract/core'
+import { replaceStateInProps, tryParse } from '@codelab/frontend/shared/utils'
+import { IActionKind, IResourceType } from '@codelab/shared/abstract/core'
+import type { Axios, Method } from 'axios'
+import axios from 'axios'
+import { GraphQLClient } from 'graphql-request'
+import merge from 'lodash/merge'
+import { computed } from 'mobx'
+import type { Ref } from 'mobx-keystone'
+import { Model, model, modelAction, prop } from 'mobx-keystone'
+
+const restFetch = (
+  client: Axios,
+  config: IRestActionConfig,
+  overrideConfig?: IPropData,
+) => {
+  const data = merge(tryParse(config.body), overrideConfig?.['body'])
+  const headers = merge(tryParse(config.headers), overrideConfig?.['headers'])
+
+  const params = merge(
+    tryParse(config.queryParams),
+    overrideConfig?.['queryParams'],
+  )
+
+  return client.request({
+    data,
+    headers,
+    method: config.method as Method,
+    params,
+    responseType: config.responseType,
+    url: config.urlSegment,
+  })
+}
+
+const graphqlFetch = (
+  client: GraphQLClient,
+  config: IGraphQLActionConfig,
+  overrideConfig?: IPropData,
+) => {
+  const headers = merge(tryParse(config.headers), overrideConfig?.['headers'])
+
+  const variables = merge(
+    tryParse(config.variables),
+    overrideConfig?.['variables'],
+  )
+
+  return client.request(config.query, variables, headers)
+}
+
+const create = (actionRef: Ref<IAction>, props: IPropData) =>
+  new ActionRunner({ actionRef, props })
+
+@model('@codelab/ActionRunner')
+export class ActionRunner
+  extends Model(() => ({
+    actionRef: prop<Ref<IAction>>(),
+    props: prop<IPropData>(() => ({})),
+  }))
+  implements IActionRunner
+{
+  @computed
+  get runner() {
+    return this.actionRef.current.type === IActionKind.ApiAction
+      ? this.apiRunner(this.props)
+      : this.codeRunner(this.props)
+  }
+
+  @modelAction
+  private replaceStateInConfig(config: IProp) {
+    return replaceStateInProps(config.values, {})
+  }
+
+  @computed
+  get _resourceConfig() {
+    return this.replaceStateInConfig(
+      (this.actionRef.current as IApiAction).resource.current.config.current,
+    ) as IBaseResourceConfigData
+  }
+
+  @computed
+  get _graphqlClient() {
+    const { headers, url } = this._resourceConfig
+    const options = { headers: tryParse(headers) }
+
+    return new GraphQLClient(url, options)
+  }
+
+  @computed
+  get _restClient() {
+    const { headers, url } = this._resourceConfig
+
+    return axios.create({ baseURL: url, headers: tryParse(headers) })
+  }
+
+  @computed
+  get apiRunner() {
+    const action = this.actionRef.current as IApiAction
+    const successAction = action.successAction?.current
+    const errorAction = action.errorAction?.current
+    const resource = action.resource.current
+    // FIXME:
+    const config = replaceStateInProps(action.config.current.values, {})
+    const graphQLClient = this._graphqlClient
+    const restClient = this._restClient
+
+    return (props: IPropData) => {
+      // eslint-disable-next-line prefer-arrow/prefer-arrow-functions
+      return async function (this: unknown, ...args: Array<unknown>) {
+        const overrideConfig = args[0] as IPropData
+
+        const fetchPromise =
+          resource.type === IResourceType.GraphQL
+            ? graphqlFetch(
+                graphQLClient,
+                config as IGraphQLActionConfig,
+                overrideConfig,
+              )
+            : restFetch(restClient, config as IRestActionConfig, overrideConfig)
+
+        try {
+          const response = await fetchPromise
+
+          //  return successAction?.runner(props).call(this, response)
+        } catch (error) {
+          //  return errorAction?.runner(props).call(this, error)
+        }
+      }
+    }
+  }
+
+  @computed
+  get codeRunner() {
+    try {
+      // eslint-disable-next-line no-new-func
+      return new Function(
+        'props',
+        `return ${(this.actionRef.current as ICodeAction).code}`,
+      )
+    } catch (error) {
+      console.log(error)
+
+      return () => () => undefined
+    }
+  }
+
+  static create = create
+}

--- a/libs/frontend/domain/renderer/src/action-runner.model.ts
+++ b/libs/frontend/domain/renderer/src/action-runner.model.ts
@@ -67,7 +67,7 @@ const create = (rootElement: IElement) => {
   const store = rootElement.store.current
   const component = rootElement.parentComponent?.current
   // more props will be added other then component
-  const props = { $component: component?.runtimeProp?.componentEvaluatedProps }
+  const props = component?.runtimeProp?.componentEvaluatedProps || {}
 
   return store.actions.map(
     (action) =>

--- a/libs/frontend/domain/renderer/src/element-runtime-props.model.ts
+++ b/libs/frontend/domain/renderer/src/element-runtime-props.model.ts
@@ -62,10 +62,7 @@ export class ElementRuntimeProps
   @computed
   get evaluatedProps() {
     const componentProps = this.node.parentComponent?.current.runtimeProp
-
-    const injectedProps = {
-      $component: componentProps?.componentEvaluatedProps,
-    }
+    const injectedProps = componentProps?.componentEvaluatedProps || {}
 
     return replaceStateInProps(
       this.renderedTypedProps,
@@ -77,10 +74,7 @@ export class ElementRuntimeProps
   @computed
   get evaluatedPropsBeforeRender() {
     const componentProps = this.node.parentComponent?.current.runtimeProp
-
-    const injectedProps = {
-      $component: componentProps?.componentEvaluatedProps,
-    }
+    const injectedProps = componentProps?.componentEvaluatedProps || {}
 
     return replaceStateInProps(
       this.props,

--- a/libs/frontend/domain/renderer/src/element-runtime-props.model.ts
+++ b/libs/frontend/domain/renderer/src/element-runtime-props.model.ts
@@ -61,19 +61,31 @@ export class ElementRuntimeProps
 
   @computed
   get evaluatedProps() {
+    const componentProps = this.node.parentComponent?.current.runtimeProp
+
+    const injectedProps = {
+      $component: componentProps?.componentEvaluatedProps,
+    }
+
     return replaceStateInProps(
       this.renderedTypedProps,
       this.node.store.current.state,
-      this.node.parentComponent?.current.runtimeProp?.componentEvaluatedProps,
+      injectedProps,
     )
   }
 
   @computed
   get evaluatedPropsBeforeRender() {
+    const componentProps = this.node.parentComponent?.current.runtimeProp
+
+    const injectedProps = {
+      $component: componentProps?.componentEvaluatedProps,
+    }
+
     return replaceStateInProps(
       this.props,
       this.node.store.current.state,
-      this.node.parentComponent?.current.runtimeProp?.componentEvaluatedProps,
+      injectedProps,
     )
   }
 

--- a/libs/frontend/domain/renderer/src/index.ts
+++ b/libs/frontend/domain/renderer/src/index.ts
@@ -1,3 +1,4 @@
+export * from './action-runner.model'
 export * from './atoms'
 export * from './render.service'
 export * from './Renderer'

--- a/libs/frontend/domain/renderer/src/test/conditional-render-pipe.spec.ts
+++ b/libs/frontend/domain/renderer/src/test/conditional-render-pipe.spec.ts
@@ -29,7 +29,7 @@ describe('ConditionalRenderPipe', () => {
   })
 
   it('should stop rendering by returning an empty output', async () => {
-    data.element.setRenderIfExpression('{{this.shouldRender}}')
+    data.element.setRenderIfExpression('{{props.shouldRender}}')
     // changing state is bit tricky so, just use props
     data.element.props.current.set('shouldRender', false)
 
@@ -41,7 +41,7 @@ describe('ConditionalRenderPipe', () => {
   })
 
   it('should continue rendering', async () => {
-    data.element.setRenderIfExpression('{{this.shouldRender}}')
+    data.element.setRenderIfExpression('{{props.shouldRender}}')
     // changing state is bit tricky so, just use props
     data.element.props.current.set('shouldRender', true)
 

--- a/libs/frontend/domain/renderer/src/test/setup/setup-test.ts
+++ b/libs/frontend/domain/renderer/src/test/setup/setup-test.ts
@@ -229,7 +229,7 @@ export const setupTestForRenderer = (pipes: Array<RenderPipeClass> = []) => {
       data: JSON.stringify({
         componentProp: 'original',
         [CUSTOM_TEXT_PROP_KEY]: "I'm a component",
-        expressionProp: `expression value - {{component.${data.componentField.key}}}`,
+        expressionProp: `expression value - {{props.${data.componentField.key}}}`,
       }),
       id: v4(),
     })

--- a/libs/frontend/domain/renderer/src/test/typed-prop-tranformers.spec.ts
+++ b/libs/frontend/domain/renderer/src/test/typed-prop-tranformers.spec.ts
@@ -57,7 +57,7 @@ describe('RenderService', () => {
 
     data.component.rootElement.current.props.current.set(
       CUSTOM_TEXT_PROP_KEY,
-      `{{component.${data.textField.key}}}`,
+      `{{props.${data.textField.key}}}`,
     )
 
     const text = 'some text'
@@ -84,7 +84,7 @@ describe('RenderService', () => {
 
     data.component.rootElement.current.props.current.set(
       CUSTOM_TEXT_PROP_KEY,
-      `{{component.${data.textField.key}}}`,
+      `{{props.${data.textField.key}}}`,
     )
 
     // component props values

--- a/libs/frontend/domain/renderer/src/typedPropTransformers/action-type-transformer.ts
+++ b/libs/frontend/domain/renderer/src/typedPropTransformers/action-type-transformer.ts
@@ -2,9 +2,7 @@ import type {
   ITypedPropTransformer,
   TypedProp,
 } from '@codelab/frontend/abstract/core'
-import { getActionService } from '@codelab/frontend/domain/store'
 import { hasStateExpression } from '@codelab/frontend/shared/utils'
-import { computed } from 'mobx'
 import { ExtendedModel, model } from 'mobx-keystone'
 import { BaseRenderPipe } from '../renderPipes/render-pipe.base'
 
@@ -27,26 +25,16 @@ export class ActionTypeTransformer
   extends ExtendedModel(BaseRenderPipe, {})
   implements ITypedPropTransformer
 {
-  @computed
-  private get actionService() {
-    return getActionService(this)
-  }
-
   public transform(prop: TypedProp) {
     // unwrap custom action code so it is evaluated later
     if (hasStateExpression(prop.value)) {
       return prop.value
     }
 
-    const actionModel = this.actionService.action(prop.value)
+    console.log('I am here')
 
-    if (!actionModel) {
-      return prop
-    }
+    const actionRunner = this.renderer.actionRunners.get(prop.value)
 
-    // get action executor for its own store's state
-    const actionExecutor = actionModel.store.current.state[actionModel.name]
-
-    return actionExecutor || (() => null)
+    return actionRunner?.runner || (() => undefined)
   }
 }

--- a/libs/frontend/domain/renderer/src/utils/should-render-element.ts
+++ b/libs/frontend/domain/renderer/src/utils/should-render-element.ts
@@ -3,7 +3,6 @@ import {
   evaluateExpression,
   hasStateExpression,
 } from '@codelab/frontend/shared/utils'
-import { mergeProps } from '@codelab/shared/utils'
 
 export const shouldRenderElement = (
   { renderIfExpression, store }: IElement,
@@ -13,8 +12,5 @@ export const shouldRenderElement = (
     return true
   }
 
-  return evaluateExpression(
-    renderIfExpression,
-    mergeProps(props, store.current.state),
-  )
+  return evaluateExpression(renderIfExpression, store.current.state, props)
 }

--- a/libs/frontend/domain/store/src/store/action.service.ts
+++ b/libs/frontend/domain/store/src/store/action.service.ts
@@ -34,7 +34,6 @@ export class ActionService
     actionFactory: prop(() => new ActionFactory({})),
     actionRepository: prop(() => new ActionRepository({})),
     actions: prop(() => objectMap<IAction>()),
-    clones: prop(() => objectMap<IAction>()),
     createModal: prop(() => new ModalService({})),
     deleteModal: prop(() => new ActionModalService({})),
     updateModal: prop(() => new ActionModalService({})),
@@ -57,7 +56,7 @@ export class ActionService
   }
 
   action(id: string) {
-    return this.actions.get(id) || this.clones.get(id)
+    return this.actions.get(id)
   }
 
   @modelAction

--- a/libs/frontend/domain/store/src/store/models/api-action.model.ts
+++ b/libs/frontend/domain/store/src/store/models/api-action.model.ts
@@ -7,7 +7,6 @@ import type {
 } from '@codelab/frontend/abstract/core'
 import {
   actionRef,
-  getRenderService,
   propRef,
   resourceRef,
   storeRef,
@@ -20,11 +19,8 @@ import {
 import { IActionKind } from '@codelab/shared/abstract/core'
 import type { Nullable, Nullish } from '@codelab/shared/abstract/types'
 import { connectNodeId } from '@codelab/shared/domain/mapper'
-import { computed } from 'mobx'
 import type { Ref } from 'mobx-keystone'
 import { ExtendedModel, model, modelAction, prop } from 'mobx-keystone'
-import { v4 } from 'uuid'
-import { getActionService } from '../action.service.context'
 import { createBaseAction } from './base-action.model'
 
 const create = ({
@@ -58,43 +54,6 @@ export class ApiAction
   })
   implements IApiAction
 {
-  @computed
-  get actionService() {
-    return getActionService(this)
-  }
-
-  @computed
-  get renderService() {
-    return getRenderService(this)
-  }
-
-  @computed
-  get runner() {
-    return (
-      this.renderService.activeRenderer?.current.actionRunners.get(this.id)
-        ?.runner || (() => undefined)
-    )
-  }
-
-  @modelAction
-  clone(storeId: string) {
-    const clonedErrorAction = this.errorAction?.current.clone(storeId)
-    const clonedSuccessAction = this.errorAction?.current.clone(storeId)
-
-    return this.actionService.add<IApiActionDTO>({
-      __typename: IActionKind.ApiAction,
-      config: { id: this.config.id },
-      errorAction: clonedErrorAction ? { id: clonedErrorAction.id } : undefined,
-      id: v4(),
-      name: this.name,
-      resource: { id: this.resource.id },
-      store: { id: storeId },
-      successAction: clonedSuccessAction
-        ? { id: clonedSuccessAction.id }
-        : undefined,
-    })
-  }
-
   @modelAction
   writeCache({
     config,

--- a/libs/frontend/domain/store/src/store/models/base-action.model.ts
+++ b/libs/frontend/domain/store/src/store/models/base-action.model.ts
@@ -17,4 +17,4 @@ export const createBaseAction = <T extends IActionKind>(type: T) =>
       store: prop<Ref<IStore>>(),
       type: prop<T>(() => type),
     })
-    implements Omit<IBaseAction, 'clone' | 'runner'> {}
+    implements IBaseAction {}

--- a/libs/frontend/domain/store/src/store/models/base-action.model.ts
+++ b/libs/frontend/domain/store/src/store/models/base-action.model.ts
@@ -17,4 +17,4 @@ export const createBaseAction = <T extends IActionKind>(type: T) =>
       store: prop<Ref<IStore>>(),
       type: prop<T>(() => type),
     })
-    implements Omit<IBaseAction, 'clone' | 'createRunner'> {}
+    implements Omit<IBaseAction, 'clone' | 'runner'> {}

--- a/libs/frontend/domain/store/src/store/models/code-action.model.ts
+++ b/libs/frontend/domain/store/src/store/models/code-action.model.ts
@@ -2,7 +2,7 @@ import type {
   ICodeAction,
   ICodeActionDTO,
 } from '@codelab/frontend/abstract/core'
-import { getRenderService, storeRef } from '@codelab/frontend/abstract/core'
+import { storeRef } from '@codelab/frontend/abstract/core'
 import {
   CodeActionCreateInput,
   CodeActionDeleteInput,
@@ -10,10 +10,7 @@ import {
 } from '@codelab/shared/abstract/codegen'
 import { IActionKind } from '@codelab/shared/abstract/core'
 import { connectNodeId } from '@codelab/shared/domain/mapper'
-import { computed } from 'mobx'
 import { ExtendedModel, model, modelAction, prop } from 'mobx-keystone'
-import { v4 } from 'uuid'
-import { getActionService } from '../action.service.context'
 import { createBaseAction } from './base-action.model'
 
 const create = ({ code, id, name, store }: ICodeActionDTO) =>
@@ -32,27 +29,6 @@ export class CodeAction
   })
   implements ICodeAction
 {
-  @computed
-  get actionService() {
-    return getActionService(this)
-  }
-
-  @computed
-  get renderService() {
-    return getRenderService(this)
-  }
-
-  @modelAction
-  clone(storeId: string) {
-    return this.actionService.add<ICodeActionDTO>({
-      __typename: IActionKind.CodeAction,
-      code: this.code,
-      id: v4(),
-      name: this.name,
-      store: { id: storeId },
-    })
-  }
-
   @modelAction
   writeCache({ code, name }: Partial<ICodeActionDTO>) {
     this.name = name ?? this.name

--- a/libs/frontend/domain/store/src/store/models/code-action.model.ts
+++ b/libs/frontend/domain/store/src/store/models/code-action.model.ts
@@ -2,7 +2,7 @@ import type {
   ICodeAction,
   ICodeActionDTO,
 } from '@codelab/frontend/abstract/core'
-import { storeRef } from '@codelab/frontend/abstract/core'
+import { getRenderService, storeRef } from '@codelab/frontend/abstract/core'
 import {
   CodeActionCreateInput,
   CodeActionDeleteInput,
@@ -37,16 +37,9 @@ export class CodeAction
     return getActionService(this)
   }
 
-  @modelAction
-  createRunner() {
-    try {
-      // eslint-disable-next-line no-eval
-      return eval(`(${this.code})`)
-    } catch (error) {
-      console.log(error)
-
-      return () => undefined
-    }
+  @computed
+  get renderService() {
+    return getRenderService(this)
   }
 
   @modelAction

--- a/libs/frontend/domain/store/src/store/models/store.model.ts
+++ b/libs/frontend/domain/store/src/store/models/store.model.ts
@@ -90,9 +90,7 @@ export class Store
       mergeProps(
         this.api.current.defaultValues,
         this.actions
-          .map((action) => ({
-            [action.current.name]: action.current.createRunner(),
-          }))
+          .map((action) => ({ [action.current.name]: action.current.runner }))
           .reduce(merge, {}),
       ),
       {},

--- a/libs/frontend/domain/store/src/store/models/store.model.ts
+++ b/libs/frontend/domain/store/src/store/models/store.model.ts
@@ -8,6 +8,8 @@ import type {
 import {
   actionRef,
   componentRef,
+  getRenderService,
+  getRunnerId,
   pageRef,
   typeRef,
 } from '@codelab/frontend/abstract/core'
@@ -64,42 +66,6 @@ export class Store
   implements IStore
 {
   @computed
-  get storeService() {
-    return getStoreService(this)
-  }
-
-  @computed
-  get jsonString() {
-    return propSafeStringify(this.state)
-  }
-
-  @modelAction
-  writeCache({ actions, api, id, name }: Partial<IStoreDTO>) {
-    this.id = id ? id : this.id
-    this.name = name ? name : this.name
-    this.api = api ? (typeRef(api.id) as Ref<IInterfaceType>) : this.api
-    this.actions =
-      actions?.map((action) => actionRef(action.id)) ?? this.actions
-
-    return this
-  }
-
-  @computed
-  get state() {
-    return makeAutoObservable(
-      mergeProps(
-        this.api.current.defaultValues,
-        this.actions
-          .map((action) => ({ [action.current.name]: action.current.runner }))
-          .reduce(merge, {}),
-      ),
-      {},
-      // bind actions to state
-      { autoBind: true },
-    )
-  }
-
-  @computed
   get actionsTree() {
     return this.actions
       .map((action) => ({
@@ -114,15 +80,64 @@ export class Store
       .filter((node) => Boolean(node))
   }
 
+  @computed
+  get storeService() {
+    return getStoreService(this)
+  }
+
+  @computed
+  get jsonString() {
+    return propSafeStringify(this.state)
+  }
+
+  @computed
+  get renderService() {
+    return getRenderService(this)
+  }
+
+  @computed
+  get state() {
+    const renderer = this.renderService.activeRenderer?.current
+
+    return makeAutoObservable(
+      mergeProps(
+        this.api.current.defaultValues,
+        this.actions
+          .map(({ current: action }) => {
+            const actionId = getRunnerId(this.id, action.id)
+            const actionRunner = renderer?.actionRunners.get(actionId)
+            const fallback = () => console.error(`fail to call ${action.name}`)
+            const runner = actionRunner?.runner || fallback
+
+            return { [action.name]: runner }
+          })
+          .reduce(merge, {}),
+      ),
+      {},
+      // bind actions to state
+      { autoBind: true },
+    )
+  }
+
+  @modelAction
+  writeCache({ actions, api, id, name }: Partial<IStoreDTO>) {
+    this.id = id ? id : this.id
+    this.name = name ? name : this.name
+    this.api = api ? (typeRef(api.id) as Ref<IInterfaceType>) : this.api
+    this.actions =
+      actions?.map((action) => actionRef(action.id)) ?? this.actions
+
+    return this
+  }
+
   @modelAction
   clone(componentId: string) {
     const id = v4()
 
     return this.storeService.add({
-      // we clone actions so that action runner is resolved from the correct store
-      actions: [...this.actions.values()].map((action) =>
-        action.current.clone(id),
-      ),
+      actions: [...this.actions.values()].map((action) => ({
+        id: action.current.id,
+      })),
       api: typeRef<IInterfaceType>(this.api.id),
       component: componentRef(componentId),
       id,

--- a/libs/frontend/domain/type/src/interface-form/type-schema.factory.ts
+++ b/libs/frontend/domain/type/src/interface-form/type-schema.factory.ts
@@ -306,7 +306,13 @@ export class TypeSchemaFactory {
       '',
     )
 
-    return { label: '', properties, type: 'object', uniforms: nullUniforms }
+    return {
+      label: '',
+      properties,
+      required: ['type'],
+      type: 'object',
+      uniforms: nullUniforms,
+    }
   }
 
   private getExtraProperties(type: IType, context?: UiPropertiesContext) {

--- a/libs/frontend/presentation/container/src/routerHooks/useCurrentApp.hook.ts
+++ b/libs/frontend/presentation/container/src/routerHooks/useCurrentApp.hook.ts
@@ -24,8 +24,6 @@ export const useCurrentApp = () => {
   const userName = query.userName as string
   const appName = appSlug && getNameFromSlug(appSlug)
 
-  console.log(appSlug, appName)
-
   const owner = userService.usersList.find(
     ({ username }) => username === userName,
   )

--- a/libs/frontend/shared/utils/src/state-expressions.ts
+++ b/libs/frontend/shared/utils/src/state-expressions.ts
@@ -22,13 +22,13 @@ export const stripStateExpression = (expression: string) =>
 export const evaluateExpression = (
   expression: string,
   state: IPropData,
-  componentProps: IPropData = {},
+  props: IPropData = {},
 ) => {
   try {
     const code = `return ${stripStateExpression(expression)}`
 
     // eslint-disable-next-line no-new-func
-    return new Function('component', code).call(state, componentProps)
+    return new Function('props', code).call(state, props)
   } catch (error) {
     console.log(error)
 
@@ -39,24 +39,24 @@ export const evaluateExpression = (
 export const replaceStateInProps = (
   props: IPropData,
   state: IPropData = {},
-  componentProps: IPropData = {},
+  injectedProps: IPropData = {},
 ) =>
   mapDeep(
     props,
     // value mapper
     (value, key) =>
-      isString(value) ? getByExpression(value, state, componentProps) : value,
+      isString(value) ? getByExpression(value, state, injectedProps) : value,
     // key mapper
     (value, key) =>
       (isString(key)
-        ? getByExpression(key, state, componentProps)
+        ? getByExpression(key, state, injectedProps)
         : key) as string,
   )
 
 export const getByExpression = (
   key: string,
   state: IPropData,
-  componentProps: IPropData = {},
+  props: IPropData = {},
 ) => {
   if (!hasStateExpression(key)) {
     return key
@@ -66,13 +66,13 @@ export const getByExpression = (
    * return typed value for : {{expression}}
    */
   if (isSingleStateExpression(key)) {
-    return evaluateExpression(key, state, componentProps)
+    return evaluateExpression(key, state, props)
   }
 
   /**
    * return string value for : [text1]? {{expression1}} [text2]? {{expression2}}...
    */
   return key.replace(STATE_PATH_TEMPLATE_REGEX, (value) =>
-    evaluateExpression(value, state, componentProps),
+    evaluateExpression(value, state, props),
   )
 }


### PR DESCRIPTION
<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(libs-ui-component): must begin with lowercase` -->

## Description

<!-- This is a short description on the Pull Request -->
- In expressions and in actions component props are accessible via `props.[propName]`
- add action runner to enable us inject props into actions during render
- in typed props `type` property wasn't submitted by form until I added `required`.
- Action Modals wasn't working as expected therefor they were moved to the correct place. (maybe will change with the upcoming UI)
- Action model is now a pure data model

## Video or Image

<!-- Add video or image showing how the new feature works -->

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged -->

Fixes #
- #2696
- #2733
