### PR TITLE
fix: attach new actions to corresponding stores

### DIFF
--- a/libs/frontend/domain/store/src/store/action.service.ts
+++ b/libs/frontend/domain/store/src/store/action.service.ts
@@ -1,10 +1,11 @@
-import type {
-  IAction,
-  IActionDTO,
-  IActionService,
-  IActionWhere,
-  ICreateActionData,
-  IUpdateActionData,
+import {
+  actionRef,
+  type IAction,
+  type IActionDTO,
+  type IActionService,
+  type IActionWhere,
+  type ICreateActionData,
+  type IUpdateActionData,
 } from '@codelab/frontend/abstract/core'
 import { getPropService } from '@codelab/frontend/domain/prop'
 import { getTypeService } from '@codelab/frontend/domain/type'
@@ -106,6 +107,9 @@ export class ActionService
   @transaction
   create = _async(function* (this: ActionService, data: ICreateActionData) {
     const action = this.add(ActionFactory.mapDataToDTO(data))
+    const store = action.store.current
+
+    store.actions.push(actionRef(action))
 
     if (data.type === IActionKind.ApiAction) {
       this.propService.add({

--- a/libs/frontend/presentation/codelab-ui/src/views/CuiCollapse/CuiCollapse.tsx
+++ b/libs/frontend/presentation/codelab-ui/src/views/CuiCollapse/CuiCollapse.tsx
@@ -41,7 +41,7 @@ export const CuiCollapse = ({
     <div className="flex h-full w-full flex-col overflow-y-auto overflow-x-hidden">
       <div className="flex h-full w-full flex-col py-1">
         {panels.map((view) => (
-          <>
+          <React.Fragment key={view.key}>
             <CuiCollapsePanelHeader
               defaultExpand={activePanels[view.key]}
               label={view.label}
@@ -52,11 +52,10 @@ export const CuiCollapse = ({
               <CuiCollapsePanelContent
                 content={view.content}
                 isLoading={view.isLoading}
-                key={view.key}
                 label={view.label}
               />
             )}
-          </>
+          </React.Fragment>
         ))}
       </div>
     </div>

--- a/libs/frontend/presentation/codelab-ui/src/views/CuiCollapse/CuiCollapsePanelContent.tsx
+++ b/libs/frontend/presentation/codelab-ui/src/views/CuiCollapse/CuiCollapsePanelContent.tsx
@@ -4,21 +4,18 @@ import { CuiSkeletonWrapper } from '../../components'
 export interface CuiCollapsePanelContentProps {
   content: React.ReactNode
   isLoading?: boolean
-  key: string
   label: string
 }
 
 export const CuiCollapsePanelContent = ({
   content,
   isLoading = false,
-  key,
   label,
 }: CuiCollapsePanelContentProps) => {
   return (
     <div
       className="flex h-full min-h-1/3 w-full flex-col overflow-auto bg-white"
       data-cy={`codelabui-sidebar-view-content-${label}`}
-      key={key}
     >
       <div className="w-full flex-1 overflow-auto">
         <CuiSkeletonWrapper isLoading={isLoading}>{content}</CuiSkeletonWrapper>

--- a/libs/frontend/presentation/codelab-ui/src/views/CuiSidebarToolbar/CuiSidebarToolbarItem.tsx
+++ b/libs/frontend/presentation/codelab-ui/src/views/CuiSidebarToolbar/CuiSidebarToolbarItem.tsx
@@ -6,13 +6,12 @@ type CuiSidebarToolbarItemProps = Omit<ToolbarItem, 'label'>
 
 export const CuiSidebarToolbarItem = ({
   icon,
-  key,
   onClick,
   title,
 }: CuiSidebarToolbarItemProps) => {
   return (
     <div className="h-full w-full" data-cy={`codelabui-toolbar-item-${title}`}>
-      <Tooltip key={key} title={title}>
+      <Tooltip title={title}>
         <div className="flex flex-col items-center p-1" onClick={onClick}>
           {icon}
         </div>

--- a/libs/frontend/presentation/codelab-ui/src/views/CuiTree/CuiTreeItemToolbar/CuiTreeItemToolbarItem.tsx
+++ b/libs/frontend/presentation/codelab-ui/src/views/CuiTree/CuiTreeItemToolbar/CuiTreeItemToolbarItem.tsx
@@ -6,13 +6,12 @@ type CuiTreeItemToolbarItemProps = Omit<ToolbarItem, 'label'>
 
 export const CuiTreeItemToolbarItem = ({
   icon,
-  key,
   onClick,
   title,
 }: CuiTreeItemToolbarItemProps) => {
   return (
     <div className="h-full w-full" data-cy={`codelabui-toolbar-item-${title}`}>
-      <Tooltip key={key} title={title}>
+      <Tooltip title={title}>
         <div className="flex flex-col items-center p-1" onClick={onClick}>
           {icon}
         </div>


### PR DESCRIPTION
<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(libs-ui-component): must begin with lowercase` -->

## Description
- When new action was created - it was not attached to corresponding store and as a result it did not show up in sidebar "Actions" panel
- Also fixed a couple of script errors related to missing "key" attribute

## Video or Image

<!-- Add video or image showing how the new feature works -->


https://github.com/codelab-app/platform/assets/74900868/5cce008c-a34a-42c2-938f-f292ad04263b



## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged -->

Fixes #2765 
