### PR TITLE
fix: load descendant page elements on app load

### DIFF
--- a/libs/frontend/domain/app/src/store/app.service.ts
+++ b/libs/frontend/domain/app/src/store/app.service.ts
@@ -179,7 +179,12 @@ export class AppService
        * Pages
        */
       appData.pages.forEach((pageData) => {
-        this.elementService.add(pageData.rootElement)
+        const pageElements = [
+          pageData.rootElement,
+          ...pageData.rootElement.descendantElements,
+        ]
+
+        pageElements.map((element) => this.elementService.add(element))
 
         this.storeService.load([pageData.store])
 


### PR DESCRIPTION
<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(libs-ui-component): must begin with lowercase` -->

## Description

The issue was that `loadAppsWithNestedPreviews` did not load descendant elements to the store and when the app was deleted - an error was thrown on an attempt to iterate over all page descendant elements because it could not resolve refs.
As a solution - `loadAppsWithNestedPreviews` is updated to load all elements to store, to keep the state valid and avoid script errors about unresolved refs

## Video or Image

Stable steps to reproduce issue



https://github.com/codelab-app/platform/assets/74900868/6873fc5a-d7ff-49ad-9b53-1a1534e8367e



After the fix



https://github.com/codelab-app/platform/assets/74900868/3cde88d2-8cb9-4f92-82bc-040c56dc4e5a





## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged -->

Fixes #2782 
