### PR TITLE
feat: move child mapper instances around

### DIFF
--- a/libs/backend/abstract/codegen/src/ogm-types.gen.ts
+++ b/libs/backend/abstract/codegen/src/ogm-types.gen.ts
@@ -3984,6 +3984,8 @@ export type Element = {
   parentComponentAggregate?: Maybe<ElementComponentParentComponentAggregationSelection>
   childMapperComponent?: Maybe<Component>
   childMapperComponentAggregate?: Maybe<ElementComponentChildMapperComponentAggregationSelection>
+  childMapperPreviousSibling?: Maybe<Element>
+  childMapperPreviousSiblingAggregate?: Maybe<ElementElementChildMapperPreviousSiblingAggregationSelection>
   preRenderAction?: Maybe<BaseAction>
   postRenderAction?: Maybe<BaseAction>
   renderComponentType?: Maybe<Component>
@@ -3998,6 +4000,7 @@ export type Element = {
   propsConnection: ElementPropsConnection
   parentComponentConnection: ElementParentComponentConnection
   childMapperComponentConnection: ElementChildMapperComponentConnection
+  childMapperPreviousSiblingConnection: ElementChildMapperPreviousSiblingConnection
   preRenderActionConnection: ElementPreRenderActionConnection
   postRenderActionConnection: ElementPostRenderActionConnection
   renderComponentTypeConnection: ElementRenderComponentTypeConnection
@@ -4089,6 +4092,17 @@ export type ElementChildMapperComponentArgs = {
 
 export type ElementChildMapperComponentAggregateArgs = {
   where?: InputMaybe<ComponentWhere>
+  directed?: InputMaybe<Scalars['Boolean']>
+}
+
+export type ElementChildMapperPreviousSiblingArgs = {
+  where?: InputMaybe<ElementWhere>
+  options?: InputMaybe<ElementOptions>
+  directed?: InputMaybe<Scalars['Boolean']>
+}
+
+export type ElementChildMapperPreviousSiblingAggregateArgs = {
+  where?: InputMaybe<ElementWhere>
   directed?: InputMaybe<Scalars['Boolean']>
 }
 
@@ -4190,6 +4204,14 @@ export type ElementChildMapperComponentConnectionArgs = {
   sort?: InputMaybe<Array<ElementChildMapperComponentConnectionSort>>
 }
 
+export type ElementChildMapperPreviousSiblingConnectionArgs = {
+  where?: InputMaybe<ElementChildMapperPreviousSiblingConnectionWhere>
+  first?: InputMaybe<Scalars['Int']>
+  after?: InputMaybe<Scalars['String']>
+  directed?: InputMaybe<Scalars['Boolean']>
+  sort?: InputMaybe<Array<ElementChildMapperPreviousSiblingConnectionSort>>
+}
+
 export type ElementPreRenderActionConnectionArgs = {
   where?: InputMaybe<ElementPreRenderActionConnectionWhere>
   first?: InputMaybe<Scalars['Int']>
@@ -4264,6 +4286,19 @@ export type ElementChildMapperComponentRelationship = {
   node: Component
 }
 
+export type ElementChildMapperPreviousSiblingConnection = {
+  __typename?: 'ElementChildMapperPreviousSiblingConnection'
+  edges: Array<ElementChildMapperPreviousSiblingRelationship>
+  totalCount: Scalars['Int']
+  pageInfo: PageInfo
+}
+
+export type ElementChildMapperPreviousSiblingRelationship = {
+  __typename?: 'ElementChildMapperPreviousSiblingRelationship'
+  cursor: Scalars['String']
+  node: Element
+}
+
 export type ElementComponentChildMapperComponentAggregationSelection = {
   __typename?: 'ElementComponentChildMapperComponentAggregationSelection'
   count: Scalars['Int']
@@ -4307,6 +4342,24 @@ export type ElementEdge = {
   __typename?: 'ElementEdge'
   cursor: Scalars['String']
   node: Element
+}
+
+export type ElementElementChildMapperPreviousSiblingAggregationSelection = {
+  __typename?: 'ElementElementChildMapperPreviousSiblingAggregationSelection'
+  count: Scalars['Int']
+  node?: Maybe<ElementElementChildMapperPreviousSiblingNodeAggregateSelection>
+}
+
+export type ElementElementChildMapperPreviousSiblingNodeAggregateSelection = {
+  __typename?: 'ElementElementChildMapperPreviousSiblingNodeAggregateSelection'
+  id: IdAggregateSelectionNonNullable
+  name: StringAggregateSelectionNonNullable
+  customCss: StringAggregateSelectionNullable
+  guiCss: StringAggregateSelectionNullable
+  propTransformationJs: StringAggregateSelectionNullable
+  childMapperPropKey: StringAggregateSelectionNullable
+  renderForEachPropKey: StringAggregateSelectionNullable
+  renderIfExpression: StringAggregateSelectionNullable
 }
 
 export type ElementElementFirstChildAggregationSelection = {
@@ -16548,6 +16601,479 @@ export type ElementChildMapperComponentUpdateFieldInput = {
   connectOrCreate?: InputMaybe<ElementChildMapperComponentConnectOrCreateFieldInput>
 }
 
+export type ElementChildMapperPreviousSiblingAggregateInput = {
+  count?: InputMaybe<Scalars['Int']>
+  count_LT?: InputMaybe<Scalars['Int']>
+  count_LTE?: InputMaybe<Scalars['Int']>
+  count_GT?: InputMaybe<Scalars['Int']>
+  count_GTE?: InputMaybe<Scalars['Int']>
+  AND?: InputMaybe<Array<ElementChildMapperPreviousSiblingAggregateInput>>
+  OR?: InputMaybe<Array<ElementChildMapperPreviousSiblingAggregateInput>>
+  NOT?: InputMaybe<ElementChildMapperPreviousSiblingAggregateInput>
+  node?: InputMaybe<ElementChildMapperPreviousSiblingNodeAggregationWhereInput>
+}
+
+export type ElementChildMapperPreviousSiblingConnectFieldInput = {
+  where?: InputMaybe<ElementConnectWhere>
+  connect?: InputMaybe<ElementConnectInput>
+  /** Whether or not to overwrite any matching relationship with the new properties. Will default to `false` in 4.0.0. */
+  overwrite?: Scalars['Boolean']
+}
+
+export type ElementChildMapperPreviousSiblingConnectionSort = {
+  node?: InputMaybe<ElementSort>
+}
+
+export type ElementChildMapperPreviousSiblingConnectionWhere = {
+  AND?: InputMaybe<Array<ElementChildMapperPreviousSiblingConnectionWhere>>
+  OR?: InputMaybe<Array<ElementChildMapperPreviousSiblingConnectionWhere>>
+  NOT?: InputMaybe<ElementChildMapperPreviousSiblingConnectionWhere>
+  node?: InputMaybe<ElementWhere>
+  /** @deprecated Negation filters will be deprecated, use the NOT operator to achieve the same behavior */
+  node_NOT?: InputMaybe<ElementWhere>
+}
+
+export type ElementChildMapperPreviousSiblingConnectOrCreateFieldInput = {
+  where: ElementConnectOrCreateWhere
+  onCreate: ElementChildMapperPreviousSiblingConnectOrCreateFieldInputOnCreate
+}
+
+export type ElementChildMapperPreviousSiblingConnectOrCreateFieldInputOnCreate =
+  {
+    node: ElementOnCreateInput
+  }
+
+export type ElementChildMapperPreviousSiblingCreateFieldInput = {
+  node: ElementCreateInput
+}
+
+export type ElementChildMapperPreviousSiblingDeleteFieldInput = {
+  where?: InputMaybe<ElementChildMapperPreviousSiblingConnectionWhere>
+  delete?: InputMaybe<ElementDeleteInput>
+}
+
+export type ElementChildMapperPreviousSiblingDisconnectFieldInput = {
+  where?: InputMaybe<ElementChildMapperPreviousSiblingConnectionWhere>
+  disconnect?: InputMaybe<ElementDisconnectInput>
+}
+
+export type ElementChildMapperPreviousSiblingFieldInput = {
+  create?: InputMaybe<ElementChildMapperPreviousSiblingCreateFieldInput>
+  connect?: InputMaybe<ElementChildMapperPreviousSiblingConnectFieldInput>
+  connectOrCreate?: InputMaybe<ElementChildMapperPreviousSiblingConnectOrCreateFieldInput>
+}
+
+export type ElementChildMapperPreviousSiblingNodeAggregationWhereInput = {
+  AND?: InputMaybe<
+    Array<ElementChildMapperPreviousSiblingNodeAggregationWhereInput>
+  >
+  OR?: InputMaybe<
+    Array<ElementChildMapperPreviousSiblingNodeAggregationWhereInput>
+  >
+  NOT?: InputMaybe<ElementChildMapperPreviousSiblingNodeAggregationWhereInput>
+  /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
+  id_EQUAL?: InputMaybe<Scalars['ID']>
+  /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
+  name_EQUAL?: InputMaybe<Scalars['String']>
+  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
+  name_AVERAGE_EQUAL?: InputMaybe<Scalars['Float']>
+  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
+  name_LONGEST_EQUAL?: InputMaybe<Scalars['Int']>
+  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
+  name_SHORTEST_EQUAL?: InputMaybe<Scalars['Int']>
+  name_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars['Float']>
+  name_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars['Int']>
+  name_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars['Int']>
+  /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
+  name_GT?: InputMaybe<Scalars['Int']>
+  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
+  name_AVERAGE_GT?: InputMaybe<Scalars['Float']>
+  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
+  name_LONGEST_GT?: InputMaybe<Scalars['Int']>
+  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
+  name_SHORTEST_GT?: InputMaybe<Scalars['Int']>
+  name_AVERAGE_LENGTH_GT?: InputMaybe<Scalars['Float']>
+  name_LONGEST_LENGTH_GT?: InputMaybe<Scalars['Int']>
+  name_SHORTEST_LENGTH_GT?: InputMaybe<Scalars['Int']>
+  /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
+  name_GTE?: InputMaybe<Scalars['Int']>
+  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
+  name_AVERAGE_GTE?: InputMaybe<Scalars['Float']>
+  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
+  name_LONGEST_GTE?: InputMaybe<Scalars['Int']>
+  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
+  name_SHORTEST_GTE?: InputMaybe<Scalars['Int']>
+  name_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars['Float']>
+  name_LONGEST_LENGTH_GTE?: InputMaybe<Scalars['Int']>
+  name_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars['Int']>
+  /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
+  name_LT?: InputMaybe<Scalars['Int']>
+  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
+  name_AVERAGE_LT?: InputMaybe<Scalars['Float']>
+  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
+  name_LONGEST_LT?: InputMaybe<Scalars['Int']>
+  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
+  name_SHORTEST_LT?: InputMaybe<Scalars['Int']>
+  name_AVERAGE_LENGTH_LT?: InputMaybe<Scalars['Float']>
+  name_LONGEST_LENGTH_LT?: InputMaybe<Scalars['Int']>
+  name_SHORTEST_LENGTH_LT?: InputMaybe<Scalars['Int']>
+  /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
+  name_LTE?: InputMaybe<Scalars['Int']>
+  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
+  name_AVERAGE_LTE?: InputMaybe<Scalars['Float']>
+  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
+  name_LONGEST_LTE?: InputMaybe<Scalars['Int']>
+  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
+  name_SHORTEST_LTE?: InputMaybe<Scalars['Int']>
+  name_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars['Float']>
+  name_LONGEST_LENGTH_LTE?: InputMaybe<Scalars['Int']>
+  name_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars['Int']>
+  /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
+  customCss_EQUAL?: InputMaybe<Scalars['String']>
+  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
+  customCss_AVERAGE_EQUAL?: InputMaybe<Scalars['Float']>
+  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
+  customCss_LONGEST_EQUAL?: InputMaybe<Scalars['Int']>
+  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
+  customCss_SHORTEST_EQUAL?: InputMaybe<Scalars['Int']>
+  customCss_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars['Float']>
+  customCss_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars['Int']>
+  customCss_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars['Int']>
+  /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
+  customCss_GT?: InputMaybe<Scalars['Int']>
+  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
+  customCss_AVERAGE_GT?: InputMaybe<Scalars['Float']>
+  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
+  customCss_LONGEST_GT?: InputMaybe<Scalars['Int']>
+  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
+  customCss_SHORTEST_GT?: InputMaybe<Scalars['Int']>
+  customCss_AVERAGE_LENGTH_GT?: InputMaybe<Scalars['Float']>
+  customCss_LONGEST_LENGTH_GT?: InputMaybe<Scalars['Int']>
+  customCss_SHORTEST_LENGTH_GT?: InputMaybe<Scalars['Int']>
+  /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
+  customCss_GTE?: InputMaybe<Scalars['Int']>
+  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
+  customCss_AVERAGE_GTE?: InputMaybe<Scalars['Float']>
+  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
+  customCss_LONGEST_GTE?: InputMaybe<Scalars['Int']>
+  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
+  customCss_SHORTEST_GTE?: InputMaybe<Scalars['Int']>
+  customCss_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars['Float']>
+  customCss_LONGEST_LENGTH_GTE?: InputMaybe<Scalars['Int']>
+  customCss_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars['Int']>
+  /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
+  customCss_LT?: InputMaybe<Scalars['Int']>
+  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
+  customCss_AVERAGE_LT?: InputMaybe<Scalars['Float']>
+  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
+  customCss_LONGEST_LT?: InputMaybe<Scalars['Int']>
+  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
+  customCss_SHORTEST_LT?: InputMaybe<Scalars['Int']>
+  customCss_AVERAGE_LENGTH_LT?: InputMaybe<Scalars['Float']>
+  customCss_LONGEST_LENGTH_LT?: InputMaybe<Scalars['Int']>
+  customCss_SHORTEST_LENGTH_LT?: InputMaybe<Scalars['Int']>
+  /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
+  customCss_LTE?: InputMaybe<Scalars['Int']>
+  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
+  customCss_AVERAGE_LTE?: InputMaybe<Scalars['Float']>
+  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
+  customCss_LONGEST_LTE?: InputMaybe<Scalars['Int']>
+  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
+  customCss_SHORTEST_LTE?: InputMaybe<Scalars['Int']>
+  customCss_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars['Float']>
+  customCss_LONGEST_LENGTH_LTE?: InputMaybe<Scalars['Int']>
+  customCss_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars['Int']>
+  /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
+  guiCss_EQUAL?: InputMaybe<Scalars['String']>
+  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
+  guiCss_AVERAGE_EQUAL?: InputMaybe<Scalars['Float']>
+  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
+  guiCss_LONGEST_EQUAL?: InputMaybe<Scalars['Int']>
+  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
+  guiCss_SHORTEST_EQUAL?: InputMaybe<Scalars['Int']>
+  guiCss_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars['Float']>
+  guiCss_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars['Int']>
+  guiCss_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars['Int']>
+  /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
+  guiCss_GT?: InputMaybe<Scalars['Int']>
+  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
+  guiCss_AVERAGE_GT?: InputMaybe<Scalars['Float']>
+  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
+  guiCss_LONGEST_GT?: InputMaybe<Scalars['Int']>
+  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
+  guiCss_SHORTEST_GT?: InputMaybe<Scalars['Int']>
+  guiCss_AVERAGE_LENGTH_GT?: InputMaybe<Scalars['Float']>
+  guiCss_LONGEST_LENGTH_GT?: InputMaybe<Scalars['Int']>
+  guiCss_SHORTEST_LENGTH_GT?: InputMaybe<Scalars['Int']>
+  /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
+  guiCss_GTE?: InputMaybe<Scalars['Int']>
+  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
+  guiCss_AVERAGE_GTE?: InputMaybe<Scalars['Float']>
+  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
+  guiCss_LONGEST_GTE?: InputMaybe<Scalars['Int']>
+  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
+  guiCss_SHORTEST_GTE?: InputMaybe<Scalars['Int']>
+  guiCss_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars['Float']>
+  guiCss_LONGEST_LENGTH_GTE?: InputMaybe<Scalars['Int']>
+  guiCss_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars['Int']>
+  /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
+  guiCss_LT?: InputMaybe<Scalars['Int']>
+  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
+  guiCss_AVERAGE_LT?: InputMaybe<Scalars['Float']>
+  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
+  guiCss_LONGEST_LT?: InputMaybe<Scalars['Int']>
+  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
+  guiCss_SHORTEST_LT?: InputMaybe<Scalars['Int']>
+  guiCss_AVERAGE_LENGTH_LT?: InputMaybe<Scalars['Float']>
+  guiCss_LONGEST_LENGTH_LT?: InputMaybe<Scalars['Int']>
+  guiCss_SHORTEST_LENGTH_LT?: InputMaybe<Scalars['Int']>
+  /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
+  guiCss_LTE?: InputMaybe<Scalars['Int']>
+  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
+  guiCss_AVERAGE_LTE?: InputMaybe<Scalars['Float']>
+  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
+  guiCss_LONGEST_LTE?: InputMaybe<Scalars['Int']>
+  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
+  guiCss_SHORTEST_LTE?: InputMaybe<Scalars['Int']>
+  guiCss_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars['Float']>
+  guiCss_LONGEST_LENGTH_LTE?: InputMaybe<Scalars['Int']>
+  guiCss_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars['Int']>
+  /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
+  propTransformationJs_EQUAL?: InputMaybe<Scalars['String']>
+  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
+  propTransformationJs_AVERAGE_EQUAL?: InputMaybe<Scalars['Float']>
+  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
+  propTransformationJs_LONGEST_EQUAL?: InputMaybe<Scalars['Int']>
+  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
+  propTransformationJs_SHORTEST_EQUAL?: InputMaybe<Scalars['Int']>
+  propTransformationJs_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars['Float']>
+  propTransformationJs_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars['Int']>
+  propTransformationJs_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars['Int']>
+  /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
+  propTransformationJs_GT?: InputMaybe<Scalars['Int']>
+  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
+  propTransformationJs_AVERAGE_GT?: InputMaybe<Scalars['Float']>
+  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
+  propTransformationJs_LONGEST_GT?: InputMaybe<Scalars['Int']>
+  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
+  propTransformationJs_SHORTEST_GT?: InputMaybe<Scalars['Int']>
+  propTransformationJs_AVERAGE_LENGTH_GT?: InputMaybe<Scalars['Float']>
+  propTransformationJs_LONGEST_LENGTH_GT?: InputMaybe<Scalars['Int']>
+  propTransformationJs_SHORTEST_LENGTH_GT?: InputMaybe<Scalars['Int']>
+  /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
+  propTransformationJs_GTE?: InputMaybe<Scalars['Int']>
+  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
+  propTransformationJs_AVERAGE_GTE?: InputMaybe<Scalars['Float']>
+  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
+  propTransformationJs_LONGEST_GTE?: InputMaybe<Scalars['Int']>
+  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
+  propTransformationJs_SHORTEST_GTE?: InputMaybe<Scalars['Int']>
+  propTransformationJs_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars['Float']>
+  propTransformationJs_LONGEST_LENGTH_GTE?: InputMaybe<Scalars['Int']>
+  propTransformationJs_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars['Int']>
+  /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
+  propTransformationJs_LT?: InputMaybe<Scalars['Int']>
+  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
+  propTransformationJs_AVERAGE_LT?: InputMaybe<Scalars['Float']>
+  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
+  propTransformationJs_LONGEST_LT?: InputMaybe<Scalars['Int']>
+  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
+  propTransformationJs_SHORTEST_LT?: InputMaybe<Scalars['Int']>
+  propTransformationJs_AVERAGE_LENGTH_LT?: InputMaybe<Scalars['Float']>
+  propTransformationJs_LONGEST_LENGTH_LT?: InputMaybe<Scalars['Int']>
+  propTransformationJs_SHORTEST_LENGTH_LT?: InputMaybe<Scalars['Int']>
+  /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
+  propTransformationJs_LTE?: InputMaybe<Scalars['Int']>
+  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
+  propTransformationJs_AVERAGE_LTE?: InputMaybe<Scalars['Float']>
+  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
+  propTransformationJs_LONGEST_LTE?: InputMaybe<Scalars['Int']>
+  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
+  propTransformationJs_SHORTEST_LTE?: InputMaybe<Scalars['Int']>
+  propTransformationJs_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars['Float']>
+  propTransformationJs_LONGEST_LENGTH_LTE?: InputMaybe<Scalars['Int']>
+  propTransformationJs_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars['Int']>
+  /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
+  childMapperPropKey_EQUAL?: InputMaybe<Scalars['String']>
+  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
+  childMapperPropKey_AVERAGE_EQUAL?: InputMaybe<Scalars['Float']>
+  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
+  childMapperPropKey_LONGEST_EQUAL?: InputMaybe<Scalars['Int']>
+  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
+  childMapperPropKey_SHORTEST_EQUAL?: InputMaybe<Scalars['Int']>
+  childMapperPropKey_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars['Float']>
+  childMapperPropKey_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars['Int']>
+  childMapperPropKey_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars['Int']>
+  /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
+  childMapperPropKey_GT?: InputMaybe<Scalars['Int']>
+  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
+  childMapperPropKey_AVERAGE_GT?: InputMaybe<Scalars['Float']>
+  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
+  childMapperPropKey_LONGEST_GT?: InputMaybe<Scalars['Int']>
+  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
+  childMapperPropKey_SHORTEST_GT?: InputMaybe<Scalars['Int']>
+  childMapperPropKey_AVERAGE_LENGTH_GT?: InputMaybe<Scalars['Float']>
+  childMapperPropKey_LONGEST_LENGTH_GT?: InputMaybe<Scalars['Int']>
+  childMapperPropKey_SHORTEST_LENGTH_GT?: InputMaybe<Scalars['Int']>
+  /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
+  childMapperPropKey_GTE?: InputMaybe<Scalars['Int']>
+  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
+  childMapperPropKey_AVERAGE_GTE?: InputMaybe<Scalars['Float']>
+  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
+  childMapperPropKey_LONGEST_GTE?: InputMaybe<Scalars['Int']>
+  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
+  childMapperPropKey_SHORTEST_GTE?: InputMaybe<Scalars['Int']>
+  childMapperPropKey_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars['Float']>
+  childMapperPropKey_LONGEST_LENGTH_GTE?: InputMaybe<Scalars['Int']>
+  childMapperPropKey_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars['Int']>
+  /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
+  childMapperPropKey_LT?: InputMaybe<Scalars['Int']>
+  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
+  childMapperPropKey_AVERAGE_LT?: InputMaybe<Scalars['Float']>
+  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
+  childMapperPropKey_LONGEST_LT?: InputMaybe<Scalars['Int']>
+  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
+  childMapperPropKey_SHORTEST_LT?: InputMaybe<Scalars['Int']>
+  childMapperPropKey_AVERAGE_LENGTH_LT?: InputMaybe<Scalars['Float']>
+  childMapperPropKey_LONGEST_LENGTH_LT?: InputMaybe<Scalars['Int']>
+  childMapperPropKey_SHORTEST_LENGTH_LT?: InputMaybe<Scalars['Int']>
+  /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
+  childMapperPropKey_LTE?: InputMaybe<Scalars['Int']>
+  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
+  childMapperPropKey_AVERAGE_LTE?: InputMaybe<Scalars['Float']>
+  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
+  childMapperPropKey_LONGEST_LTE?: InputMaybe<Scalars['Int']>
+  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
+  childMapperPropKey_SHORTEST_LTE?: InputMaybe<Scalars['Int']>
+  childMapperPropKey_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars['Float']>
+  childMapperPropKey_LONGEST_LENGTH_LTE?: InputMaybe<Scalars['Int']>
+  childMapperPropKey_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars['Int']>
+  /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
+  renderForEachPropKey_EQUAL?: InputMaybe<Scalars['String']>
+  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
+  renderForEachPropKey_AVERAGE_EQUAL?: InputMaybe<Scalars['Float']>
+  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
+  renderForEachPropKey_LONGEST_EQUAL?: InputMaybe<Scalars['Int']>
+  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
+  renderForEachPropKey_SHORTEST_EQUAL?: InputMaybe<Scalars['Int']>
+  renderForEachPropKey_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars['Float']>
+  renderForEachPropKey_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars['Int']>
+  renderForEachPropKey_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars['Int']>
+  /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
+  renderForEachPropKey_GT?: InputMaybe<Scalars['Int']>
+  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
+  renderForEachPropKey_AVERAGE_GT?: InputMaybe<Scalars['Float']>
+  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
+  renderForEachPropKey_LONGEST_GT?: InputMaybe<Scalars['Int']>
+  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
+  renderForEachPropKey_SHORTEST_GT?: InputMaybe<Scalars['Int']>
+  renderForEachPropKey_AVERAGE_LENGTH_GT?: InputMaybe<Scalars['Float']>
+  renderForEachPropKey_LONGEST_LENGTH_GT?: InputMaybe<Scalars['Int']>
+  renderForEachPropKey_SHORTEST_LENGTH_GT?: InputMaybe<Scalars['Int']>
+  /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
+  renderForEachPropKey_GTE?: InputMaybe<Scalars['Int']>
+  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
+  renderForEachPropKey_AVERAGE_GTE?: InputMaybe<Scalars['Float']>
+  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
+  renderForEachPropKey_LONGEST_GTE?: InputMaybe<Scalars['Int']>
+  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
+  renderForEachPropKey_SHORTEST_GTE?: InputMaybe<Scalars['Int']>
+  renderForEachPropKey_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars['Float']>
+  renderForEachPropKey_LONGEST_LENGTH_GTE?: InputMaybe<Scalars['Int']>
+  renderForEachPropKey_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars['Int']>
+  /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
+  renderForEachPropKey_LT?: InputMaybe<Scalars['Int']>
+  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
+  renderForEachPropKey_AVERAGE_LT?: InputMaybe<Scalars['Float']>
+  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
+  renderForEachPropKey_LONGEST_LT?: InputMaybe<Scalars['Int']>
+  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
+  renderForEachPropKey_SHORTEST_LT?: InputMaybe<Scalars['Int']>
+  renderForEachPropKey_AVERAGE_LENGTH_LT?: InputMaybe<Scalars['Float']>
+  renderForEachPropKey_LONGEST_LENGTH_LT?: InputMaybe<Scalars['Int']>
+  renderForEachPropKey_SHORTEST_LENGTH_LT?: InputMaybe<Scalars['Int']>
+  /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
+  renderForEachPropKey_LTE?: InputMaybe<Scalars['Int']>
+  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
+  renderForEachPropKey_AVERAGE_LTE?: InputMaybe<Scalars['Float']>
+  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
+  renderForEachPropKey_LONGEST_LTE?: InputMaybe<Scalars['Int']>
+  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
+  renderForEachPropKey_SHORTEST_LTE?: InputMaybe<Scalars['Int']>
+  renderForEachPropKey_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars['Float']>
+  renderForEachPropKey_LONGEST_LENGTH_LTE?: InputMaybe<Scalars['Int']>
+  renderForEachPropKey_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars['Int']>
+  /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
+  renderIfExpression_EQUAL?: InputMaybe<Scalars['String']>
+  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
+  renderIfExpression_AVERAGE_EQUAL?: InputMaybe<Scalars['Float']>
+  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
+  renderIfExpression_LONGEST_EQUAL?: InputMaybe<Scalars['Int']>
+  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
+  renderIfExpression_SHORTEST_EQUAL?: InputMaybe<Scalars['Int']>
+  renderIfExpression_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars['Float']>
+  renderIfExpression_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars['Int']>
+  renderIfExpression_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars['Int']>
+  /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
+  renderIfExpression_GT?: InputMaybe<Scalars['Int']>
+  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
+  renderIfExpression_AVERAGE_GT?: InputMaybe<Scalars['Float']>
+  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
+  renderIfExpression_LONGEST_GT?: InputMaybe<Scalars['Int']>
+  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
+  renderIfExpression_SHORTEST_GT?: InputMaybe<Scalars['Int']>
+  renderIfExpression_AVERAGE_LENGTH_GT?: InputMaybe<Scalars['Float']>
+  renderIfExpression_LONGEST_LENGTH_GT?: InputMaybe<Scalars['Int']>
+  renderIfExpression_SHORTEST_LENGTH_GT?: InputMaybe<Scalars['Int']>
+  /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
+  renderIfExpression_GTE?: InputMaybe<Scalars['Int']>
+  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
+  renderIfExpression_AVERAGE_GTE?: InputMaybe<Scalars['Float']>
+  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
+  renderIfExpression_LONGEST_GTE?: InputMaybe<Scalars['Int']>
+  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
+  renderIfExpression_SHORTEST_GTE?: InputMaybe<Scalars['Int']>
+  renderIfExpression_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars['Float']>
+  renderIfExpression_LONGEST_LENGTH_GTE?: InputMaybe<Scalars['Int']>
+  renderIfExpression_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars['Int']>
+  /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
+  renderIfExpression_LT?: InputMaybe<Scalars['Int']>
+  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
+  renderIfExpression_AVERAGE_LT?: InputMaybe<Scalars['Float']>
+  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
+  renderIfExpression_LONGEST_LT?: InputMaybe<Scalars['Int']>
+  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
+  renderIfExpression_SHORTEST_LT?: InputMaybe<Scalars['Int']>
+  renderIfExpression_AVERAGE_LENGTH_LT?: InputMaybe<Scalars['Float']>
+  renderIfExpression_LONGEST_LENGTH_LT?: InputMaybe<Scalars['Int']>
+  renderIfExpression_SHORTEST_LENGTH_LT?: InputMaybe<Scalars['Int']>
+  /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
+  renderIfExpression_LTE?: InputMaybe<Scalars['Int']>
+  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
+  renderIfExpression_AVERAGE_LTE?: InputMaybe<Scalars['Float']>
+  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
+  renderIfExpression_LONGEST_LTE?: InputMaybe<Scalars['Int']>
+  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
+  renderIfExpression_SHORTEST_LTE?: InputMaybe<Scalars['Int']>
+  renderIfExpression_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars['Float']>
+  renderIfExpression_LONGEST_LENGTH_LTE?: InputMaybe<Scalars['Int']>
+  renderIfExpression_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars['Int']>
+}
+
+export type ElementChildMapperPreviousSiblingUpdateConnectionInput = {
+  node?: InputMaybe<ElementUpdateInput>
+}
+
+export type ElementChildMapperPreviousSiblingUpdateFieldInput = {
+  where?: InputMaybe<ElementChildMapperPreviousSiblingConnectionWhere>
+  update?: InputMaybe<ElementChildMapperPreviousSiblingUpdateConnectionInput>
+  connect?: InputMaybe<ElementChildMapperPreviousSiblingConnectFieldInput>
+  disconnect?: InputMaybe<ElementChildMapperPreviousSiblingDisconnectFieldInput>
+  create?: InputMaybe<ElementChildMapperPreviousSiblingCreateFieldInput>
+  delete?: InputMaybe<ElementChildMapperPreviousSiblingDeleteFieldInput>
+  connectOrCreate?: InputMaybe<ElementChildMapperPreviousSiblingConnectOrCreateFieldInput>
+}
+
 export type ElementConnectInput = {
   nextSibling?: InputMaybe<ElementNextSiblingConnectFieldInput>
   prevSibling?: InputMaybe<ElementPrevSiblingConnectFieldInput>
@@ -16557,6 +17083,7 @@ export type ElementConnectInput = {
   props?: InputMaybe<ElementPropsConnectFieldInput>
   parentComponent?: InputMaybe<ElementParentComponentConnectFieldInput>
   childMapperComponent?: InputMaybe<ElementChildMapperComponentConnectFieldInput>
+  childMapperPreviousSibling?: InputMaybe<ElementChildMapperPreviousSiblingConnectFieldInput>
   preRenderAction?: InputMaybe<ElementPreRenderActionConnectFieldInput>
   postRenderAction?: InputMaybe<ElementPostRenderActionConnectFieldInput>
   renderComponentType?: InputMaybe<ElementRenderComponentTypeConnectFieldInput>
@@ -16572,6 +17099,7 @@ export type ElementConnectOrCreateInput = {
   props?: InputMaybe<ElementPropsConnectOrCreateFieldInput>
   parentComponent?: InputMaybe<ElementParentComponentConnectOrCreateFieldInput>
   childMapperComponent?: InputMaybe<ElementChildMapperComponentConnectOrCreateFieldInput>
+  childMapperPreviousSibling?: InputMaybe<ElementChildMapperPreviousSiblingConnectOrCreateFieldInput>
   renderComponentType?: InputMaybe<ElementRenderComponentTypeConnectOrCreateFieldInput>
   renderAtomType?: InputMaybe<ElementRenderAtomTypeConnectOrCreateFieldInput>
 }
@@ -16601,6 +17129,7 @@ export type ElementCreateInput = {
   props?: InputMaybe<ElementPropsFieldInput>
   parentComponent?: InputMaybe<ElementParentComponentFieldInput>
   childMapperComponent?: InputMaybe<ElementChildMapperComponentFieldInput>
+  childMapperPreviousSibling?: InputMaybe<ElementChildMapperPreviousSiblingFieldInput>
   preRenderAction?: InputMaybe<ElementPreRenderActionFieldInput>
   postRenderAction?: InputMaybe<ElementPostRenderActionFieldInput>
   renderComponentType?: InputMaybe<ElementRenderComponentTypeFieldInput>
@@ -16616,6 +17145,7 @@ export type ElementDeleteInput = {
   props?: InputMaybe<ElementPropsDeleteFieldInput>
   parentComponent?: InputMaybe<ElementParentComponentDeleteFieldInput>
   childMapperComponent?: InputMaybe<ElementChildMapperComponentDeleteFieldInput>
+  childMapperPreviousSibling?: InputMaybe<ElementChildMapperPreviousSiblingDeleteFieldInput>
   preRenderAction?: InputMaybe<ElementPreRenderActionDeleteFieldInput>
   postRenderAction?: InputMaybe<ElementPostRenderActionDeleteFieldInput>
   renderComponentType?: InputMaybe<ElementRenderComponentTypeDeleteFieldInput>
@@ -16631,6 +17161,7 @@ export type ElementDisconnectInput = {
   props?: InputMaybe<ElementPropsDisconnectFieldInput>
   parentComponent?: InputMaybe<ElementParentComponentDisconnectFieldInput>
   childMapperComponent?: InputMaybe<ElementChildMapperComponentDisconnectFieldInput>
+  childMapperPreviousSibling?: InputMaybe<ElementChildMapperPreviousSiblingDisconnectFieldInput>
   preRenderAction?: InputMaybe<ElementPreRenderActionDisconnectFieldInput>
   postRenderAction?: InputMaybe<ElementPostRenderActionDisconnectFieldInput>
   renderComponentType?: InputMaybe<ElementRenderComponentTypeDisconnectFieldInput>
@@ -19157,6 +19688,7 @@ export type ElementRelationInput = {
   props?: InputMaybe<ElementPropsCreateFieldInput>
   parentComponent?: InputMaybe<ElementParentComponentCreateFieldInput>
   childMapperComponent?: InputMaybe<ElementChildMapperComponentCreateFieldInput>
+  childMapperPreviousSibling?: InputMaybe<ElementChildMapperPreviousSiblingCreateFieldInput>
   preRenderAction?: InputMaybe<ElementPreRenderActionCreateFieldInput>
   postRenderAction?: InputMaybe<ElementPostRenderActionCreateFieldInput>
   renderComponentType?: InputMaybe<ElementRenderComponentTypeCreateFieldInput>
@@ -20057,6 +20589,7 @@ export type ElementUpdateInput = {
   props?: InputMaybe<ElementPropsUpdateFieldInput>
   parentComponent?: InputMaybe<ElementParentComponentUpdateFieldInput>
   childMapperComponent?: InputMaybe<ElementChildMapperComponentUpdateFieldInput>
+  childMapperPreviousSibling?: InputMaybe<ElementChildMapperPreviousSiblingUpdateFieldInput>
   preRenderAction?: InputMaybe<ElementPreRenderActionUpdateFieldInput>
   postRenderAction?: InputMaybe<ElementPostRenderActionUpdateFieldInput>
   renderComponentType?: InputMaybe<ElementRenderComponentTypeUpdateFieldInput>
@@ -20219,6 +20752,9 @@ export type ElementWhere = {
   childMapperComponent?: InputMaybe<ComponentWhere>
   childMapperComponent_NOT?: InputMaybe<ComponentWhere>
   childMapperComponentAggregate?: InputMaybe<ElementChildMapperComponentAggregateInput>
+  childMapperPreviousSibling?: InputMaybe<ElementWhere>
+  childMapperPreviousSibling_NOT?: InputMaybe<ElementWhere>
+  childMapperPreviousSiblingAggregate?: InputMaybe<ElementChildMapperPreviousSiblingAggregateInput>
   renderComponentType?: InputMaybe<ComponentWhere>
   renderComponentType_NOT?: InputMaybe<ComponentWhere>
   renderComponentTypeAggregate?: InputMaybe<ElementRenderComponentTypeAggregateInput>
@@ -20241,6 +20777,8 @@ export type ElementWhere = {
   parentComponentConnection_NOT?: InputMaybe<ElementParentComponentConnectionWhere>
   childMapperComponentConnection?: InputMaybe<ElementChildMapperComponentConnectionWhere>
   childMapperComponentConnection_NOT?: InputMaybe<ElementChildMapperComponentConnectionWhere>
+  childMapperPreviousSiblingConnection?: InputMaybe<ElementChildMapperPreviousSiblingConnectionWhere>
+  childMapperPreviousSiblingConnection_NOT?: InputMaybe<ElementChildMapperPreviousSiblingConnectionWhere>
   preRenderActionConnection?: InputMaybe<ElementPreRenderActionConnectionWhere>
   preRenderActionConnection_NOT?: InputMaybe<ElementPreRenderActionConnectionWhere>
   postRenderActionConnection?: InputMaybe<ElementPostRenderActionConnectionWhere>

--- a/libs/backend/domain/element/src/model/element.model.ts
+++ b/libs/backend/domain/element/src/model/element.model.ts
@@ -4,6 +4,8 @@ import type { IEntity, Nullable } from '@codelab/shared/abstract/types'
 export class Element implements IElementDTO {
   childMapperComponent?: IEntity | null | undefined
 
+  childMapperPreviousSibling?: IEntity | null | undefined
+
   childMapperPropKey?: Nullable<string> | undefined
 
   customCss?: Nullable<string> | undefined

--- a/libs/backend/infra/adapter/neo4j/src/schema/model/element.schema.ts
+++ b/libs/backend/infra/adapter/neo4j/src/schema/model/element.schema.ts
@@ -38,6 +38,8 @@ export const elementSchema = gql`
     childMapperPropKey: String
     childMapperComponent: Component
       @relationship(type: "CHILD_MAPPER_COMPONENT", direction: OUT)
+    childMapperPreviousSibling: Element
+      @relationship(type: "CHILD_MAPPER_PREVIOUS_SIBLING", direction: IN)
     renderForEachPropKey: String
     renderIfExpression: String
 

--- a/libs/backend/infra/adapter/neo4j/src/selectionSet/element-selection-set.ts
+++ b/libs/backend/infra/adapter/neo4j/src/selectionSet/element-selection-set.ts
@@ -30,6 +30,9 @@ const baseElementSelectionSet = `
   firstChild {
     id
   }
+  childMapperPreviousSibling {
+    id
+  }
   props
     ${propSelectionSet}
   renderForEachPropKey

--- a/libs/frontend/abstract/core/src/domain/element/element.dto.interface.ts
+++ b/libs/frontend/abstract/core/src/domain/element/element.dto.interface.ts
@@ -29,6 +29,7 @@ export type IUpdateElementData = Pick<
 > &
   Pick<ICreateElementData, 'id'> & {
     childMapperComponent?: Nullish<IEntity>
+    childMapperPreviousSibling?: Nullish<IEntity>
     childMapperPropKey?: Nullish<string>
     propTransformationJs?: Nullish<string>
     renderForEachPropKey?: Nullable<string>
@@ -41,6 +42,7 @@ export type IUpdateElementData = Pick<
 export type IUpdateBaseElementData = Pick<
   IUpdateElementData,
   | 'childMapperComponent'
+  | 'childMapperPreviousSibling'
   | 'childMapperPropKey'
   | 'id'
   | 'name'

--- a/libs/frontend/abstract/core/src/domain/element/element.fragment.graphql
+++ b/libs/frontend/abstract/core/src/domain/element/element.fragment.graphql
@@ -36,6 +36,9 @@ fragment Element on Element {
   props {
     ...Prop
   }
+  childMapperPreviousSibling {
+    id
+  }
   childMapperPropKey
   childMapperComponent {
     id

--- a/libs/frontend/abstract/core/src/domain/element/element.fragment.graphql.gen.ts
+++ b/libs/frontend/abstract/core/src/domain/element/element.fragment.graphql.gen.ts
@@ -27,6 +27,7 @@ export type ElementFragment = {
   parent?: { id: string } | null
   firstChild?: { id: string } | null
   props: PropFragment
+  childMapperPreviousSibling?: { id: string } | null
   childMapperComponent?: { id: string; name: string } | null
   preRenderAction?:
     | { id: string; type: Types.ActionKind }
@@ -75,6 +76,9 @@ export const ElementFragmentDoc = gql`
     }
     props {
       ...Prop
+    }
+    childMapperPreviousSibling {
+      id
     }
     childMapperPropKey
     childMapperComponent {

--- a/libs/frontend/abstract/core/src/domain/element/element.model.interface.ts
+++ b/libs/frontend/abstract/core/src/domain/element/element.model.interface.ts
@@ -58,6 +58,7 @@ export interface IElement
   ancestorError: Nullish<RenderingError>
   atomName: string
   childMapperComponent?: Nullable<Ref<IComponent>>
+  childMapperPreviousSibling?: Nullable<Ref<IElement>>
   childMapperPropKey?: Nullable<string>
   children: Array<IElement>
   // the closest container node that element belongs to

--- a/libs/frontend/domain/builder/src/sections/explorer-pane/builder-tree/ElementTreeView.tsx
+++ b/libs/frontend/domain/builder/src/sections/explorer-pane/builder-tree/ElementTreeView.tsx
@@ -56,6 +56,19 @@ export const ElementTreeView = observer<ElementTreeViewProps>(
 
     return (
       <CuiTree<IElementTreeViewDataNode>
+        allowDrop={(data) => {
+          // Child mapper component instances cannot be moved around individually since they are
+          // dynamically rendered and can't have NODE_SIBLING relationship to actual elements
+          // They can only be moved around via the `childMapperPreviousSibling` field of the element
+          if (
+            data.dragNode.isChildMapperComponentInstance ||
+            data.dropNode.isChildMapperComponentInstance
+          ) {
+            return false
+          }
+
+          return true
+        }}
         defaultExpandAll
         disabled={isMoving}
         draggable={true}

--- a/libs/frontend/domain/element/src/components/ChildMapperCompositeField.tsx
+++ b/libs/frontend/domain/element/src/components/ChildMapperCompositeField.tsx
@@ -1,4 +1,4 @@
-import type { IPropData } from '@codelab/frontend/abstract/core'
+import type { IElement, IPropData } from '@codelab/frontend/abstract/core'
 import { SelectComponent } from '@codelab/frontend/domain/type'
 import {
   AutoCompleteField,
@@ -6,9 +6,24 @@ import {
 } from '@codelab/frontend/presentation/view'
 import type { IEntity } from '@codelab/shared/abstract/types'
 import { useField } from 'uniforms'
+import { mapElementOption } from '../utils'
+import { SelectLinkElement } from './SelectLinkElement'
 
-const ChildMapperFields = ({ propsData }: { propsData: IPropData }) => {
-  const [fieldProps] = useField<{ value?: IEntity }>('childMapperComponent', {})
+interface ChildMapperFieldsProps {
+  element: IElement
+  propsData: IPropData
+}
+
+const ChildMapperFields = ({ element, propsData }: ChildMapperFieldsProps) => {
+  const [childMapperComponentFieldProps] = useField<{ value?: IEntity }>(
+    'childMapperComponent',
+    {},
+  )
+
+  const [childMapperPreviousSiblingFieldProps] = useField<{ value?: IEntity }>(
+    'childMapperPreviousSibling',
+    {},
+  )
 
   const PropKeyField = ToggleExpressionField({
     getBaseControl: () => (
@@ -37,8 +52,20 @@ const ChildMapperFields = ({ propsData }: { propsData: IPropData }) => {
         label="Component"
         name="childMapperComponent.id"
         onChange={(value) =>
-          fieldProps.onChange((value ? { id: value } : null) as IEntity)
+          childMapperComponentFieldProps.onChange(
+            (value ? { id: value } : null) as IEntity,
+          )
         }
+      />
+      <SelectLinkElement
+        allElementOptions={element.children.map(mapElementOption)}
+        name="childMapperPreviousSibling.id"
+        onChange={(value) => {
+          return childMapperPreviousSiblingFieldProps.onChange(
+            (value ? { id: value } : null) as IEntity,
+          )
+        }}
+        targetElementId={element.id}
       />
     </section>
   )

--- a/libs/frontend/domain/element/src/components/SelectLinkElement.tsx
+++ b/libs/frontend/domain/element/src/components/SelectLinkElement.tsx
@@ -3,17 +3,28 @@ import type { SelectElementProps } from '@codelab/frontend/domain/type'
 import { SelectChildElement } from '@codelab/frontend/domain/type'
 import { observer } from 'mobx-react-lite'
 import { useForm } from 'uniforms'
+import type { SelectFieldProps } from 'uniforms-antd'
 import { AutoField } from 'uniforms-antd'
 
-type SelectLinkElementProps = Pick<SelectElementProps, 'allElementOptions'> & {
+type SelectLinkElementProps = Pick<
+  SelectElementProps,
+  'allElementOptions' | 'targetElementId'
+> & {
   name: string
+  onChange?: SelectFieldProps['onChange']
   required?: boolean
 }
 
 export const SelectLinkElement = observer(
-  ({ allElementOptions, name, required }: SelectLinkElementProps) => {
+  ({
+    allElementOptions,
+    name,
+    onChange,
+    required,
+    targetElementId,
+  }: SelectLinkElementProps) => {
     const form = useForm<ICreateElementData>()
-    const parentElementId = form.model.parentElement?.id
+    const parentElementId = targetElementId ?? form.model.parentElement?.id
 
     if (!parentElementId) {
       return null
@@ -26,6 +37,7 @@ export const SelectLinkElement = observer(
             allElementOptions={allElementOptions}
             allowClear
             disableWhenOneOpt={false}
+            onChange={onChange}
             targetElementId={parentElementId}
             // eslint-disable-next-line react/jsx-props-no-spreading, @typescript-eslint/no-explicit-any
             {...(props as any)}

--- a/libs/frontend/domain/element/src/store/element.service.ts
+++ b/libs/frontend/domain/element/src/store/element.service.ts
@@ -662,6 +662,9 @@ export class ElementService
       childMapperComponent: element.childMapperComponent
         ? { id: element.childMapperComponent.id }
         : null,
+      childMapperPreviousSibling: element.childMapperPreviousSibling
+        ? { id: element.childMapperPreviousSibling.id }
+        : null,
       childMapperPropKey: element.childMapperPropKey,
       customCss: element.customCss,
       guiCss: element.guiCss,

--- a/libs/frontend/domain/element/src/use-cases/element/update-element/UpdateElementForm.tsx
+++ b/libs/frontend/domain/element/src/use-cases/element/update-element/UpdateElementForm.tsx
@@ -80,7 +80,11 @@ export const UpdateElementForm = observer<UpdateElementFormProps>(
       expandedFields.push('renderCondition')
     }
 
-    if (model.childMapperPropKey ?? model.childMapperComponent) {
+    if (
+      model.childMapperPropKey ??
+      model.childMapperPreviousSibling ??
+      model.childMapperComponent
+    ) {
       expandedFields.push('childMapper')
     }
 
@@ -100,6 +104,7 @@ export const UpdateElementForm = observer<UpdateElementFormProps>(
         <AutoFields
           omitFields={[
             'childMapperComponent',
+            'childMapperPreviousSibling',
             'childMapperPropKey',
             'renderIfExpression',
             'renderForEachPropKey',
@@ -131,7 +136,10 @@ export const UpdateElementForm = observer<UpdateElementFormProps>(
             <SelectActionField name="postRenderAction" />
           </Collapse.Panel>
           <Collapse.Panel header="Child Mapper" key="childMapper">
-            <ChildMapperCompositeField propsData={propsData} />
+            <ChildMapperCompositeField
+              element={element}
+              propsData={propsData}
+            />
           </Collapse.Panel>
         </Collapse>
       </Form>

--- a/libs/frontend/domain/element/src/use-cases/element/update-element/update-element.schema.ts
+++ b/libs/frontend/domain/element/src/use-cases/element/update-element/update-element.schema.ts
@@ -1,8 +1,10 @@
 import type { IUpdateBaseElementData } from '@codelab/frontend/abstract/core'
+import { getSelectElementComponent } from '@codelab/frontend/domain/type'
 import {
   idSchema,
   titleCaseValidation,
 } from '@codelab/frontend/presentation/view'
+import { ElementTypeKind } from '@codelab/shared/abstract/codegen'
 import { IRenderTypeKind } from '@codelab/shared/abstract/core'
 import type { JSONSchemaType } from 'ajv'
 
@@ -42,6 +44,20 @@ export const updateElementSchema: JSONSchemaType<IUpdateBaseElementData> = {
         id: {
           label: 'Child Mapper Component',
           type: 'string',
+        },
+      },
+      required: [],
+      type: 'object',
+    },
+    childMapperPreviousSibling: {
+      nullable: true,
+      properties: {
+        id: {
+          label: 'Render next to',
+          type: 'string',
+          uniforms: {
+            component: getSelectElementComponent(ElementTypeKind.ChildrenOnly),
+          },
         },
       },
       required: [],

--- a/libs/frontend/domain/element/src/utils/get-element-model.ts
+++ b/libs/frontend/domain/element/src/utils/get-element-model.ts
@@ -27,6 +27,9 @@ export const getElementModel = (element: IElement) => {
     childMapperComponent: element.childMapperComponent
       ? { id: element.childMapperComponent.id }
       : null,
+    childMapperPreviousSibling: element.childMapperPreviousSibling
+      ? { id: element.childMapperPreviousSibling.id }
+      : null,
     childMapperPropKey: element.childMapperPropKey,
     id: element.id,
     name: element.name,

--- a/libs/frontend/domain/renderer/src/renderer.model.ts
+++ b/libs/frontend/domain/renderer/src/renderer.model.ts
@@ -279,14 +279,21 @@ export class Renderer
    * Renders the elements children, createTransformer memoizes the function
    */
   renderChildren = createTransformer(
-    (parentOutput: IRenderOutput): ArrayOrSingle<ReactNode> => {
+    ({ element, props }: IRenderOutput): ArrayOrSingle<ReactNode> => {
+      const childMapperChildren = this.getChildMapperChildren(element)
+
+      const childMapperRenderIndex =
+        element.children.findIndex(
+          (child) => child.id === element.childMapperPreviousSibling?.id,
+        ) + 1
+
+      const elementChildren = [...element.children]
+      elementChildren.splice(childMapperRenderIndex, 0, ...childMapperChildren)
+
       const children = [
-        ...parentOutput.element.children,
-        ...this.getComponentInstanceChildren(parentOutput.element),
-        ...this.getChildPageChildren(parentOutput.element),
-        // Render the children from child mapper last
-        // TODO: allow user to move around the elements from the child mapper
-        ...this.getChildMapperChildren(parentOutput.element),
+        ...elementChildren,
+        ...this.getComponentInstanceChildren(element),
+        ...this.getChildPageChildren(element),
       ]
 
       const renderedChildren = children.map((child) =>
@@ -297,11 +304,11 @@ export class Renderer
 
       if (!hasChildren) {
         // Inject text, but only if we have no regular children
-        const injectedText = parentOutput.props?.[CUSTOM_TEXT_PROP_KEY]
+        const injectedText = props?.[CUSTOM_TEXT_PROP_KEY]
 
         const shouldInjectText =
-          isAtomInstance(parentOutput.element.renderType) &&
-          parentOutput.element.renderType.current.allowCustomTextInjection
+          isAtomInstance(element.renderType) &&
+          element.renderType.current.allowCustomTextInjection
 
         if (shouldInjectText && injectedText) {
           return makeCustomTextContainer(injectedText)

--- a/libs/frontend/presentation/codelab-ui/src/views/CuiTree/CuiTree.tsx
+++ b/libs/frontend/presentation/codelab-ui/src/views/CuiTree/CuiTree.tsx
@@ -29,6 +29,7 @@ export interface CuiTreeBasicDataNode {
 }
 
 export interface CuiTreeProps<T extends CuiTreeBasicDataNode> {
+  allowDrop?: DirectoryTreeProps<T>['allowDrop']
   defaultExpandAll?: DirectoryTreeProps<T>['defaultExpandAll']
   disabled?: DirectoryTreeProps<T>['disabled']
   draggable?: boolean

--- a/libs/shared/abstract/codegen/src/types.api.graphql.gen.ts
+++ b/libs/shared/abstract/codegen/src/types.api.graphql.gen.ts
@@ -7118,6 +7118,9 @@ export type Element = {
   childMapperComponent?: Maybe<Component>
   childMapperComponentAggregate?: Maybe<ElementComponentChildMapperComponentAggregationSelection>
   childMapperComponentConnection: ElementChildMapperComponentConnection
+  childMapperPreviousSibling?: Maybe<Element>
+  childMapperPreviousSiblingAggregate?: Maybe<ElementElementChildMapperPreviousSiblingAggregationSelection>
+  childMapperPreviousSiblingConnection: ElementChildMapperPreviousSiblingConnection
   childMapperPropKey?: Maybe<Scalars['String']['output']>
   customCss?: Maybe<Scalars['String']['output']>
   descendantElements: Array<Element>
@@ -7178,6 +7181,25 @@ export type ElementChildMapperComponentConnectionArgs = {
   first?: InputMaybe<Scalars['Int']['input']>
   sort?: InputMaybe<Array<ElementChildMapperComponentConnectionSort>>
   where?: InputMaybe<ElementChildMapperComponentConnectionWhere>
+}
+
+export type ElementChildMapperPreviousSiblingArgs = {
+  directed?: InputMaybe<Scalars['Boolean']['input']>
+  options?: InputMaybe<ElementOptions>
+  where?: InputMaybe<ElementWhere>
+}
+
+export type ElementChildMapperPreviousSiblingAggregateArgs = {
+  directed?: InputMaybe<Scalars['Boolean']['input']>
+  where?: InputMaybe<ElementWhere>
+}
+
+export type ElementChildMapperPreviousSiblingConnectionArgs = {
+  after?: InputMaybe<Scalars['String']['input']>
+  directed?: InputMaybe<Scalars['Boolean']['input']>
+  first?: InputMaybe<Scalars['Int']['input']>
+  sort?: InputMaybe<Array<ElementChildMapperPreviousSiblingConnectionSort>>
+  where?: InputMaybe<ElementChildMapperPreviousSiblingConnectionWhere>
 }
 
 export type ElementFirstChildArgs = {
@@ -7530,6 +7552,232 @@ export type ElementChildMapperComponentUpdateFieldInput = {
   where?: InputMaybe<ElementChildMapperComponentConnectionWhere>
 }
 
+export type ElementChildMapperPreviousSiblingAggregateInput = {
+  AND?: InputMaybe<Array<ElementChildMapperPreviousSiblingAggregateInput>>
+  NOT?: InputMaybe<ElementChildMapperPreviousSiblingAggregateInput>
+  OR?: InputMaybe<Array<ElementChildMapperPreviousSiblingAggregateInput>>
+  count?: InputMaybe<Scalars['Int']['input']>
+  count_GT?: InputMaybe<Scalars['Int']['input']>
+  count_GTE?: InputMaybe<Scalars['Int']['input']>
+  count_LT?: InputMaybe<Scalars['Int']['input']>
+  count_LTE?: InputMaybe<Scalars['Int']['input']>
+  node?: InputMaybe<ElementChildMapperPreviousSiblingNodeAggregationWhereInput>
+}
+
+export type ElementChildMapperPreviousSiblingConnectFieldInput = {
+  connect?: InputMaybe<ElementConnectInput>
+  /** Whether or not to overwrite any matching relationship with the new properties. Will default to `false` in 4.0.0. */
+  overwrite?: Scalars['Boolean']['input']
+  where?: InputMaybe<ElementConnectWhere>
+}
+
+export type ElementChildMapperPreviousSiblingConnectOrCreateFieldInput = {
+  onCreate: ElementChildMapperPreviousSiblingConnectOrCreateFieldInputOnCreate
+  where: ElementConnectOrCreateWhere
+}
+
+export type ElementChildMapperPreviousSiblingConnectOrCreateFieldInputOnCreate =
+  {
+    node: ElementOnCreateInput
+  }
+
+export type ElementChildMapperPreviousSiblingConnection = {
+  __typename?: 'ElementChildMapperPreviousSiblingConnection'
+  edges: Array<ElementChildMapperPreviousSiblingRelationship>
+  pageInfo: PageInfo
+  totalCount: Scalars['Int']['output']
+}
+
+export type ElementChildMapperPreviousSiblingConnectionSort = {
+  node?: InputMaybe<ElementSort>
+}
+
+export type ElementChildMapperPreviousSiblingConnectionWhere = {
+  AND?: InputMaybe<Array<ElementChildMapperPreviousSiblingConnectionWhere>>
+  NOT?: InputMaybe<ElementChildMapperPreviousSiblingConnectionWhere>
+  OR?: InputMaybe<Array<ElementChildMapperPreviousSiblingConnectionWhere>>
+  node?: InputMaybe<ElementWhere>
+}
+
+export type ElementChildMapperPreviousSiblingCreateFieldInput = {
+  node: ElementCreateInput
+}
+
+export type ElementChildMapperPreviousSiblingDeleteFieldInput = {
+  delete?: InputMaybe<ElementDeleteInput>
+  where?: InputMaybe<ElementChildMapperPreviousSiblingConnectionWhere>
+}
+
+export type ElementChildMapperPreviousSiblingDisconnectFieldInput = {
+  disconnect?: InputMaybe<ElementDisconnectInput>
+  where?: InputMaybe<ElementChildMapperPreviousSiblingConnectionWhere>
+}
+
+export type ElementChildMapperPreviousSiblingFieldInput = {
+  connect?: InputMaybe<ElementChildMapperPreviousSiblingConnectFieldInput>
+  connectOrCreate?: InputMaybe<ElementChildMapperPreviousSiblingConnectOrCreateFieldInput>
+  create?: InputMaybe<ElementChildMapperPreviousSiblingCreateFieldInput>
+}
+
+export type ElementChildMapperPreviousSiblingNodeAggregationWhereInput = {
+  AND?: InputMaybe<
+    Array<ElementChildMapperPreviousSiblingNodeAggregationWhereInput>
+  >
+  NOT?: InputMaybe<ElementChildMapperPreviousSiblingNodeAggregationWhereInput>
+  OR?: InputMaybe<
+    Array<ElementChildMapperPreviousSiblingNodeAggregationWhereInput>
+  >
+  childMapperPropKey_AVERAGE_LENGTH_EQUAL?: InputMaybe<
+    Scalars['Float']['input']
+  >
+  childMapperPropKey_AVERAGE_LENGTH_GT?: InputMaybe<Scalars['Float']['input']>
+  childMapperPropKey_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars['Float']['input']>
+  childMapperPropKey_AVERAGE_LENGTH_LT?: InputMaybe<Scalars['Float']['input']>
+  childMapperPropKey_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars['Float']['input']>
+  childMapperPropKey_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars['Int']['input']>
+  childMapperPropKey_LONGEST_LENGTH_GT?: InputMaybe<Scalars['Int']['input']>
+  childMapperPropKey_LONGEST_LENGTH_GTE?: InputMaybe<Scalars['Int']['input']>
+  childMapperPropKey_LONGEST_LENGTH_LT?: InputMaybe<Scalars['Int']['input']>
+  childMapperPropKey_LONGEST_LENGTH_LTE?: InputMaybe<Scalars['Int']['input']>
+  childMapperPropKey_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars['Int']['input']>
+  childMapperPropKey_SHORTEST_LENGTH_GT?: InputMaybe<Scalars['Int']['input']>
+  childMapperPropKey_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars['Int']['input']>
+  childMapperPropKey_SHORTEST_LENGTH_LT?: InputMaybe<Scalars['Int']['input']>
+  childMapperPropKey_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars['Int']['input']>
+  customCss_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars['Float']['input']>
+  customCss_AVERAGE_LENGTH_GT?: InputMaybe<Scalars['Float']['input']>
+  customCss_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars['Float']['input']>
+  customCss_AVERAGE_LENGTH_LT?: InputMaybe<Scalars['Float']['input']>
+  customCss_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars['Float']['input']>
+  customCss_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars['Int']['input']>
+  customCss_LONGEST_LENGTH_GT?: InputMaybe<Scalars['Int']['input']>
+  customCss_LONGEST_LENGTH_GTE?: InputMaybe<Scalars['Int']['input']>
+  customCss_LONGEST_LENGTH_LT?: InputMaybe<Scalars['Int']['input']>
+  customCss_LONGEST_LENGTH_LTE?: InputMaybe<Scalars['Int']['input']>
+  customCss_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars['Int']['input']>
+  customCss_SHORTEST_LENGTH_GT?: InputMaybe<Scalars['Int']['input']>
+  customCss_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars['Int']['input']>
+  customCss_SHORTEST_LENGTH_LT?: InputMaybe<Scalars['Int']['input']>
+  customCss_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars['Int']['input']>
+  guiCss_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars['Float']['input']>
+  guiCss_AVERAGE_LENGTH_GT?: InputMaybe<Scalars['Float']['input']>
+  guiCss_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars['Float']['input']>
+  guiCss_AVERAGE_LENGTH_LT?: InputMaybe<Scalars['Float']['input']>
+  guiCss_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars['Float']['input']>
+  guiCss_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars['Int']['input']>
+  guiCss_LONGEST_LENGTH_GT?: InputMaybe<Scalars['Int']['input']>
+  guiCss_LONGEST_LENGTH_GTE?: InputMaybe<Scalars['Int']['input']>
+  guiCss_LONGEST_LENGTH_LT?: InputMaybe<Scalars['Int']['input']>
+  guiCss_LONGEST_LENGTH_LTE?: InputMaybe<Scalars['Int']['input']>
+  guiCss_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars['Int']['input']>
+  guiCss_SHORTEST_LENGTH_GT?: InputMaybe<Scalars['Int']['input']>
+  guiCss_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars['Int']['input']>
+  guiCss_SHORTEST_LENGTH_LT?: InputMaybe<Scalars['Int']['input']>
+  guiCss_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars['Int']['input']>
+  name_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars['Float']['input']>
+  name_AVERAGE_LENGTH_GT?: InputMaybe<Scalars['Float']['input']>
+  name_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars['Float']['input']>
+  name_AVERAGE_LENGTH_LT?: InputMaybe<Scalars['Float']['input']>
+  name_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars['Float']['input']>
+  name_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars['Int']['input']>
+  name_LONGEST_LENGTH_GT?: InputMaybe<Scalars['Int']['input']>
+  name_LONGEST_LENGTH_GTE?: InputMaybe<Scalars['Int']['input']>
+  name_LONGEST_LENGTH_LT?: InputMaybe<Scalars['Int']['input']>
+  name_LONGEST_LENGTH_LTE?: InputMaybe<Scalars['Int']['input']>
+  name_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars['Int']['input']>
+  name_SHORTEST_LENGTH_GT?: InputMaybe<Scalars['Int']['input']>
+  name_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars['Int']['input']>
+  name_SHORTEST_LENGTH_LT?: InputMaybe<Scalars['Int']['input']>
+  name_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars['Int']['input']>
+  propTransformationJs_AVERAGE_LENGTH_EQUAL?: InputMaybe<
+    Scalars['Float']['input']
+  >
+  propTransformationJs_AVERAGE_LENGTH_GT?: InputMaybe<Scalars['Float']['input']>
+  propTransformationJs_AVERAGE_LENGTH_GTE?: InputMaybe<
+    Scalars['Float']['input']
+  >
+  propTransformationJs_AVERAGE_LENGTH_LT?: InputMaybe<Scalars['Float']['input']>
+  propTransformationJs_AVERAGE_LENGTH_LTE?: InputMaybe<
+    Scalars['Float']['input']
+  >
+  propTransformationJs_LONGEST_LENGTH_EQUAL?: InputMaybe<
+    Scalars['Int']['input']
+  >
+  propTransformationJs_LONGEST_LENGTH_GT?: InputMaybe<Scalars['Int']['input']>
+  propTransformationJs_LONGEST_LENGTH_GTE?: InputMaybe<Scalars['Int']['input']>
+  propTransformationJs_LONGEST_LENGTH_LT?: InputMaybe<Scalars['Int']['input']>
+  propTransformationJs_LONGEST_LENGTH_LTE?: InputMaybe<Scalars['Int']['input']>
+  propTransformationJs_SHORTEST_LENGTH_EQUAL?: InputMaybe<
+    Scalars['Int']['input']
+  >
+  propTransformationJs_SHORTEST_LENGTH_GT?: InputMaybe<Scalars['Int']['input']>
+  propTransformationJs_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars['Int']['input']>
+  propTransformationJs_SHORTEST_LENGTH_LT?: InputMaybe<Scalars['Int']['input']>
+  propTransformationJs_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars['Int']['input']>
+  renderForEachPropKey_AVERAGE_LENGTH_EQUAL?: InputMaybe<
+    Scalars['Float']['input']
+  >
+  renderForEachPropKey_AVERAGE_LENGTH_GT?: InputMaybe<Scalars['Float']['input']>
+  renderForEachPropKey_AVERAGE_LENGTH_GTE?: InputMaybe<
+    Scalars['Float']['input']
+  >
+  renderForEachPropKey_AVERAGE_LENGTH_LT?: InputMaybe<Scalars['Float']['input']>
+  renderForEachPropKey_AVERAGE_LENGTH_LTE?: InputMaybe<
+    Scalars['Float']['input']
+  >
+  renderForEachPropKey_LONGEST_LENGTH_EQUAL?: InputMaybe<
+    Scalars['Int']['input']
+  >
+  renderForEachPropKey_LONGEST_LENGTH_GT?: InputMaybe<Scalars['Int']['input']>
+  renderForEachPropKey_LONGEST_LENGTH_GTE?: InputMaybe<Scalars['Int']['input']>
+  renderForEachPropKey_LONGEST_LENGTH_LT?: InputMaybe<Scalars['Int']['input']>
+  renderForEachPropKey_LONGEST_LENGTH_LTE?: InputMaybe<Scalars['Int']['input']>
+  renderForEachPropKey_SHORTEST_LENGTH_EQUAL?: InputMaybe<
+    Scalars['Int']['input']
+  >
+  renderForEachPropKey_SHORTEST_LENGTH_GT?: InputMaybe<Scalars['Int']['input']>
+  renderForEachPropKey_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars['Int']['input']>
+  renderForEachPropKey_SHORTEST_LENGTH_LT?: InputMaybe<Scalars['Int']['input']>
+  renderForEachPropKey_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars['Int']['input']>
+  renderIfExpression_AVERAGE_LENGTH_EQUAL?: InputMaybe<
+    Scalars['Float']['input']
+  >
+  renderIfExpression_AVERAGE_LENGTH_GT?: InputMaybe<Scalars['Float']['input']>
+  renderIfExpression_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars['Float']['input']>
+  renderIfExpression_AVERAGE_LENGTH_LT?: InputMaybe<Scalars['Float']['input']>
+  renderIfExpression_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars['Float']['input']>
+  renderIfExpression_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars['Int']['input']>
+  renderIfExpression_LONGEST_LENGTH_GT?: InputMaybe<Scalars['Int']['input']>
+  renderIfExpression_LONGEST_LENGTH_GTE?: InputMaybe<Scalars['Int']['input']>
+  renderIfExpression_LONGEST_LENGTH_LT?: InputMaybe<Scalars['Int']['input']>
+  renderIfExpression_LONGEST_LENGTH_LTE?: InputMaybe<Scalars['Int']['input']>
+  renderIfExpression_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars['Int']['input']>
+  renderIfExpression_SHORTEST_LENGTH_GT?: InputMaybe<Scalars['Int']['input']>
+  renderIfExpression_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars['Int']['input']>
+  renderIfExpression_SHORTEST_LENGTH_LT?: InputMaybe<Scalars['Int']['input']>
+  renderIfExpression_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars['Int']['input']>
+}
+
+export type ElementChildMapperPreviousSiblingRelationship = {
+  __typename?: 'ElementChildMapperPreviousSiblingRelationship'
+  cursor: Scalars['String']['output']
+  node: Element
+}
+
+export type ElementChildMapperPreviousSiblingUpdateConnectionInput = {
+  node?: InputMaybe<ElementUpdateInput>
+}
+
+export type ElementChildMapperPreviousSiblingUpdateFieldInput = {
+  connect?: InputMaybe<ElementChildMapperPreviousSiblingConnectFieldInput>
+  connectOrCreate?: InputMaybe<ElementChildMapperPreviousSiblingConnectOrCreateFieldInput>
+  create?: InputMaybe<ElementChildMapperPreviousSiblingCreateFieldInput>
+  delete?: InputMaybe<ElementChildMapperPreviousSiblingDeleteFieldInput>
+  disconnect?: InputMaybe<ElementChildMapperPreviousSiblingDisconnectFieldInput>
+  update?: InputMaybe<ElementChildMapperPreviousSiblingUpdateConnectionInput>
+  where?: InputMaybe<ElementChildMapperPreviousSiblingConnectionWhere>
+}
+
 export type ElementComponentChildMapperComponentAggregationSelection = {
   __typename?: 'ElementComponentChildMapperComponentAggregationSelection'
   count: Scalars['Int']['output']
@@ -7571,6 +7819,7 @@ export type ElementComponentRenderComponentTypeNodeAggregateSelection = {
 
 export type ElementConnectInput = {
   childMapperComponent?: InputMaybe<ElementChildMapperComponentConnectFieldInput>
+  childMapperPreviousSibling?: InputMaybe<ElementChildMapperPreviousSiblingConnectFieldInput>
   firstChild?: InputMaybe<ElementFirstChildConnectFieldInput>
   nextSibling?: InputMaybe<ElementNextSiblingConnectFieldInput>
   page?: InputMaybe<ElementPageConnectFieldInput>
@@ -7586,6 +7835,7 @@ export type ElementConnectInput = {
 
 export type ElementConnectOrCreateInput = {
   childMapperComponent?: InputMaybe<ElementChildMapperComponentConnectOrCreateFieldInput>
+  childMapperPreviousSibling?: InputMaybe<ElementChildMapperPreviousSiblingConnectOrCreateFieldInput>
   firstChild?: InputMaybe<ElementFirstChildConnectOrCreateFieldInput>
   nextSibling?: InputMaybe<ElementNextSiblingConnectOrCreateFieldInput>
   page?: InputMaybe<ElementPageConnectOrCreateFieldInput>
@@ -7607,6 +7857,7 @@ export type ElementConnectWhere = {
 
 export type ElementCreateInput = {
   childMapperComponent?: InputMaybe<ElementChildMapperComponentFieldInput>
+  childMapperPreviousSibling?: InputMaybe<ElementChildMapperPreviousSiblingFieldInput>
   childMapperPropKey?: InputMaybe<Scalars['String']['input']>
   customCss?: InputMaybe<Scalars['String']['input']>
   firstChild?: InputMaybe<ElementFirstChildFieldInput>
@@ -7630,6 +7881,7 @@ export type ElementCreateInput = {
 
 export type ElementDeleteInput = {
   childMapperComponent?: InputMaybe<ElementChildMapperComponentDeleteFieldInput>
+  childMapperPreviousSibling?: InputMaybe<ElementChildMapperPreviousSiblingDeleteFieldInput>
   firstChild?: InputMaybe<ElementFirstChildDeleteFieldInput>
   nextSibling?: InputMaybe<ElementNextSiblingDeleteFieldInput>
   page?: InputMaybe<ElementPageDeleteFieldInput>
@@ -7645,6 +7897,7 @@ export type ElementDeleteInput = {
 
 export type ElementDisconnectInput = {
   childMapperComponent?: InputMaybe<ElementChildMapperComponentDisconnectFieldInput>
+  childMapperPreviousSibling?: InputMaybe<ElementChildMapperPreviousSiblingDisconnectFieldInput>
   firstChild?: InputMaybe<ElementFirstChildDisconnectFieldInput>
   nextSibling?: InputMaybe<ElementNextSiblingDisconnectFieldInput>
   page?: InputMaybe<ElementPageDisconnectFieldInput>
@@ -7662,6 +7915,24 @@ export type ElementEdge = {
   __typename?: 'ElementEdge'
   cursor: Scalars['String']['output']
   node: Element
+}
+
+export type ElementElementChildMapperPreviousSiblingAggregationSelection = {
+  __typename?: 'ElementElementChildMapperPreviousSiblingAggregationSelection'
+  count: Scalars['Int']['output']
+  node?: Maybe<ElementElementChildMapperPreviousSiblingNodeAggregateSelection>
+}
+
+export type ElementElementChildMapperPreviousSiblingNodeAggregateSelection = {
+  __typename?: 'ElementElementChildMapperPreviousSiblingNodeAggregateSelection'
+  childMapperPropKey: StringAggregateSelectionNullable
+  customCss: StringAggregateSelectionNullable
+  guiCss: StringAggregateSelectionNullable
+  id: IdAggregateSelectionNonNullable
+  name: StringAggregateSelectionNonNullable
+  propTransformationJs: StringAggregateSelectionNullable
+  renderForEachPropKey: StringAggregateSelectionNullable
+  renderIfExpression: StringAggregateSelectionNullable
 }
 
 export type ElementElementFirstChildAggregationSelection = {
@@ -9135,6 +9406,7 @@ export type ElementPropsUpdateFieldInput = {
 
 export type ElementRelationInput = {
   childMapperComponent?: InputMaybe<ElementChildMapperComponentCreateFieldInput>
+  childMapperPreviousSibling?: InputMaybe<ElementChildMapperPreviousSiblingCreateFieldInput>
   firstChild?: InputMaybe<ElementFirstChildCreateFieldInput>
   nextSibling?: InputMaybe<ElementNextSiblingCreateFieldInput>
   page?: InputMaybe<ElementPageCreateFieldInput>
@@ -9728,6 +10000,7 @@ export type ElementUniqueWhere = {
 
 export type ElementUpdateInput = {
   childMapperComponent?: InputMaybe<ElementChildMapperComponentUpdateFieldInput>
+  childMapperPreviousSibling?: InputMaybe<ElementChildMapperPreviousSiblingUpdateFieldInput>
   childMapperPropKey?: InputMaybe<Scalars['String']['input']>
   customCss?: InputMaybe<Scalars['String']['input']>
   firstChild?: InputMaybe<ElementFirstChildUpdateFieldInput>
@@ -9758,6 +10031,11 @@ export type ElementWhere = {
   childMapperComponentConnection?: InputMaybe<ElementChildMapperComponentConnectionWhere>
   childMapperComponentConnection_NOT?: InputMaybe<ElementChildMapperComponentConnectionWhere>
   childMapperComponent_NOT?: InputMaybe<ComponentWhere>
+  childMapperPreviousSibling?: InputMaybe<ElementWhere>
+  childMapperPreviousSiblingAggregate?: InputMaybe<ElementChildMapperPreviousSiblingAggregateInput>
+  childMapperPreviousSiblingConnection?: InputMaybe<ElementChildMapperPreviousSiblingConnectionWhere>
+  childMapperPreviousSiblingConnection_NOT?: InputMaybe<ElementChildMapperPreviousSiblingConnectionWhere>
+  childMapperPreviousSibling_NOT?: InputMaybe<ElementWhere>
   childMapperPropKey?: InputMaybe<Scalars['String']['input']>
   childMapperPropKey_CONTAINS?: InputMaybe<Scalars['String']['input']>
   childMapperPropKey_ENDS_WITH?: InputMaybe<Scalars['String']['input']>
@@ -22232,6 +22510,7 @@ export type ElementFragment = {
   parent?: { __typename?: 'Element'; id: string } | null
   firstChild?: { __typename?: 'Element'; id: string } | null
   props: { __typename?: 'Prop' } & PropFragment
+  childMapperPreviousSibling?: { __typename?: 'Element'; id: string } | null
   childMapperComponent?: {
     __typename?: 'Component'
     id: string

--- a/libs/shared/abstract/core/src/element.dto.interface.ts
+++ b/libs/shared/abstract/core/src/element.dto.interface.ts
@@ -7,6 +7,7 @@ import type { RenderType } from './render-type'
 export interface IElementDTO {
   // slug: string
   childMapperComponent?: Nullable<IEntity>
+  childMapperPreviousSibling?: Nullable<IEntity>
   childMapperPropKey?: Nullable<string>
   customCss?: Nullable<string>
   firstChild?: Nullable<IEntity>

--- a/schema.graphql
+++ b/schema.graphql
@@ -6787,6 +6787,22 @@ type Element {
     sort: [ElementChildMapperComponentConnectionSort!]
     where: ElementChildMapperComponentConnectionWhere
   ): ElementChildMapperComponentConnection!
+  childMapperPreviousSibling(
+    directed: Boolean = true
+    options: ElementOptions
+    where: ElementWhere
+  ): Element
+  childMapperPreviousSiblingAggregate(
+    directed: Boolean = true
+    where: ElementWhere
+  ): ElementElementChildMapperPreviousSiblingAggregationSelection
+  childMapperPreviousSiblingConnection(
+    after: String
+    directed: Boolean = true
+    first: Int
+    sort: [ElementChildMapperPreviousSiblingConnectionSort!]
+    where: ElementChildMapperPreviousSiblingConnectionWhere
+  ): ElementChildMapperPreviousSiblingConnection!
   childMapperPropKey: String
   customCss: String
   descendantElements: [Element!]!
@@ -7108,6 +7124,204 @@ input ElementChildMapperComponentUpdateFieldInput {
   where: ElementChildMapperComponentConnectionWhere
 }
 
+input ElementChildMapperPreviousSiblingAggregateInput {
+  AND: [ElementChildMapperPreviousSiblingAggregateInput!]
+  NOT: ElementChildMapperPreviousSiblingAggregateInput
+  OR: [ElementChildMapperPreviousSiblingAggregateInput!]
+  count: Int
+  count_GT: Int
+  count_GTE: Int
+  count_LT: Int
+  count_LTE: Int
+  node: ElementChildMapperPreviousSiblingNodeAggregationWhereInput
+}
+
+input ElementChildMapperPreviousSiblingConnectFieldInput {
+  connect: ElementConnectInput
+
+  """
+  Whether or not to overwrite any matching relationship with the new properties. Will default to `false` in 4.0.0.
+  """
+  overwrite: Boolean! = true
+  where: ElementConnectWhere
+}
+
+input ElementChildMapperPreviousSiblingConnectOrCreateFieldInput {
+  onCreate: ElementChildMapperPreviousSiblingConnectOrCreateFieldInputOnCreate!
+  where: ElementConnectOrCreateWhere!
+}
+
+input ElementChildMapperPreviousSiblingConnectOrCreateFieldInputOnCreate {
+  node: ElementOnCreateInput!
+}
+
+type ElementChildMapperPreviousSiblingConnection {
+  edges: [ElementChildMapperPreviousSiblingRelationship!]!
+  pageInfo: PageInfo!
+  totalCount: Int!
+}
+
+input ElementChildMapperPreviousSiblingConnectionSort {
+  node: ElementSort
+}
+
+input ElementChildMapperPreviousSiblingConnectionWhere {
+  AND: [ElementChildMapperPreviousSiblingConnectionWhere!]
+  NOT: ElementChildMapperPreviousSiblingConnectionWhere
+  OR: [ElementChildMapperPreviousSiblingConnectionWhere!]
+  node: ElementWhere
+}
+
+input ElementChildMapperPreviousSiblingCreateFieldInput {
+  node: ElementCreateInput!
+}
+
+input ElementChildMapperPreviousSiblingDeleteFieldInput {
+  delete: ElementDeleteInput
+  where: ElementChildMapperPreviousSiblingConnectionWhere
+}
+
+input ElementChildMapperPreviousSiblingDisconnectFieldInput {
+  disconnect: ElementDisconnectInput
+  where: ElementChildMapperPreviousSiblingConnectionWhere
+}
+
+input ElementChildMapperPreviousSiblingFieldInput {
+  connect: ElementChildMapperPreviousSiblingConnectFieldInput
+  connectOrCreate: ElementChildMapperPreviousSiblingConnectOrCreateFieldInput
+  create: ElementChildMapperPreviousSiblingCreateFieldInput
+}
+
+input ElementChildMapperPreviousSiblingNodeAggregationWhereInput {
+  AND: [ElementChildMapperPreviousSiblingNodeAggregationWhereInput!]
+  NOT: ElementChildMapperPreviousSiblingNodeAggregationWhereInput
+  OR: [ElementChildMapperPreviousSiblingNodeAggregationWhereInput!]
+  childMapperPropKey_AVERAGE_LENGTH_EQUAL: Float
+  childMapperPropKey_AVERAGE_LENGTH_GT: Float
+  childMapperPropKey_AVERAGE_LENGTH_GTE: Float
+  childMapperPropKey_AVERAGE_LENGTH_LT: Float
+  childMapperPropKey_AVERAGE_LENGTH_LTE: Float
+  childMapperPropKey_LONGEST_LENGTH_EQUAL: Int
+  childMapperPropKey_LONGEST_LENGTH_GT: Int
+  childMapperPropKey_LONGEST_LENGTH_GTE: Int
+  childMapperPropKey_LONGEST_LENGTH_LT: Int
+  childMapperPropKey_LONGEST_LENGTH_LTE: Int
+  childMapperPropKey_SHORTEST_LENGTH_EQUAL: Int
+  childMapperPropKey_SHORTEST_LENGTH_GT: Int
+  childMapperPropKey_SHORTEST_LENGTH_GTE: Int
+  childMapperPropKey_SHORTEST_LENGTH_LT: Int
+  childMapperPropKey_SHORTEST_LENGTH_LTE: Int
+  customCss_AVERAGE_LENGTH_EQUAL: Float
+  customCss_AVERAGE_LENGTH_GT: Float
+  customCss_AVERAGE_LENGTH_GTE: Float
+  customCss_AVERAGE_LENGTH_LT: Float
+  customCss_AVERAGE_LENGTH_LTE: Float
+  customCss_LONGEST_LENGTH_EQUAL: Int
+  customCss_LONGEST_LENGTH_GT: Int
+  customCss_LONGEST_LENGTH_GTE: Int
+  customCss_LONGEST_LENGTH_LT: Int
+  customCss_LONGEST_LENGTH_LTE: Int
+  customCss_SHORTEST_LENGTH_EQUAL: Int
+  customCss_SHORTEST_LENGTH_GT: Int
+  customCss_SHORTEST_LENGTH_GTE: Int
+  customCss_SHORTEST_LENGTH_LT: Int
+  customCss_SHORTEST_LENGTH_LTE: Int
+  guiCss_AVERAGE_LENGTH_EQUAL: Float
+  guiCss_AVERAGE_LENGTH_GT: Float
+  guiCss_AVERAGE_LENGTH_GTE: Float
+  guiCss_AVERAGE_LENGTH_LT: Float
+  guiCss_AVERAGE_LENGTH_LTE: Float
+  guiCss_LONGEST_LENGTH_EQUAL: Int
+  guiCss_LONGEST_LENGTH_GT: Int
+  guiCss_LONGEST_LENGTH_GTE: Int
+  guiCss_LONGEST_LENGTH_LT: Int
+  guiCss_LONGEST_LENGTH_LTE: Int
+  guiCss_SHORTEST_LENGTH_EQUAL: Int
+  guiCss_SHORTEST_LENGTH_GT: Int
+  guiCss_SHORTEST_LENGTH_GTE: Int
+  guiCss_SHORTEST_LENGTH_LT: Int
+  guiCss_SHORTEST_LENGTH_LTE: Int
+  name_AVERAGE_LENGTH_EQUAL: Float
+  name_AVERAGE_LENGTH_GT: Float
+  name_AVERAGE_LENGTH_GTE: Float
+  name_AVERAGE_LENGTH_LT: Float
+  name_AVERAGE_LENGTH_LTE: Float
+  name_LONGEST_LENGTH_EQUAL: Int
+  name_LONGEST_LENGTH_GT: Int
+  name_LONGEST_LENGTH_GTE: Int
+  name_LONGEST_LENGTH_LT: Int
+  name_LONGEST_LENGTH_LTE: Int
+  name_SHORTEST_LENGTH_EQUAL: Int
+  name_SHORTEST_LENGTH_GT: Int
+  name_SHORTEST_LENGTH_GTE: Int
+  name_SHORTEST_LENGTH_LT: Int
+  name_SHORTEST_LENGTH_LTE: Int
+  propTransformationJs_AVERAGE_LENGTH_EQUAL: Float
+  propTransformationJs_AVERAGE_LENGTH_GT: Float
+  propTransformationJs_AVERAGE_LENGTH_GTE: Float
+  propTransformationJs_AVERAGE_LENGTH_LT: Float
+  propTransformationJs_AVERAGE_LENGTH_LTE: Float
+  propTransformationJs_LONGEST_LENGTH_EQUAL: Int
+  propTransformationJs_LONGEST_LENGTH_GT: Int
+  propTransformationJs_LONGEST_LENGTH_GTE: Int
+  propTransformationJs_LONGEST_LENGTH_LT: Int
+  propTransformationJs_LONGEST_LENGTH_LTE: Int
+  propTransformationJs_SHORTEST_LENGTH_EQUAL: Int
+  propTransformationJs_SHORTEST_LENGTH_GT: Int
+  propTransformationJs_SHORTEST_LENGTH_GTE: Int
+  propTransformationJs_SHORTEST_LENGTH_LT: Int
+  propTransformationJs_SHORTEST_LENGTH_LTE: Int
+  renderForEachPropKey_AVERAGE_LENGTH_EQUAL: Float
+  renderForEachPropKey_AVERAGE_LENGTH_GT: Float
+  renderForEachPropKey_AVERAGE_LENGTH_GTE: Float
+  renderForEachPropKey_AVERAGE_LENGTH_LT: Float
+  renderForEachPropKey_AVERAGE_LENGTH_LTE: Float
+  renderForEachPropKey_LONGEST_LENGTH_EQUAL: Int
+  renderForEachPropKey_LONGEST_LENGTH_GT: Int
+  renderForEachPropKey_LONGEST_LENGTH_GTE: Int
+  renderForEachPropKey_LONGEST_LENGTH_LT: Int
+  renderForEachPropKey_LONGEST_LENGTH_LTE: Int
+  renderForEachPropKey_SHORTEST_LENGTH_EQUAL: Int
+  renderForEachPropKey_SHORTEST_LENGTH_GT: Int
+  renderForEachPropKey_SHORTEST_LENGTH_GTE: Int
+  renderForEachPropKey_SHORTEST_LENGTH_LT: Int
+  renderForEachPropKey_SHORTEST_LENGTH_LTE: Int
+  renderIfExpression_AVERAGE_LENGTH_EQUAL: Float
+  renderIfExpression_AVERAGE_LENGTH_GT: Float
+  renderIfExpression_AVERAGE_LENGTH_GTE: Float
+  renderIfExpression_AVERAGE_LENGTH_LT: Float
+  renderIfExpression_AVERAGE_LENGTH_LTE: Float
+  renderIfExpression_LONGEST_LENGTH_EQUAL: Int
+  renderIfExpression_LONGEST_LENGTH_GT: Int
+  renderIfExpression_LONGEST_LENGTH_GTE: Int
+  renderIfExpression_LONGEST_LENGTH_LT: Int
+  renderIfExpression_LONGEST_LENGTH_LTE: Int
+  renderIfExpression_SHORTEST_LENGTH_EQUAL: Int
+  renderIfExpression_SHORTEST_LENGTH_GT: Int
+  renderIfExpression_SHORTEST_LENGTH_GTE: Int
+  renderIfExpression_SHORTEST_LENGTH_LT: Int
+  renderIfExpression_SHORTEST_LENGTH_LTE: Int
+}
+
+type ElementChildMapperPreviousSiblingRelationship {
+  cursor: String!
+  node: Element!
+}
+
+input ElementChildMapperPreviousSiblingUpdateConnectionInput {
+  node: ElementUpdateInput
+}
+
+input ElementChildMapperPreviousSiblingUpdateFieldInput {
+  connect: ElementChildMapperPreviousSiblingConnectFieldInput
+  connectOrCreate: ElementChildMapperPreviousSiblingConnectOrCreateFieldInput
+  create: ElementChildMapperPreviousSiblingCreateFieldInput
+  delete: ElementChildMapperPreviousSiblingDeleteFieldInput
+  disconnect: ElementChildMapperPreviousSiblingDisconnectFieldInput
+  update: ElementChildMapperPreviousSiblingUpdateConnectionInput
+  where: ElementChildMapperPreviousSiblingConnectionWhere
+}
+
 type ElementComponentChildMapperComponentAggregationSelection {
   count: Int!
   node: ElementComponentChildMapperComponentNodeAggregateSelection
@@ -7143,6 +7357,7 @@ type ElementComponentRenderComponentTypeNodeAggregateSelection {
 
 input ElementConnectInput {
   childMapperComponent: ElementChildMapperComponentConnectFieldInput
+  childMapperPreviousSibling: ElementChildMapperPreviousSiblingConnectFieldInput
   firstChild: ElementFirstChildConnectFieldInput
   nextSibling: ElementNextSiblingConnectFieldInput
   page: ElementPageConnectFieldInput
@@ -7158,6 +7373,7 @@ input ElementConnectInput {
 
 input ElementConnectOrCreateInput {
   childMapperComponent: ElementChildMapperComponentConnectOrCreateFieldInput
+  childMapperPreviousSibling: ElementChildMapperPreviousSiblingConnectOrCreateFieldInput
   firstChild: ElementFirstChildConnectOrCreateFieldInput
   nextSibling: ElementNextSiblingConnectOrCreateFieldInput
   page: ElementPageConnectOrCreateFieldInput
@@ -7179,6 +7395,7 @@ input ElementConnectWhere {
 
 input ElementCreateInput {
   childMapperComponent: ElementChildMapperComponentFieldInput
+  childMapperPreviousSibling: ElementChildMapperPreviousSiblingFieldInput
   childMapperPropKey: String
   customCss: String
   firstChild: ElementFirstChildFieldInput
@@ -7202,6 +7419,7 @@ input ElementCreateInput {
 
 input ElementDeleteInput {
   childMapperComponent: ElementChildMapperComponentDeleteFieldInput
+  childMapperPreviousSibling: ElementChildMapperPreviousSiblingDeleteFieldInput
   firstChild: ElementFirstChildDeleteFieldInput
   nextSibling: ElementNextSiblingDeleteFieldInput
   page: ElementPageDeleteFieldInput
@@ -7217,6 +7435,7 @@ input ElementDeleteInput {
 
 input ElementDisconnectInput {
   childMapperComponent: ElementChildMapperComponentDisconnectFieldInput
+  childMapperPreviousSibling: ElementChildMapperPreviousSiblingDisconnectFieldInput
   firstChild: ElementFirstChildDisconnectFieldInput
   nextSibling: ElementNextSiblingDisconnectFieldInput
   page: ElementPageDisconnectFieldInput
@@ -7233,6 +7452,22 @@ input ElementDisconnectInput {
 type ElementEdge {
   cursor: String!
   node: Element!
+}
+
+type ElementElementChildMapperPreviousSiblingAggregationSelection {
+  count: Int!
+  node: ElementElementChildMapperPreviousSiblingNodeAggregateSelection
+}
+
+type ElementElementChildMapperPreviousSiblingNodeAggregateSelection {
+  childMapperPropKey: StringAggregateSelectionNullable!
+  customCss: StringAggregateSelectionNullable!
+  guiCss: StringAggregateSelectionNullable!
+  id: IDAggregateSelectionNonNullable!
+  name: StringAggregateSelectionNonNullable!
+  propTransformationJs: StringAggregateSelectionNullable!
+  renderForEachPropKey: StringAggregateSelectionNullable!
+  renderIfExpression: StringAggregateSelectionNullable!
 }
 
 type ElementElementFirstChildAggregationSelection {
@@ -8603,6 +8838,7 @@ input ElementPropsUpdateFieldInput {
 
 input ElementRelationInput {
   childMapperComponent: ElementChildMapperComponentCreateFieldInput
+  childMapperPreviousSibling: ElementChildMapperPreviousSiblingCreateFieldInput
   firstChild: ElementFirstChildCreateFieldInput
   nextSibling: ElementNextSiblingCreateFieldInput
   page: ElementPageCreateFieldInput
@@ -9159,6 +9395,7 @@ input ElementUniqueWhere {
 
 input ElementUpdateInput {
   childMapperComponent: ElementChildMapperComponentUpdateFieldInput
+  childMapperPreviousSibling: ElementChildMapperPreviousSiblingUpdateFieldInput
   childMapperPropKey: String
   customCss: String
   firstChild: ElementFirstChildUpdateFieldInput
@@ -9189,6 +9426,11 @@ input ElementWhere {
   childMapperComponentConnection: ElementChildMapperComponentConnectionWhere
   childMapperComponentConnection_NOT: ElementChildMapperComponentConnectionWhere
   childMapperComponent_NOT: ComponentWhere
+  childMapperPreviousSibling: ElementWhere
+  childMapperPreviousSiblingAggregate: ElementChildMapperPreviousSiblingAggregateInput
+  childMapperPreviousSiblingConnection: ElementChildMapperPreviousSiblingConnectionWhere
+  childMapperPreviousSiblingConnection_NOT: ElementChildMapperPreviousSiblingConnectionWhere
+  childMapperPreviousSibling_NOT: ElementWhere
   childMapperPropKey: String
   childMapperPropKey_CONTAINS: String
   childMapperPropKey_ENDS_WITH: String


### PR DESCRIPTION
<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(libs-ui-component): must begin with lowercase` -->

## Description

<!-- This is a short description on the Pull Request -->
- added a new field `childMapperPreviousSibling` to select where to render the instances of the child mapper
  - only the children of the element can be selected
- disable drag and drop of the child mapper instance nodes in the tree view

## Video or Image

<!-- Add video or image showing how the new feature works -->

https://github.com/codelab-app/platform/assets/27695022/63b92e4a-3861-40fd-b89e-11d17dd340bb


## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged -->

Fixes #2783 
