### PR TITLE
refactor: allow to set callback on script load/error

### DIFF
--- a/data/export/admin/atoms/HtmlScript.json
+++ b/data/export/admin/atoms/HtmlScript.json
@@ -209,6 +209,40 @@
       "api": {
         "id": "8b27806f-3ba0-4e5d-8051-8ad72a0f9511"
       }
+    },
+    {
+      "id": "f043bf13-099d-49de-a8c4-60046209bb1a",
+      "key": "onLoad",
+      "name": "onLoad",
+      "description": null,
+      "validationRules": null,
+      "defaultValues": null,
+      "fieldType": {
+        "__typename": "ActionType",
+        "id": "90b255f4-6ba9-4e2c-a44b-af43ff0b9a7f",
+        "kind": "ActionType",
+        "name": "ActionType"
+      },
+      "api": {
+        "id": "8b27806f-3ba0-4e5d-8051-8ad72a0f9511"
+      }
+    },
+    {
+      "id": "b2a33a2f-032b-47e6-9cf3-44906770a102",
+      "key": "onError",
+      "name": "onError",
+      "description": null,
+      "validationRules": null,
+      "defaultValues": null,
+      "fieldType": {
+        "__typename": "ActionType",
+        "id": "90b255f4-6ba9-4e2c-a44b-af43ff0b9a7f",
+        "kind": "ActionType",
+        "name": "ActionType"
+      },
+      "api": {
+        "id": "8b27806f-3ba0-4e5d-8051-8ad72a0f9511"
+      }
     }
   ],
   "types": [

--- a/scripts/vercel/landing/build.sh
+++ b/scripts/vercel/landing/build.sh
@@ -4,4 +4,4 @@
 # https://github.com/vercel/community/discussions/30
 # rm -rf node_modules/.cache/nx
 du -sh * | sort -h
-npx nx build landing -c prod --runner vercel --verbose
+npx nx build landing -c prod --runner default --verbose

--- a/scripts/vercel/platform-api-next/build.sh
+++ b/scripts/vercel/platform-api-next/build.sh
@@ -8,4 +8,4 @@ set -x
 # rm -rf node_modules/.cache/nx
 cd ../..
 du -sh * | sort -h
-npx nx build platform-api-next -c prod --runner vercel --verbose
+npx nx build platform-api-next -c prod --runner default --verbose

--- a/scripts/vercel/platform/build.sh
+++ b/scripts/vercel/platform/build.sh
@@ -8,4 +8,4 @@ set -x
 # rm -rf node_modules/.cache/nx
 cd ../..
 du -sh * | sort -h
-npx nx build platform -c prod --runner vercel --verbose
+npx nx build platform -c prod --runner default --verbose

--- a/scripts/vercel/websites/build.sh
+++ b/scripts/vercel/websites/build.sh
@@ -4,4 +4,4 @@
 # https://github.com/vercel/community/discussions/30
 # rm -rf node_modules/.cache/nx
 du -sh * | sort -h
-npx nx build websites -c prod --runner vercel --verbose
+npx nx build websites -c prod --runner default --verbose


### PR DESCRIPTION
<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(libs-ui-component): must begin with lowercase` -->

## Description
Allow users to specify `onload` and `onerror` callbacks for scripts.
Use case example: now I can load supabase script, and initialize supabaseClient once it is loaded and set the instance to the store. After this I am able to fetch data from supabase using this instance

## Video or Image

<!-- Add video or image showing how the new feature works -->

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged -->

Fixes #2737 
