### PR TITLE
fix: can't open apps with digits in name

### DIFF
--- a/apps/platform-e2e/src/e2e/builder.cy.ts
+++ b/apps/platform-e2e/src/e2e/builder.cy.ts
@@ -1,7 +1,7 @@
 import { ROOT_ELEMENT_NAME } from '@codelab/frontend/abstract/core'
 import type { IAppDTO } from '@codelab/shared/abstract/core'
 import { IAtomType } from '@codelab/shared/abstract/core'
-import slugify from 'voca/slugify'
+import { slugify } from '@codelab/shared/utils'
 import { FIELD_TYPE } from '../support/antd/form'
 import { loginSession } from '../support/nextjs-auth0/commands/login'
 

--- a/apps/platform-e2e/src/e2e/component.cy.ts
+++ b/apps/platform-e2e/src/e2e/component.cy.ts
@@ -1,6 +1,6 @@
 import type { IAppDTO } from '@codelab/shared/abstract/core'
 import { IAtomType, IPrimitiveTypeKind } from '@codelab/shared/abstract/core'
-import slugify from 'voca/slugify'
+import { slugify } from '@codelab/shared/utils'
 import { FIELD_TYPE } from '../support/antd/form'
 import { loginSession } from '../support/nextjs-auth0/commands/login'
 

--- a/apps/platform-e2e/src/e2e/css.cy.ts
+++ b/apps/platform-e2e/src/e2e/css.cy.ts
@@ -1,6 +1,6 @@
 import { ROOT_ELEMENT_NAME } from '@codelab/frontend/abstract/core'
 import { IAtomType } from '@codelab/shared/abstract/core'
-import slugify from 'voca/slugify'
+import { slugify } from '@codelab/shared/utils'
 import { loginSession } from '../support/nextjs-auth0/commands/login'
 
 const ELEMENT_BUTTON = 'Button'

