### PR TITLE
fix: caching decorators after TS version change

### DIFF
--- a/libs/frontend/domain/app/src/services/app.repo.ts
+++ b/libs/frontend/domain/app/src/services/app.repo.ts
@@ -1,6 +1,7 @@
-import type { IApp, IAppRepository } from '@codelab/frontend/abstract/core'
+import type { IAppRepository } from '@codelab/frontend/abstract/core'
+import { IApp } from '@codelab/frontend/abstract/core'
 import { cachedWithTTL, clearCacheForKey } from '@codelab/frontend/shared/utils'
-import type { AppOptions, AppWhere } from '@codelab/shared/abstract/codegen'
+import { AppOptions, AppWhere } from '@codelab/shared/abstract/codegen'
 import { Model, model } from 'mobx-keystone'
 import { appApi } from '../store'
 
@@ -16,7 +17,7 @@ export class AppRepository extends Model({}) implements IAppRepository {
     return apps[0]!
   }
 
-  // @clearCacheForKey('apps')
+  @clearCacheForKey('apps')
   async update(app: IApp) {
     const {
       updateApps: { apps },
@@ -28,12 +29,12 @@ export class AppRepository extends Model({}) implements IAppRepository {
     return apps[0]!
   }
 
-  // @cachedWithTTL('apps')
+  @cachedWithTTL('apps')
   async find(where?: AppWhere, options?: AppOptions) {
     return await appApi.GetApps({ options, where })
   }
 
-  // @clearCacheForKey('apps')
+  @clearCacheForKey('apps')
   async delete(apps: Array<IApp>) {
     const {
       deleteApps: { nodesDeleted },

--- a/libs/frontend/domain/atom/src/store/atom.repo.ts
+++ b/libs/frontend/domain/atom/src/store/atom.repo.ts
@@ -1,74 +1,63 @@
-import type { IAtom, IAtomRepository } from '@codelab/frontend/abstract/core'
-import { filterNotHookType } from '@codelab/frontend/abstract/core'
-import type { AtomOptions, AtomWhere } from '@codelab/shared/abstract/codegen'
+import type { IAtomRepository } from '@codelab/frontend/abstract/core'
+import { filterNotHookType, IAtom } from '@codelab/frontend/abstract/core'
+import { cachedWithTTL, clearCacheForKey } from '@codelab/frontend/shared/utils'
+import { AtomOptions, AtomWhere } from '@codelab/shared/abstract/codegen'
 import sortBy from 'lodash/sortBy'
-import { _async, _await, Model, model, modelFlow } from 'mobx-keystone'
+import { Model, model } from 'mobx-keystone'
 import { atomApi } from './atom.api'
 
 // atoms are part of the system and they unlikely to change often,
 // so we can cache them until the page is refreshed using Infinity as the TTL
 @model('@codelab/AtomRepository')
 export class AtomRepository extends Model({}) implements IAtomRepository {
-  @modelFlow
-  // @clearCacheForKey('atoms')
-  add = _async(function* (this: AtomRepository, atom: IAtom) {
+  @clearCacheForKey('atoms')
+  async add(this: AtomRepository, atom: IAtom) {
     const {
       createAtoms: { atoms },
-    } = yield* _await(atomApi.CreateAtoms({ input: [atom.toCreateInput()] }))
+    } = await atomApi.CreateAtoms({ input: [atom.toCreateInput()] })
 
     return atoms[0]
-  })
+  }
 
-  @modelFlow
-  // @clearCacheForKey('atoms')
-  update = _async(function* (this: AtomRepository, atom: IAtom) {
+  @clearCacheForKey('atoms')
+  async update(this: AtomRepository, atom: IAtom) {
     const {
       updateAtoms: { atoms },
-    } = yield* _await(
-      atomApi.UpdateAtoms({
-        update: atom.toUpdateInput(),
-        where: { id: atom.id },
-      }),
-    )
+    } = await atomApi.UpdateAtoms({
+      update: atom.toUpdateInput(),
+      where: { id: atom.id },
+    })
 
     return atoms[0]!
-  })
+  }
 
-  @modelFlow
-  // @cachedWithTTL('atoms', Infinity)
-  find = _async(function* (
-    this: AtomRepository,
-    where?: AtomWhere,
-    options?: AtomOptions,
-  ) {
-    return yield* _await(atomApi.GetAtoms({ options, where }))
-  })
+  @cachedWithTTL('atoms', Infinity)
+  async find(this: AtomRepository, where?: AtomWhere, options?: AtomOptions) {
+    return await atomApi.GetAtoms({ options, where })
+  }
 
-  @modelFlow
-  // @clearCacheForKey('atoms')
-  delete = _async(function* (this: AtomRepository, atoms: Array<IAtom>) {
+  @clearCacheForKey('atoms')
+  async delete(this: AtomRepository, atoms: Array<IAtom>) {
     const {
       deleteAtoms: { nodesDeleted },
-    } = yield* _await(
-      atomApi.DeleteAtoms({
-        where: { id_IN: atoms.map(({ id }) => id) },
-      }),
-    )
+    } = await atomApi.DeleteAtoms({
+      where: { id_IN: atoms.map(({ id }) => id) },
+    })
 
     return nodesDeleted
-  })
+  }
 
   /**
    * Get list of atom previews for select dropdown
    */
-  @modelFlow
-  // @cachedWithTTL('atoms', Infinity)
-  findOptions = _async(function* (this: AtomRepository) {
-    const { atoms } = yield* _await(atomApi.GetAtomOptions())
+
+  @cachedWithTTL('atoms', Infinity)
+  async findOptions(this: AtomRepository) {
+    const { atoms } = await atomApi.GetAtomOptions()
 
     return sortBy(
       atoms.filter(({ type }) => filterNotHookType(type)),
       'name',
     )
-  })
+  }
 }

--- a/libs/frontend/domain/resource/src/store/resource.repo.ts
+++ b/libs/frontend/domain/resource/src/store/resource.repo.ts
@@ -1,9 +1,7 @@
-import type {
-  IResource,
-  IResourceRepository,
-} from '@codelab/frontend/abstract/core'
+import type { IResourceRepository } from '@codelab/frontend/abstract/core'
+import { IResource } from '@codelab/frontend/abstract/core'
 import { cachedWithTTL, clearCacheForKey } from '@codelab/frontend/shared/utils'
-import type {
+import {
   ResourceOptions,
   ResourceWhere,
 } from '@codelab/shared/abstract/codegen'
@@ -15,13 +13,13 @@ export class ResourceRepository
   extends Model({})
   implements IResourceRepository
 {
-  // @cachedWithTTL('resources')
-  find = async (where?: ResourceWhere, options?: ResourceOptions) => {
+  @cachedWithTTL('resources')
+  async find(where?: ResourceWhere, options?: ResourceOptions) {
     return await resourceApi.GetResources({ options, where })
   }
 
-  // @clearCacheForKey('resources')
-  add = async (resource: IResource) => {
+  @clearCacheForKey('resources')
+  async add(resource: IResource) {
     const {
       createResources: { resources },
     } = await resourceApi.CreateResources({ input: [resource.toCreateInput()] })
@@ -29,8 +27,8 @@ export class ResourceRepository
     return resources[0]!
   }
 
-  // @clearCacheForKey('resources')
-  update = async (resource: IResource) => {
+  @clearCacheForKey('resources')
+  async update(resource: IResource) {
     const {
       updateResources: { resources },
     } = await resourceApi.UpdateResource({
@@ -41,8 +39,8 @@ export class ResourceRepository
     return resources[0]!
   }
 
-  // @clearCacheForKey('resources')
-  delete = async (resources: Array<IResource>) => {
+  @clearCacheForKey('resources')
+  async delete(resources: Array<IResource>) {
     const {
       deleteResources: { nodesDeleted },
     } = await resourceApi.DeleteResources({


### PR DESCRIPTION
<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(libs-ui-component): must begin with lowercase` -->

## Description
Fix caching decorators to match the newer TS version, as a result, they became more compact and a bit simpler.
Also removed the `modelFlow` decorator from API methods, since they do not alter store.

## Video or Image

<!-- Add video or image showing how the new feature works -->

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged -->

Fixes #2638 
