### PR TITLE
fix: use "false" instead of undefined as default value for boolean prop 

### DIFF
--- a/libs/frontend/domain/type/src/interface-form/type-schema.factory.ts
+++ b/libs/frontend/domain/type/src/interface-form/type-schema.factory.ts
@@ -231,10 +231,13 @@ export class TypeSchemaFactory {
         }
         break
       case PrimitiveTypeKind.Boolean:
-        rulesSchema =
-          typeof context?.defaultValues === 'boolean'
-            ? { default: context.defaultValues }
-            : {}
+        rulesSchema = {
+          default:
+            typeof context?.defaultValues === 'boolean'
+              ? context.defaultValues
+              : false,
+        }
+
         break
     }
 


### PR DESCRIPTION
<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(libs-ui-component): must begin with lowercase` -->

## Description
It was not possible to add boolean field before, because default value for it was "undefined" but it was required by ajv schema. As a result the form was not submited and validation error was shown (see video in the github issue). As a solution - for boolean props used default "false" value instead of "undefined"

## Video or Image

https://github.com/codelab-app/platform/assets/74900868/3aeabf4f-2f93-47d9-9595-a5449e3424ad

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged -->

Fixes #2764 