--- a/libs/backend/domain/type/src/model/interface-type.model.ts
+++ b/libs/backend/domain/type/src/model/interface-type.model.ts
@@ -7,7 +7,7 @@ import type {
 import { ITypeKind } from '@codelab/shared/abstract/core'
 import type { IEntity } from '@codelab/shared/abstract/types'
 import { v4 } from 'uuid'
-import { capitalize } from 'voca'
+import capitalize from 'voca/capitalize'
 import { BaseType } from './base-type.model'
 
 export class InterfaceType extends BaseType implements IInterfaceTypeDTO {

--- a/libs/backend/infra/adapter/neo4j/src/resolver/pure-resolver/app/field/app-slug.ts
+++ b/libs/backend/infra/adapter/neo4j/src/resolver/pure-resolver/app/field/app-slug.ts
@@ -1,6 +1,6 @@
 import type { App } from '@codelab/shared/abstract/codegen'
+import { slugify } from '@codelab/shared/utils'
 import type { IFieldResolver } from '@graphql-tools/utils'
-import slugify from 'voca/slugify'
 import { name } from './app-name'
 
 /**

--- a/libs/backend/infra/adapter/neo4j/src/resolver/pure-resolver/page/field/page-slug.ts
+++ b/libs/backend/infra/adapter/neo4j/src/resolver/pure-resolver/page/field/page-slug.ts
@@ -1,6 +1,6 @@
 import type { Page } from '@codelab/shared/abstract/codegen'
+import { slugify } from '@codelab/shared/utils'
 import type { IFieldResolver } from '@graphql-tools/utils'
-import slugify from 'voca/slugify'
 import { name } from './page-name'
 
 /**

--- a/libs/frontend/domain/app/src/store/app.model.ts
+++ b/libs/frontend/domain/app/src/store/app.model.ts
@@ -8,12 +8,11 @@ import type {
 import type { IAppDTO, IAuth0Owner } from '@codelab/shared/abstract/core'
 import { IPageKind } from '@codelab/shared/abstract/core'
 import { connectAuth0Owner } from '@codelab/shared/domain/mapper'
-import { createUniqueName } from '@codelab/shared/utils'
+import { createUniqueName, slugify } from '@codelab/shared/utils'
 import merge from 'lodash/merge'
 import { computed } from 'mobx'
 import type { Ref } from 'mobx-keystone'
 import { idProp, Model, model, modelAction, prop } from 'mobx-keystone'
-import slugify from 'voca/slugify'
 
 const create = ({ domains, id, name, owner, pages }: IAppDTO) => {
   const app = new App({

--- a/libs/frontend/domain/page/src/store/page.model.ts
+++ b/libs/frontend/domain/page/src/store/page.model.ts
@@ -12,11 +12,10 @@ import type {
 import type { IPageDTO, IPageKind } from '@codelab/shared/abstract/core'
 import type { IEntity, Maybe } from '@codelab/shared/abstract/types'
 import { connectNodeId, reconnectNodeId } from '@codelab/shared/domain/mapper'
-import { createUniqueName } from '@codelab/shared/utils'
+import { createUniqueName, slugify } from '@codelab/shared/utils'
 import { computed } from 'mobx'
 import type { Ref } from 'mobx-keystone'
 import { ExtendedModel, model, modelAction, prop } from 'mobx-keystone'
-import slugify from 'voca/slugify'
 
 const create = ({
   app,

--- a/libs/frontend/domain/page/src/store/page.service.ts
+++ b/libs/frontend/domain/page/src/store/page.service.ts
@@ -20,6 +20,7 @@ import { InlineFormService, ModalService } from '@codelab/frontend/shared/utils'
 import type { PageWhere } from '@codelab/shared/abstract/codegen'
 import type { IPageDTO } from '@codelab/shared/abstract/core'
 import { IPageKind, ITypeKind } from '@codelab/shared/abstract/core'
+import { slugify } from '@codelab/shared/utils'
 import { computed } from 'mobx'
 import {
   _async,
@@ -33,7 +34,6 @@ import {
   transaction,
 } from 'mobx-keystone'
 import { v4 } from 'uuid'
-import { slugify } from 'voca'
 import { PageFactory } from '../services'
 import { pageApi } from './page.api'
 import { Page } from './page.model'

--- a/libs/frontend/presentation/container/src/routerHooks/useCurrentApp.hook.ts
+++ b/libs/frontend/presentation/container/src/routerHooks/useCurrentApp.hook.ts
@@ -1,14 +1,7 @@
-import { createUniqueName } from '@codelab/shared/utils'
+import { createUniqueName, getNameFromSlug } from '@codelab/shared/utils'
 import { useRouter } from 'next/router'
 import { useMemo } from 'react'
-import titleCase from 'voca/title_case'
 import { useStore } from '../providers'
-
-export const getNameFromSlug = (slug?: string) => {
-  const str = slug?.replace(/-/g, ' ')
-
-  return titleCase(str)
-}
 
 export const useCurrentApp = () => {
   const { appService, userService } = useStore()

--- a/libs/frontend/presentation/container/src/routerHooks/useCurrentPage.hook.ts
+++ b/libs/frontend/presentation/container/src/routerHooks/useCurrentPage.hook.ts
@@ -1,8 +1,8 @@
-import { createUniqueName } from '@codelab/shared/utils'
+import { createUniqueName, getNameFromSlug } from '@codelab/shared/utils'
 import { useRouter } from 'next/router'
 import { useMemo } from 'react'
 import { useStore } from '../providers'
-import { getNameFromSlug, useCurrentApp } from './useCurrentApp.hook'
+import { useCurrentApp } from './useCurrentApp.hook'
 
 export const useCurrentPage = () => {
   const { app } = useCurrentApp()
@@ -10,10 +10,7 @@ export const useCurrentPage = () => {
   const { query } = useRouter()
   const pageSlug = query.pageSlug as string
   const userName = query.userName as string
-  // this is the only exception for now:
-  // provider page has "_app" name which is sluggified to "app"
-  // and we can't reverse it from "app" to "_app" following generic rules
-  const pageName = pageSlug === 'app' ? '_app' : getNameFromSlug(pageSlug)
+  const pageName = getNameFromSlug(pageSlug)
 
   const user = userService.usersList.find(
     ({ username }) => username === userName,

--- a/libs/shared/utils/src/transform/strings.ts
+++ b/libs/shared/utils/src/transform/strings.ts
@@ -24,5 +24,21 @@ export const stripQuotes = (value: string) => value.replace(/['"]/g, '')
 export const capitalizeFirstLetter = (value: string) =>
   value.charAt(0).toUpperCase() + value.slice(1)
 
+// custom implementation of slugify method because can't rely on voca.slugify.
+// there are collisions, for example for strings like "My1 App", "My1app", "My 1 App"
+// the same slug is generated "my-1-app" and we can't reverse it back to original string.
+// in same time our custom implementation will generate "my1-app", "my1app", "my-1-app"
+export const slugify = (value?: string) =>
+  value
+    ? value
+        .toLowerCase()
+        .replace(/ /g, '-')
+        .replace(/[^\w-]+/g, '')
+    : ''
+
+export const getNameFromSlug = (slug?: string) => {
+  return slug ? slug.split('-').map(capitalizeFirstLetter).join(' ') : ''
+}
+
 // export const startsWithCapital = (word: string) =>
 //   word.charAt(0) === word.charAt(0).toUpperCase()


### PR DESCRIPTION
<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(libs-ui-component): must begin with lowercase` -->

## Description

Added custom implementation of `slugify` method because we can't rely on voca.slugify.
There are collisions, for example for strings like `My1 App`, `My1app`, `My 1 App` the same slug is generated `my-1-app` and we can't reverse it back to the original string.
The new implementation will generate `my1-app`, `my1app`, `my-1-app`

## Video or Image


https://github.com/codelab-app/platform/assets/74900868/0c84a69b-8f10-4582-8c7b-98ba17c0e8cb



## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged -->

Fixes #2745 
