### PR TITLE
fix: infinite loop on load all types for elements

### DIFF
--- a/.circleci/config/jobs/e2e.yml
+++ b/.circleci/config/jobs/e2e.yml
@@ -13,9 +13,6 @@ steps:
   - run:
       name: 'Run E2E Tests'
       command: yarn cli tasks e2e --stage ci
-      environment:
-        JEST_JUNIT_OUTPUT_DIR: '/tmp/test-reports'
-        JEST_JUNIT_OUTPUT_NAME: 'e2e-specs-results.xml'
   - store_artifacts:
       path: ~/project/apps/platform-e2e/src/videos
       destination: cypress/videos
@@ -26,4 +23,4 @@ steps:
       path: ~/project/apps/platform-e2e/src/data
       destination: cypress/data
   - store_test_results:
-      path: /tmp/test-reports
+      path: ./tmp/reports/e2e

--- a/apps/landing/project.json
+++ b/apps/landing/project.json
@@ -31,6 +31,10 @@
           "buildTarget": "landing:build:dev",
           "dev": true
         },
+        "ci": {
+          "buildTarget": "landing:build:ci",
+          "dev": false
+        },
         "prod": {
           "buildTarget": "landing:build:prod",
           "dev": false

--- a/apps/landing/project.json
+++ b/apps/landing/project.json
@@ -15,6 +15,7 @@
         "dev": {
           "outputPath": "apps/landing"
         },
+        "ci": {},
         "prod": {}
       }
     },

