### PR TITLE
feat: implement preRenderAction and postRenderAction

### DIFF
--- a/libs/backend/infra/adapter/neo4j/src/resolver/pure-resolver/action/action.resolver.ts
+++ b/libs/backend/infra/adapter/neo4j/src/resolver/pure-resolver/action/action.resolver.ts
@@ -1,0 +1,8 @@
+import type { BaseAction } from '@codelab/shared/abstract/codegen'
+import type { IResolvers } from '@graphql-tools/utils'
+
+export const actionResolver: IResolvers = {
+  BaseAction: {
+    __resolveType: (action: BaseAction) => action.type,
+  },
+}

--- a/libs/backend/infra/adapter/neo4j/src/resolver/pure-resolver/action/index.ts
+++ b/libs/backend/infra/adapter/neo4j/src/resolver/pure-resolver/action/index.ts
@@ -1,0 +1,1 @@
+export * from './action.resolver'

--- a/libs/backend/infra/adapter/neo4j/src/resolver/pure-resolver/pure-resolvers.ts
+++ b/libs/backend/infra/adapter/neo4j/src/resolver/pure-resolver/pure-resolvers.ts
@@ -1,5 +1,6 @@
 import { mergeResolvers } from '@graphql-tools/merge'
 import type { IResolvers } from '@graphql-tools/utils'
+import { actionResolver } from './action'
 import { appResolver } from './app'
 import { domainResolver } from './domain'
 import { elementResolver } from './element'
