### PR TITLE
default value issues

### DIFF
--- a/libs/frontend/domain/type/src/interface-form/fields/select-default-value/SelectDefaultValue.tsx
+++ b/libs/frontend/domain/type/src/interface-form/fields/select-default-value/SelectDefaultValue.tsx
@@ -8,6 +8,7 @@ import { Form } from '@codelab/frontend/presentation/view'
 import { PrimitiveTypeKind } from '@codelab/shared/abstract/codegen'
 import { ITypeKind } from '@codelab/shared/abstract/core'
 import type { Maybe } from '@codelab/shared/abstract/types'
+import { useAsync, useMountEffect } from '@react-hookz/web'
 import type { JSONSchemaType } from 'ajv'
 import isNil from 'lodash/isNil'
 import React, { useMemo } from 'react'
@@ -22,6 +23,14 @@ export interface SelectDefaultValueProps {
 export const SelectDefaultValue = ({
   typeService,
 }: SelectDefaultValueProps) => {
+  // Need to load the type if not loaded yet
+  // otherwise default value form will not be rendered
+  const [, getType] = useAsync(() =>
+    typeService.getAll(fieldType.value ? [fieldType.value] : []),
+  )
+
+  useMountEffect(getType.execute)
+
   const [fieldType, context] = useField<{ value?: string }>('fieldType', {})
 
   const [validationRules] = useField<{ value?: IValidationRules }>(


### PR DESCRIPTION
<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(libs-ui-component): must begin with lowercase` -->

## Description
Fixes the following problems with default values for types.

1. Default values form not shows up when adding a new field to the api
2.  ~~Default values not pre-populated when there's no value set for a field~~ (seems to be fixed in recent prs)
3. Default values are not added to the props as the value of the field. So field value (default value) is effectively useless unless updated.

<!-- This is a short description on the Pull Request -->

## Video or Image

<!-- Add video or image showing how the new feature works -->

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged -->

Fixes #2755 