--- a/apps/platform-api-next/project.json
+++ b/apps/platform-api-next/project.json
@@ -13,6 +13,7 @@
       },
       "configurations": {
         "dev": {},
+        "ci": {},
         "test": {
           "outputPath": "dist/apps/platform-api-next-test"
         },

--- a/apps/platform-api-next/project.json
+++ b/apps/platform-api-next/project.json
@@ -30,7 +30,7 @@
       },
       "configurations": {
         "ci": {
-          "buildTarget": "platform-api-next:build",
+          "buildTarget": "platform-api-next:build:ci",
           "dev": false
         },
         "dev": {},

--- a/apps/platform-e2e/project.json
+++ b/apps/platform-e2e/project.json
@@ -21,7 +21,7 @@
           "devServerTarget": "platform-e2e:serve:ci",
           "reporter": "../../node_modules/cypress-multi-reporters",
           "reporterOptions": {
-            "mochaFile": "results/my-test-output-[hash].xml"
+            "mochaFile": "./tmp/reports/e2e/cypress-results-[hash].xml"
           },
           "record": true,
           "parallel": true,

--- a/apps/platform-e2e/src/e2e/builder.cy.ts
+++ b/apps/platform-e2e/src/e2e/builder.cy.ts
@@ -1,6 +1,6 @@
 import { ROOT_ELEMENT_NAME } from '@codelab/frontend/abstract/core'
 import type { IAppDTO } from '@codelab/shared/abstract/core'
-import { IPageKindName, IAtomType } from '@codelab/shared/abstract/core'
+import { IAtomType, IPageKindName } from '@codelab/shared/abstract/core'
 import { slugify } from '@codelab/shared/utils'
 import { FIELD_TYPE } from '../support/antd/form'
 import { loginSession } from '../support/nextjs-auth0/commands/login'

--- a/apps/platform-e2e/src/e2e/builder.cy.ts
+++ b/apps/platform-e2e/src/e2e/builder.cy.ts
@@ -1,6 +1,6 @@
 import { ROOT_ELEMENT_NAME } from '@codelab/frontend/abstract/core'
 import type { IAppDTO } from '@codelab/shared/abstract/core'
-import { IAtomType } from '@codelab/shared/abstract/core'
+import { IPageKindName, IAtomType } from '@codelab/shared/abstract/core'
 import { slugify } from '@codelab/shared/utils'
 import { FIELD_TYPE } from '../support/antd/form'
 import { loginSession } from '../support/nextjs-auth0/commands/login'
@@ -60,7 +60,11 @@ describe('Elements CRUD', () => {
       .then(() => cy.request<IAppDTO>('/api/cypress/app'))
       .then((apps) => {
         const app = apps.body
-        cy.visit(`/apps/cypress/${slugify(app.name)}/pages/app/builder`)
+        cy.visit(
+          `/apps/cypress/${slugify(app.name)}/pages/${slugify(
+            IPageKindName.Provider,
+          )}/builder`,
+        )
         cy.getSpinner().should('not.exist')
 
         // select root now so we can update its child later

--- a/apps/platform-e2e/src/e2e/css.cy.ts
+++ b/apps/platform-e2e/src/e2e/css.cy.ts
@@ -1,5 +1,5 @@
 import { ROOT_ELEMENT_NAME } from '@codelab/frontend/abstract/core'
-import { IAtomType } from '@codelab/shared/abstract/core'
+import { IAtomType, IPageKindName } from '@codelab/shared/abstract/core'
 import { slugify } from '@codelab/shared/utils'
 import { loginSession } from '../support/nextjs-auth0/commands/login'
 
@@ -29,7 +29,11 @@ describe('CSS CRUD', () => {
       .then((apps) => {
         const app = apps.body
 
-        cy.visit(`/apps/cypress/${slugify(app.name)}/pages/app/builder`)
+        cy.visit(
+          `/apps/cypress/${slugify(app.name)}/pages/${slugify(
+            IPageKindName.Provider,
+          )}/builder`,
+        )
         cy.getSpinner().should('not.exist')
         cy.createElementTree([
           {
@@ -41,6 +45,7 @@ describe('CSS CRUD', () => {
       })
   })
 
+  //
   describe('Add css string', () => {
     it('should be able to add styling through css string', () => {
       cy.getSpinner().should('not.exist')

--- a/apps/platform/project.json
+++ b/apps/platform/project.json
@@ -13,6 +13,7 @@
       },
       "configurations": {
         "dev": {},
+        "ci": {},
         "test": {
           "outputPath": "dist/apps/platform-test"
         },

--- a/apps/platform/project.json
+++ b/apps/platform/project.json
@@ -31,7 +31,7 @@
       },
       "configurations": {
         "ci": {
-          "buildTarget": "platform:build",
+          "buildTarget": "platform:build:ci",
           "dev": false
         },
         "test": {

--- a/apps/websites/project.json
+++ b/apps/websites/project.json
@@ -23,25 +23,6 @@
       },
       "defaultConfiguration": "production"
     },
-    "serve-test": {
-      "executor": "nx:run-commands",
-      "configurations": {
-        "dev": {
-          "commands": [
-            {
-              "command": "nx serve websites -c test"
-            }
-          ]
-        },
-        "ci": {
-          "commands": [
-            {
-              "command": "npx next start dist/apps/websites --port 3000"
-            }
-          ]
-        }
-      }
-    },
     "serve": {
       "executor": "@nx/next:server",
       "options": {

--- a/apps/websites/project.json
+++ b/apps/websites/project.json
@@ -12,16 +12,13 @@
         "outputPath": "dist/apps/websites"
       },
       "configurations": {
-        "ci": {
-          "root": "apps/websites",
-          "outputPath": "dist/apps/websites"
-        },
-        "production": {},
-        "development": {
+        "ci": {},
+        "prod": {},
+        "dev": {
           "outputPath": "tmp/apps/websites/src"
         }
       },
-      "defaultConfiguration": "production"
+      "defaultConfiguration": "prod"
     },
     "serve": {
       "executor": "@nx/next:server",
@@ -39,21 +36,21 @@
           "memoryLimit": 8192,
           "port": 3001
         },
-        "production": {
-          "buildTarget": "websites:build:production",
+        "prod": {
+          "buildTarget": "websites:build:prod",
           "dev": false
         },
-        "development": {
-          "buildTarget": "websites:build:development",
+        "dev": {
+          "buildTarget": "websites:build:dev",
           "dev": true
         }
       },
-      "defaultConfiguration": "development"
+      "defaultConfiguration": "dev"
     },
     "export": {
       "executor": "@nx/next:export",
       "options": {
-        "buildTarget": "websites:build:production"
+        "buildTarget": "websites:build:prod"
       }
     },
     "lint": {

--- a/libs/backend/domain/user/src/model/user.model.ts
+++ b/libs/backend/domain/user/src/model/user.model.ts
@@ -35,7 +35,6 @@ export class User implements IUserDTO {
       email,
       id: v4(),
       roles: [Role.Admin],
-
       username: nickname,
     })
   }

--- a/libs/frontend/abstract/core/src/domain/type/json-schema/typed-prop.interface.ts
+++ b/libs/frontend/abstract/core/src/domain/type/json-schema/typed-prop.interface.ts
@@ -1,3 +1,4 @@
+import { ITypeKind } from '@codelab/shared/abstract/core'
 import isPlainObject from 'lodash/isPlainObject'
 import isString from 'lodash/isString'
 import type { IPropData } from '../../prop'
@@ -11,10 +12,18 @@ import type { IPropData } from '../../prop'
  * an element id, but they are hydrated in different ways in the render pipeline.
  */
 export interface TypedProp {
+  // sometimes we need to know the kind without having to load the type
+  kind: ITypeKind
   type: string
   value: string
 }
 
 export const isTypedProp = (prop: IPropData): prop is TypedProp => {
-  return isPlainObject(prop) && 'type' in prop && isString(prop['type'])
+  return (
+    isPlainObject(prop) &&
+    'type' in prop &&
+    isString(prop['type']) &&
+    'kind' in prop &&
+    prop['kind'] in ITypeKind
+  )
 }

--- a/libs/frontend/domain/renderer/src/base-runtime-props.model.ts
+++ b/libs/frontend/domain/renderer/src/base-runtime-props.model.ts
@@ -62,13 +62,7 @@ export class BaseRuntimeProps<TNode extends IPageNode>
         return undefined
       }
 
-      const typeKind = this.typeService.type(value.type)?.kind
-
-      if (!typeKind) {
-        return value.value
-      }
-
-      const transformer = this.renderer.typedPropTransformers.get(typeKind)
+      const transformer = this.renderer.typedPropTransformers.get(value.kind)
 
       if (!transformer) {
         return value.value

--- a/libs/frontend/domain/renderer/src/test/setup/setup-test.ts
+++ b/libs/frontend/domain/renderer/src/test/setup/setup-test.ts
@@ -186,6 +186,7 @@ export const setupTestForRenderer = (pipes: Array<RenderPipeClass> = []) => {
         prop01: 'prop01Value',
         prop02: 'prop02Value',
         prop03: {
+          kind: integerType.kind,
           type: integerType.id,
           value: 'prop03Value',
         },

--- a/libs/frontend/domain/renderer/src/test/typed-prop-tranformers.spec.ts
+++ b/libs/frontend/domain/renderer/src/test/typed-prop-tranformers.spec.ts
@@ -1,6 +1,5 @@
 import type { IRenderOutput, TypedProp } from '@codelab/frontend/abstract/core'
 import { CUSTOM_TEXT_PROP_KEY } from '@codelab/frontend/abstract/core'
-import { ITypeKind } from '@codelab/shared/abstract/core'
 import { render } from '@testing-library/react'
 import { setupTestForRenderer } from './setup/setup-test'
 import TestProviderWrapper from './TestProviderWrapper'
@@ -21,7 +20,7 @@ describe('RenderService', () => {
   it('should render props when kind is ReactNodeType', async () => {
     data.element.props.current.setMany({
       someNode: {
-        kind: ITypeKind.ReactNodeType,
+        kind: data.reactNodeType.kind,
         type: data.reactNodeType.id,
         value: data.component.id,
       } as TypedProp,
@@ -48,7 +47,7 @@ describe('RenderService', () => {
   it('should render prop when kind is RenderPropType with component prop values', async () => {
     data.element.props.current.setMany({
       someNode: {
-        kind: ITypeKind.RenderPropType,
+        kind: data.renderPropType.kind,
         type: data.renderPropType.id,
         value: data.component.id,
       } as TypedProp,
@@ -76,6 +75,7 @@ describe('RenderService', () => {
   it('should render props when kind is RenderPropType with passed arguments (override component props)', async () => {
     data.element.props.current.setMany({
       someNode: {
+        kind: data.renderPropType.kind,
         type: data.renderPropType.id,
         value: data.component.id,
       },

--- a/libs/frontend/domain/renderer/src/test/typed-prop-tranformers.spec.ts
+++ b/libs/frontend/domain/renderer/src/test/typed-prop-tranformers.spec.ts
@@ -1,5 +1,6 @@
 import type { IRenderOutput, TypedProp } from '@codelab/frontend/abstract/core'
 import { CUSTOM_TEXT_PROP_KEY } from '@codelab/frontend/abstract/core'
+import { ITypeKind } from '@codelab/shared/abstract/core'
 import { render } from '@testing-library/react'
 import { setupTestForRenderer } from './setup/setup-test'
 import TestProviderWrapper from './TestProviderWrapper'
@@ -20,6 +21,7 @@ describe('RenderService', () => {
   it('should render props when kind is ReactNodeType', async () => {
     data.element.props.current.setMany({
       someNode: {
+        kind: ITypeKind.ReactNodeType,
         type: data.reactNodeType.id,
         value: data.component.id,
       } as TypedProp,
@@ -46,6 +48,7 @@ describe('RenderService', () => {
   it('should render prop when kind is RenderPropType with component prop values', async () => {
     data.element.props.current.setMany({
       someNode: {
+        kind: ITypeKind.RenderPropType,
         type: data.renderPropType.id,
         value: data.component.id,
       } as TypedProp,

--- a/libs/frontend/domain/type/src/interface-form/type-schema.factory.ts
+++ b/libs/frontend/domain/type/src/interface-form/type-schema.factory.ts
@@ -141,7 +141,7 @@ export class TypeSchemaFactory {
         const valueSchema = this.transform(innerType.current)
 
         const properties = TypeSchemaFactory.schemaForTypedProp(
-          innerType.id,
+          innerType.current,
           valueSchema,
           typeLabel,
         )
@@ -199,7 +199,7 @@ export class TypeSchemaFactory {
     const extra = this.getExtraProperties(type)
 
     const properties = TypeSchemaFactory.schemaForTypedProp(
-      type.id,
+      type,
       { label: '', type: 'string', ...extra },
       '',
     )
@@ -269,15 +269,26 @@ export class TypeSchemaFactory {
    * with a `type` field that has a value of `typeId`
    */
   private static schemaForTypedProp(
-    typeId: Maybe<string>,
+    type: Maybe<IType>,
     valueSchema: JsonSchema,
     typeLabel: Maybe<string>,
   ): { [key: string]: JsonSchema } {
     return {
+      kind: {
+        default: type?.kind,
+
+        enum: type?.kind ? [type.kind] : undefined,
+
+        label: typeLabel,
+
+        type: 'string',
+
+        uniforms: blankUniforms,
+      },
       type: {
-        default: typeId,
+        default: type?.id,
         // This ensures that only this exact type is considered valid. Allows union types to use oneOf
-        enum: typeId ? [typeId] : undefined,
+        enum: type?.id ? [type.id] : undefined,
 
         label: typeLabel,
 
@@ -301,7 +312,7 @@ export class TypeSchemaFactory {
     const label = context?.fieldName ?? ''
 
     const properties = TypeSchemaFactory.schemaForTypedProp(
-      type.id,
+      type,
       { label, ...extra },
       '',
     )
@@ -309,7 +320,7 @@ export class TypeSchemaFactory {
     return {
       label: '',
       properties,
-      required: ['type'],
+      required: ['type', 'kind'],
       type: 'object',
       uniforms: nullUniforms,
     }

--- a/libs/frontend/domain/type/src/interface-form/type-schema.factory.ts
+++ b/libs/frontend/domain/type/src/interface-form/type-schema.factory.ts
@@ -279,7 +279,7 @@ export class TypeSchemaFactory {
 
         enum: type?.kind ? [type.kind] : undefined,
 
-        label: typeLabel,
+        label: `${typeLabel}Kind`,
 
         type: 'string',
 

--- a/libs/frontend/domain/type/src/store/tests/schema.data.ts
+++ b/libs/frontend/domain/type/src/store/tests/schema.data.ts
@@ -11,6 +11,13 @@ export const unionTypeExpectedSchema = {
     {
       label: '',
       properties: {
+        kind: {
+          default: stringType.kind,
+          enum: [stringType.kind],
+          label: 'TypeKind',
+          type: 'string',
+          uniforms: expect.any(Object),
+        },
         type: {
           default: stringType.id,
           enum: [stringType.id],
@@ -26,6 +33,13 @@ export const unionTypeExpectedSchema = {
     {
       label: '',
       properties: {
+        kind: {
+          default: intType.kind,
+          enum: [intType.kind],
+          label: 'TypeKind',
+          type: 'string',
+          uniforms: expect.any(Object),
+        },
         type: {
           default: intType.id,
           enum: [intType.id],
@@ -53,12 +67,14 @@ export const interfaceWithUnionExpectedSchema = {
       oneOf: [
         merge({}, unionTypeExpectedSchema.oneOf[0], {
           properties: {
+            kind: { label: 'TypeKind' },
             type: { label: 'Type' },
             value: { label: undefined },
           },
         }),
         merge({}, unionTypeExpectedSchema.oneOf[1], {
           properties: {
+            kind: { label: 'TypeKind' },
             type: { label: 'Type' },
             value: { label: undefined },
           },

--- a/libs/frontend/presentation/container/src/pageHooks/useRenderedPage.hook.ts
+++ b/libs/frontend/presentation/container/src/pageHooks/useRenderedPage.hook.ts
@@ -4,6 +4,7 @@ import type {
   IPropData,
   ITypeService,
   RendererType,
+  TypedProp,
 } from '@codelab/frontend/abstract/core'
 import {
   isComponentInstance,
@@ -12,7 +13,9 @@ import {
 } from '@codelab/frontend/abstract/core'
 import type { ProductionWebsiteProps } from '@codelab/frontend/abstract/types'
 import { PageType } from '@codelab/frontend/abstract/types'
+import { hasStateExpression } from '@codelab/frontend/shared/utils'
 import { PageKind } from '@codelab/shared/abstract/codegen'
+import { ITypeKind } from '@codelab/shared/abstract/core'
 import { useAsync } from '@react-hookz/web'
 import flatMap from 'lodash/flatMap'
 import isObject from 'lodash/isObject'
@@ -118,8 +121,12 @@ export const useRenderedPage = ({
   })
 }
 
+const hasComponentId = (prop: TypedProp): boolean =>
+  !hasStateExpression(prop.value) &&
+  [ITypeKind.ReactNodeType, ITypeKind.RenderPropType].includes(prop.kind)
+
 const getComponentIdsFromProp = (prop: IPropData): Array<string> =>
-  isTypedProp(prop)
+  isTypedProp(prop) && hasComponentId(prop)
     ? [prop.value]
     : isObject(prop)
     ? values(prop).flatMap((childProp) => getComponentIdsFromProp(childProp))

--- a/scripts/nx/reset-cache.sh
+++ b/scripts/nx/reset-cache.sh
@@ -16,16 +16,16 @@ for DIR in "${DIRS[@]}"
 do
   # Calculate size of directory
   SIZE=$(du -s $DIR | cut -f1)
-  SIZE_GB=$((SIZE / 1024 / 1024))
+  SIZE_MB=$((SIZE / 1024))
 
   # Check if size is greater than 2GB
-  if ((SIZE > 2 * 1024 * 1024)); then
-    echo "Directory $DIR is ${SIZE_GB}GB, deleting cache."
+  if ((SIZE > 1 * 1024 * 1024)); then
+    echo "Directory $DIR is ${SIZE_MB}MB, deleting cache."
 
     # Delete all except lockfile.hash, since it is used for cache key
     # find $DIR -maxdepth 1 -type f -not -name 'lockfile.hash' -delete
     npx nx reset
   else
-    echo "Directory $DIR is ${SIZE_GB}GB, keeping cache"
+    echo "Directory $DIR is ${SIZE_MB}MB, keeping cache"
   fi
 done


### PR DESCRIPTION
<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(libs-ui-component): must begin with lowercase` -->

## Description

<!-- This is a short description on the Pull Request -->
- The problem in `loadAllTypesForElements` was that `getComponentIdsFromProp` always returned ids of other entities like actions where it should return only component ids which made the loop to never end.  

## Video or Image

<!-- Add video or image showing how the new feature works -->

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged -->

Fixes #2735 