@@ -8,6 +9,7 @@ import { typeResolver } from './type'
 
 export const pureResolvers: IResolvers = mergeResolvers([
   appResolver,
+  actionResolver,
   domainResolver,
   elementResolver,
   pageResolver,

--- a/libs/backend/infra/adapter/neo4j/src/schema/model/element.schema.ts
+++ b/libs/backend/infra/adapter/neo4j/src/schema/model/element.schema.ts
@@ -39,9 +39,9 @@ export const elementSchema = gql`
     renderIfExpression: String
 
     preRenderAction: BaseAction
-      @relationship(type: "ELEMENT_ACTION", direction: OUT)
+      @relationship(type: "PRE_RENDER_ELEMENT_ACTION", direction: OUT)
     postRenderAction: BaseAction
-      @relationship(type: "ELEMENT_ACTION", direction: OUT)
+      @relationship(type: "POST_RENDER_ELEMENT_ACTION", direction: OUT)
 
     # Type of element to render, could be either a component or atom
     renderComponentType: Component

--- a/libs/backend/infra/adapter/neo4j/src/selectionSet/element-selection-set.ts
+++ b/libs/backend/infra/adapter/neo4j/src/selectionSet/element-selection-set.ts
@@ -37,9 +37,11 @@ const baseElementSelectionSet = `
   propTransformationJs
   preRenderAction {
     id
+    type
   }
   postRenderAction {
     id
+    type
   }
 `
 

--- a/libs/frontend/abstract/core/src/domain/element/element.fragment.graphql
+++ b/libs/frontend/abstract/core/src/domain/element/element.fragment.graphql
@@ -40,9 +40,11 @@ fragment Element on Element {
   renderIfExpression
   preRenderAction {
     id
+    type
   }
   postRenderAction {
     id
+    type
   }
   propTransformationJs
 }

--- a/libs/frontend/abstract/core/src/domain/element/element.fragment.graphql.gen.ts
+++ b/libs/frontend/abstract/core/src/domain/element/element.fragment.graphql.gen.ts
@@ -26,8 +26,14 @@ export type ElementFragment = {
   parent?: { id: string } | null
   firstChild?: { id: string } | null
   props: PropFragment
-  preRenderAction?: { id: string } | { id: string } | null
-  postRenderAction?: { id: string } | { id: string } | null
+  preRenderAction?:
+    | { id: string; type: Types.ActionKind }
+    | { id: string; type: Types.ActionKind }
+    | null
+  postRenderAction?:
+    | { id: string; type: Types.ActionKind }
+    | { id: string; type: Types.ActionKind }
+    | null
 }
 
 export const ElementFragmentDoc = gql`
@@ -72,9 +78,11 @@ export const ElementFragmentDoc = gql`
     renderIfExpression
     preRenderAction {
       id
+      type
     }
     postRenderAction {
       id
+      type
     }
     propTransformationJs
   }

--- a/libs/frontend/abstract/core/src/domain/element/element.model.interface.ts
+++ b/libs/frontend/abstract/core/src/domain/element/element.model.interface.ts
@@ -12,6 +12,7 @@ import type {
 import type { Ref } from 'mobx-keystone'
 import type { ICacheService } from '../../service'
 import type { IElementTreeViewDataNode } from '../../ui'
+import type { IAction } from '../action'
 import type { IComponent } from '../component'
 import type { IHook } from '../hook'
 import type { IModel } from '../model.interface'
@@ -79,6 +80,8 @@ export interface IElement
   parent?: Nullable<Ref<IElement>>
   // component that this element belongs to
   parentComponent?: Nullable<Ref<IComponent>>
+  postRenderAction?: Nullable<Ref<IAction>>
+  preRenderAction?: Nullable<Ref<IAction>>
   prevSibling?: Nullable<Ref<IElement>>
   propTransformationJs: Nullable<string>
   props: Ref<IProp>

--- a/libs/frontend/domain/element/src/store/element.model.ts
+++ b/libs/frontend/domain/element/src/store/element.model.ts
@@ -1,4 +1,5 @@
 import type {
+  IAction,
   IAtom,
   IComponent,
   IElementRenderType,
@@ -13,6 +14,7 @@ import type {
   TransformPropsFn,
 } from '@codelab/frontend/abstract/core'
 import {
+  actionRef,
   componentRef,
   CssMap,
   DATA_ELEMENT_ID,
@@ -64,6 +66,8 @@ const create = ({
   page,
   parent,
   parentComponent,
+  postRenderAction,
+  preRenderAction,
   prevSibling,
   props,
   propTransformationJs,
@@ -85,6 +89,12 @@ const create = ({
 
     // parent of first child
     parent: parent?.id ? elementRef(parent.id) : undefined,
+    postRenderAction: postRenderAction?.id
+      ? actionRef(postRenderAction.id)
+      : undefined,
+    preRenderAction: preRenderAction?.id
+      ? actionRef(preRenderAction.id)
+      : undefined,
     prevSibling: prevSibling?.id ? elementRef(prevSibling.id) : undefined,
     props: propRef(props.id),
     propTransformationJs,
@@ -126,6 +136,8 @@ export class Element
 
     // Data used for tree initializing, before our Element model is ready
     parent: prop<Nullable<Ref<IElement>>>(null).withSetter(),
+    postRenderAction: prop<Nullable<Ref<IAction>>>(null).withSetter(),
+    preRenderAction: prop<Nullable<Ref<IAction>>>(null).withSetter(),
     prevSibling: prop<Nullable<Ref<IElement>>>(null).withSetter(),
     props: prop<Ref<IProp>>().withSetter(),
     propTransformationJs: prop<Nullable<string>>(null).withSetter(),
@@ -454,10 +466,20 @@ export class Element
       ? reconnectNodeId(this.renderType.id)
       : disconnectNodeId(undefined)
 
+    const preRenderAction = this.preRenderAction?.id
+      ? reconnectNodeId(this.preRenderAction.id)
+      : disconnectNodeId(undefined)
+
+    const postRenderAction = this.postRenderAction?.id
+      ? reconnectNodeId(this.postRenderAction.id)
+      : disconnectNodeId(undefined)
+
     return {
       customCss: this.customCss,
       guiCss: this.guiCss,
       name: this.name,
+      postRenderAction,
+      preRenderAction,
       propTransformationJs: this.propTransformationJs,
       renderAtomType,
       renderComponentType,
@@ -632,11 +654,12 @@ export class Element
     customCss,
     firstChild,
     guiCss,
-    id,
     name,
     nextSibling,
     parent,
     parentComponent,
+    postRenderAction,
+    preRenderAction,
     prevSibling,
     props,
     propTransformationJs,
@@ -668,6 +691,12 @@ export class Element
     this._parentComponent = parentComponent
       ? componentRef(parentComponent.id)
       : this._parentComponent
+    this.preRenderAction = preRenderAction
+      ? actionRef(preRenderAction.id)
+      : null
+    this.postRenderAction = postRenderAction
+      ? actionRef(postRenderAction.id)
+      : null
 
     return this
   }

--- a/libs/frontend/domain/element/src/use-cases/element/create-element/CreateElementForm.tsx
+++ b/libs/frontend/domain/element/src/use-cases/element/create-element/CreateElementForm.tsx
@@ -1,6 +1,9 @@
 import type { ICreateElementData } from '@codelab/frontend/abstract/core'
 import { isAtomInstance } from '@codelab/frontend/abstract/core'
-import { SelectAction, SelectAnyElement } from '@codelab/frontend/domain/type'
+import {
+  SelectActionField,
+  SelectAnyElement,
+} from '@codelab/frontend/domain/type'
 import { useStore } from '@codelab/frontend/presentation/container'
 import { Form, FormController } from '@codelab/frontend/presentation/view'
 import { createNotificationHandler } from '@codelab/frontend/shared/utils'
@@ -107,16 +110,8 @@ export const CreateElementForm = observer(() => {
         required={false}
       />
       <RenderTypeCompositeField name="renderType" parentAtom={parentAtom} />
-      <AutoField
-        component={SelectAction}
-        name="preRenderAction.id"
-        required={false}
-      />
-      <AutoField
-        component={SelectAction}
-        name="postRenderAction.id"
-        required={false}
-      />
+      <SelectActionField name="preRenderAction" />
+      <SelectActionField name="postRenderAction" />
       <Divider />
       <AutoComputedElementNameField label="Name" name="name" />
       <FormController onCancel={closeModal} submitLabel="Create Element" />

--- a/libs/frontend/domain/element/src/use-cases/element/create-element/create-element.schema.ts
+++ b/libs/frontend/domain/element/src/use-cases/element/create-element/create-element.schema.ts
@@ -42,7 +42,7 @@ export const createElementSchema: JSONSchemaType<
           type: 'string',
         },
       },
-      required: ['id'],
+      required: [],
       type: 'object',
     },
     preRenderAction: {
@@ -53,7 +53,7 @@ export const createElementSchema: JSONSchemaType<
           type: 'string',
         },
       },
-      required: ['id'],
+      required: [],
       type: 'object',
     },
     prevSibling: {

--- a/libs/frontend/domain/element/src/use-cases/element/update-element/UpdateElementForm.tsx
+++ b/libs/frontend/domain/element/src/use-cases/element/update-element/UpdateElementForm.tsx
@@ -7,7 +7,7 @@ import {
   DATA_COMPONENT_ID,
   DATA_ELEMENT_ID,
 } from '@codelab/frontend/abstract/core'
-import { SelectAction } from '@codelab/frontend/domain/type'
+import { SelectActionField } from '@codelab/frontend/domain/type'
 import {
   useCurrentPage,
   useStore,
@@ -105,8 +105,8 @@ export const UpdateElementForm = observer<UpdateElementFormProps>(
             .sort()
             .map((label) => ({ label, value: label }))}
         />
-        <AutoField component={SelectAction} name="preRenderAction.id" />
-        <AutoField component={SelectAction} name="postRenderAction.id" />
+        <SelectActionField name="preRenderAction" />
+        <SelectActionField name="postRenderAction" />
       </Form>
     )
   },

--- a/libs/frontend/domain/element/src/utils/get-element-model.ts
+++ b/libs/frontend/domain/element/src/utils/get-element-model.ts
@@ -26,8 +26,12 @@ export const getElementModel = (element: IElement) => {
   return {
     id: element.id,
     name: element.name,
-    postRenderAction: element.postRenderAction,
-    preRenderAction: element.preRenderAction,
+    postRenderAction: element.postRenderAction
+      ? { id: element.postRenderAction.current.id }
+      : null,
+    preRenderAction: element.preRenderAction
+      ? { id: element.preRenderAction.current.id }
+      : null,
     renderForEachPropKey: element.renderForEachPropKey,
     renderIfExpression: element.renderIfExpression,
     renderType,

--- a/libs/frontend/domain/element/src/utils/get-element-model.ts
+++ b/libs/frontend/domain/element/src/utils/get-element-model.ts
@@ -26,8 +26,8 @@ export const getElementModel = (element: IElement) => {
   return {
     id: element.id,
     name: element.name,
-    // postRenderAction: element.postRenderAction,
-    // preRenderAction: element.preRenderAction,
+    postRenderAction: element.postRenderAction,
+    preRenderAction: element.preRenderAction,
     renderForEachPropKey: element.renderForEachPropKey,
     renderIfExpression: element.renderIfExpression,
     renderType,

--- a/libs/frontend/domain/renderer/src/element/element-wrapper.ts
+++ b/libs/frontend/domain/renderer/src/element/element-wrapper.ts
@@ -38,9 +38,10 @@ export const ElementWrapper = observer<ElementWrapperProps>(
       }
 
       const actionRunnerId = getRunnerId(store.id, postRenderAction.id)
-      const preRenderActionRunner = renderer.actionRunners.get(actionRunnerId)
+      const postRenderActionRunner = renderer.actionRunners.get(actionRunnerId)
+      const runner = postRenderActionRunner?.runner.bind(store.current.state)
 
-      preRenderActionRunner?.runner()
+      runner?.()
     }, [])
 
     const { atomService } = useStore()

--- a/libs/frontend/domain/renderer/src/element/element-wrapper.ts
+++ b/libs/frontend/domain/renderer/src/element/element-wrapper.ts
@@ -1,11 +1,15 @@
 import type { IElement, IRenderer } from '@codelab/frontend/abstract/core'
-import { isAtomInstance, RendererType } from '@codelab/frontend/abstract/core'
+import {
+  getRunnerId,
+  isAtomInstance,
+  RendererType,
+} from '@codelab/frontend/abstract/core'
 import { useStore } from '@codelab/frontend/presentation/container'
 import { IAtomType } from '@codelab/shared/abstract/core'
 import { mergeProps } from '@codelab/shared/utils'
 import { jsx } from '@emotion/react'
 import { observer } from 'mobx-react-lite'
-import React from 'react'
+import React, { useEffect } from 'react'
 import { ErrorBoundary } from 'react-error-boundary'
 import { shouldRenderElement } from '../utils'
 import { mapOutput } from '../utils/render-output-utils'
@@ -26,6 +30,19 @@ export interface ElementWrapperProps {
  */
 export const ElementWrapper = observer<ElementWrapperProps>(
   ({ element, renderer, ...rest }) => {
+    useEffect(() => {
+      const { postRenderAction, store } = element
+
+      if (!postRenderAction) {
+        return
+      }
+
+      const actionRunnerId = getRunnerId(store.id, postRenderAction.id)
+      const preRenderActionRunner = renderer.actionRunners.get(actionRunnerId)
+
+      preRenderActionRunner?.runner()
+    }, [])
+
     const { atomService } = useStore()
     // Render the element to an intermediate output
     const renderOutputs = renderer.renderIntermediateElement(element)

--- a/libs/frontend/domain/renderer/src/renderer.model.ts
+++ b/libs/frontend/domain/renderer/src/renderer.model.ts
@@ -16,6 +16,7 @@ import {
   elementRef,
   elementTreeRef,
   getRendererId,
+  getRunnerId,
   IElement,
   IPageNodeRef,
   isAtomInstance,
@@ -168,6 +169,15 @@ export class Renderer
       element,
       key: `element-wrapper-${element.id}`,
       renderer: this,
+    }
+
+    const { preRenderAction, store } = element
+
+    if (preRenderAction) {
+      const actionRunnerId = getRunnerId(store.id, preRenderAction.id)
+      const preRenderActionRunner = this.actionRunners.get(actionRunnerId)
+
+      preRenderActionRunner?.runner()
     }
 
     return React.createElement(ElementWrapper, wrapperProps)

--- a/libs/frontend/domain/renderer/src/renderer.model.ts
+++ b/libs/frontend/domain/renderer/src/renderer.model.ts
@@ -176,8 +176,9 @@ export class Renderer
     if (preRenderAction) {
       const actionRunnerId = getRunnerId(store.id, preRenderAction.id)
       const preRenderActionRunner = this.actionRunners.get(actionRunnerId)
+      const runner = preRenderActionRunner?.runner.bind(store.current.state)
 
-      preRenderActionRunner?.runner()
+      runner?.()
     }
 
     return React.createElement(ElementWrapper, wrapperProps)

--- a/libs/frontend/domain/type/src/interface-form/fields/select-action/SelectAction.tsx
+++ b/libs/frontend/domain/type/src/interface-form/fields/select-action/SelectAction.tsx
@@ -6,8 +6,10 @@ import { SelectField } from 'uniforms-antd'
 
 export type SelectActionProps = Pick<
   UniformSelectFieldProps,
-  'error' | 'label' | 'name'
->
+  'error' | 'label' | 'name' | 'required' | 'value'
+> & {
+  onChange(value: unknown): void
+}
 
 export const SelectAction = (fieldProps: SelectActionProps) => {
   const { actionService, builderService } = useStore()

--- a/libs/frontend/domain/type/src/interface-form/fields/select-action/SelectActionField.tsx
+++ b/libs/frontend/domain/type/src/interface-form/fields/select-action/SelectActionField.tsx
@@ -1,0 +1,22 @@
+/* eslint-disable react/jsx-props-no-spreading */
+import type { IEntity, Nullable } from '@codelab/shared/abstract/types'
+import React from 'react'
+import type { GuaranteedProps } from 'uniforms'
+import { connectField } from 'uniforms'
+import { SelectAction } from './SelectAction'
+
+export const SelectActionField = connectField(
+  (fieldProps: GuaranteedProps<Nullable<IEntity>>) => {
+    return (
+      <SelectAction
+        {...fieldProps}
+        name="id"
+        onChange={(value) =>
+          fieldProps.onChange((value ? { id: value } : null) as IEntity)
+        }
+        required={false}
+        value={fieldProps.value?.id}
+      />
+    )
+  },
+)

--- a/libs/frontend/domain/type/src/interface-form/fields/select-action/index.ts
+++ b/libs/frontend/domain/type/src/interface-form/fields/select-action/index.ts
@@ -1,1 +1,2 @@
 export * from './SelectAction'
+export * from './SelectActionField'

--- a/libs/frontend/domain/type/src/interface-form/ui-properties/action-type-ui-properties.ts
+++ b/libs/frontend/domain/type/src/interface-form/ui-properties/action-type-ui-properties.ts
@@ -17,7 +17,12 @@ export const actionTypeUiProperties: UiPropertiesFn<IActionType> = () => {
     uniforms: {
       component: ToggleExpressionField({
         getBaseControl: (fieldProps) =>
-          SelectAction({ ...fieldProps, label: null, name: '' }),
+          SelectAction({
+            ...fieldProps,
+            label: null,
+            name: '',
+            value: fieldProps.value as string,
+          }),
         onToggle: (showExpression, { field, onChange }, lastValue) => {
           if (showExpression) {
             onChange(lastValue ?? ACTION_TEMPLATE)

--- a/libs/shared/abstract/codegen/src/types.api.graphql.gen.ts
+++ b/libs/shared/abstract/codegen/src/types.api.graphql.gen.ts
@@ -21816,12 +21816,12 @@ export type ElementFragment = {
   firstChild?: { __typename?: 'Element'; id: string } | null
   props: { __typename?: 'Prop' } & PropFragment
   preRenderAction?:
-    | { __typename?: 'ApiAction'; id: string }
-    | { __typename?: 'CodeAction'; id: string }
+    | { __typename?: 'ApiAction'; id: string; type: ActionKind }
+    | { __typename?: 'CodeAction'; id: string; type: ActionKind }
     | null
   postRenderAction?:
-    | { __typename?: 'ApiAction'; id: string }
-    | { __typename?: 'CodeAction'; id: string }
+    | { __typename?: 'ApiAction'; id: string; type: ActionKind }
+    | { __typename?: 'CodeAction'; id: string; type: ActionKind }
     | null
 }
 


### PR DESCRIPTION
<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(libs-ui-component): must begin with lowercase` -->

## Description

Implemented preRenderAction (executed in `renderElement` before element is starting to render) and postRenderAction (executed in `useEffect` with `[]`).

<!-- This is a short description on the Pull Request -->

## Video or Image

<!-- Add video or image showing how the new feature works -->

https://github.com/codelab-app/platform/assets/74900868/2ce554d8-4992-4ad3-ac26-90624dd2621c

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged -->

Fixes #2738 
