### PR TITLE
fix: child mapper rendering with filtered data

### DIFF
--- a/libs/frontend/domain/prop/src/store/prop.model.ts
+++ b/libs/frontend/domain/prop/src/store/prop.model.ts
@@ -12,6 +12,8 @@ import type { IPropDTO } from '@codelab/shared/abstract/core'
 import type { Nullable } from '@codelab/shared/abstract/types'
 import { mergeProps, propSafeStringify } from '@codelab/shared/utils'
 import get from 'lodash/get'
+import isMatch from 'lodash/isMatch'
+import isNil from 'lodash/isNil'
 import merge from 'lodash/merge'
 import omit from 'lodash/omit'
 import omitBy from 'lodash/omitBy'
@@ -109,7 +111,13 @@ export class Prop
 
   @modelAction
   setMany(data: IPropData) {
-    this.data = frozen(mergeProps(this.data.data, data))
+    // This prevents re-renders caused by setting props with the same values
+    const shouldChangeProp =
+      isNil(this.data.data) || !isMatch(this.data.data, data)
+
+    if (shouldChangeProp) {
+      this.data = frozen(mergeProps(this.data.data, data))
+    }
   }
 
   @modelAction

--- a/libs/frontend/domain/renderer/src/element-runtime-props.model.ts
+++ b/libs/frontend/domain/renderer/src/element-runtime-props.model.ts
@@ -105,11 +105,19 @@ export class ElementRuntimeProps
     }
 
     if (hasStateExpression(this.node.childMapperPropKey)) {
-      return evaluateExpression(
+      const evaluatedExpression = evaluateExpression(
         this.node.childMapperPropKey,
         this.node.store.current.state,
         injectedProps,
       )
+
+      if (!Array.isArray(evaluatedExpression)) {
+        console.error('The evaluated childMapperPropKey is not an array')
+
+        return []
+      }
+
+      return evaluatedExpression
     }
 
     const allPropsOptions = mergeProps(this.node.store.current.state, {

--- a/libs/frontend/domain/renderer/src/renderer.model.ts
+++ b/libs/frontend/domain/renderer/src/renderer.model.ts
@@ -244,10 +244,11 @@ export class Renderer
 
         const rootElement = clonedComponent.rootElement.current
 
+        clonedComponent.props.current.setMany(
+          isObject(propValue) ? propValue : { value: propValue },
+        )
+
         if (!this.runtimeProps.get(clonedComponent.id)) {
-          clonedComponent.props.current.setMany(
-            isObject(propValue) ? propValue : { value: propValue },
-          )
           this.addRuntimeProps(componentRef(clonedComponent.id))
         }
 

--- a/libs/frontend/shared/utils/src/try-parse.ts
+++ b/libs/frontend/shared/utils/src/try-parse.ts
@@ -6,6 +6,7 @@ export const tryParse = (str: Nullish<string>) => {
   } catch (error) {
     console.log(error)
 
-    return str
+    // to prevent passing wrong value since the expected output is a parsed JSON
+    return undefined
   }
 }


### PR DESCRIPTION
<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(libs-ui-component): must begin with lowercase` -->

## Description

<!-- This is a short description on the Pull Request -->
This is for being able to render the component from the child mapper with filtering logic. The filtering logic could be from via action code or a REST endpoint with query for filtering
- [x] Filtering via code action
- [x] Passing a state value to a REST action in the queryParams

Fixed:
- cached prop data issue for the component instances that got rendered after filtering
- evaluating the rest api config with the state expressions


## Video or Image

<!-- Add video or image showing how the new feature works -->

Demo: All products are fetched via pre-render action and only called once. The filtering is done via code actions so theres no extra calls

https://github.com/codelab-app/platform/assets/27695022/c5aab808-3955-4386-bb97-e33a7aa14b4c

<br />

Demo: Products are filtered via passing a query param `name` to the API endpoint.

https://github.com/codelab-app/platform/assets/27695022/52b4e410-de82-4703-953d-901d1a6088d3

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged -->

Fixes #2784 
