### PR TITLE
chore: e2e test for child mapper logic

### DIFF
--- a/apps/platform-e2e/src/e2e/builder.cy.ts
+++ b/apps/platform-e2e/src/e2e/builder.cy.ts
@@ -5,6 +5,11 @@ import { slugify } from '@codelab/shared/utils'
 import { FIELD_TYPE } from '../support/antd/form'
 import { loginSession } from '../support/nextjs-auth0/commands/login'
 
+interface ComponentChildData {
+  atom: string
+  name: string
+}
+
 const COMPONENT_NAME = 'Component Name'
 const ELEMENT_CONTAINER = 'Container'
 const ELEMENT_ROW = 'Row'
@@ -51,6 +56,11 @@ const elements = [
 ]
 
 const updatedElementName = 'Container Updated'
+
+const componentChildren = [
+  { atom: IAtomType.AntDesignSpace, name: 'Space' },
+  { atom: IAtomType.AntDesignTypographyText, name: 'Typography' },
+]
 
 describe('Elements CRUD', () => {
   before(() => {
@@ -153,6 +163,8 @@ describe('Element Child Mapper', () => {
       .then(() => cy.request<IAppDTO>('/api/cypress/app'))
       .then((apps) => {
         const app = apps.body
+
+        // create a component
         cy.visit(
           `/apps/cypress/${slugify(app.name)}/pages/${slugify(
             IPageKindName.Provider,
@@ -178,6 +190,46 @@ describe('Element Child Mapper', () => {
           timeout: 10000,
         })
         cy.findByText(COMPONENT_NAME).should('exist')
+
+        // add element to component
+        cy.getSider().getButton({ icon: 'edit' }).click()
+        cy.wrap(componentChildren).each((child: ComponentChildData) => {
+          cy.getCuiTreeItemByPrimaryTitle(COMPONENT_NAME).trigger('contextmenu')
+
+          cy.contains(/Add child/).click({ force: true })
+          cy.findByTestId('create-element-form').setFormFieldValue({
+            label: 'Render Type',
+            type: FIELD_TYPE.SELECT,
+            value: 'Atom',
+          })
+          cy.findByTestId('create-element-form').setFormFieldValue({
+            label: 'Atom',
+            type: FIELD_TYPE.SELECT,
+            value: child.atom,
+          })
+          cy.findByTestId('create-element-form').setFormFieldValue({
+            label: 'Name',
+            type: FIELD_TYPE.INPUT,
+            value: child.name,
+          })
+          cy.findByTestId('create-element-form')
+            .getButton({ label: 'Create Element' })
+            .click()
+          cy.findByTestId('create-element-form').should('not.exist', {
+            timeout: 10000,
+          })
+          cy.getCuiTreeItemByPrimaryTitle(child.name).click({ force: true })
+        })
+
+        // Should run after each
+        cy.get(`.ant-tabs [aria-label="setting"]`).click()
+        cy.get('.ant-tabs-tabpane-active form .ql-editor').type(
+          'text {{ props.name }}',
+          { parseSpecialCharSequences: false },
+        )
+        cy.get('#render-root').findByText('text undefined').should('exist')
+
+        // go to builder
         cy.visit(
           `/apps/cypress/${slugify(app.name)}/pages/${slugify(
             IPageKindName.Provider,
@@ -200,20 +252,114 @@ describe('Element Child Mapper', () => {
         name: ELEMENT_ROW,
         parentElement: ROOT_ELEMENT_NAME,
       },
+      {
+        name: 'Child 1',
+        parentElement: ELEMENT_ROW,
+      },
+      {
+        name: 'Child 2',
+        parentElement: ELEMENT_ROW,
+      },
     ])
-    cy.findByText(ELEMENT_ROW).click()
+    cy.findAllByText(ELEMENT_ROW).first().click()
     cy.findByText('Child Mapper').click()
+    cy.get('.ant-collapse').setFormFieldValue({
+      label: 'Render next to',
+      type: FIELD_TYPE.SELECT,
+      value: 'Child 2',
+    })
+    cy.get('.ant-collapse').findByRole('button', { name: 'JS' }).click()
+    cy.get('.ant-collapse').setFormFieldValue({
+      type: FIELD_TYPE.CODE_MIRROR,
+      value: '{{[{ name: "test 1" }, { name: "test 2" }]}}',
+    })
     cy.get('.ant-collapse').setFormFieldValue({
       label: 'Component',
       type: FIELD_TYPE.SELECT,
       value: COMPONENT_NAME,
     })
-    cy.get('.ant-collapse').findByRole('button', { name: 'JS' }).click()
+  })
+
+  it('should render the component instances with props values from array', () => {
+    cy.get('#render-root').findByText('text test 1').should('exist')
+    cy.get('#render-root').findByText('text test 2').should('exist')
+  })
+
+  it('should render the component instances n times and next to the selected previous sibling', () => {
+    cy.get('.ant-tree-treenode-draggable:nth-child(3)')
+      .findByText('Child 2')
+      .should('exist')
+    cy.get('.ant-tree-treenode-draggable:nth-child(4)')
+      .findByText(`${COMPONENT_NAME} 0`)
+      .should('exist')
+    cy.get('.ant-tree-treenode-draggable:nth-child(5)')
+      .findByText(`${COMPONENT_NAME} 1`)
+      .should('exist')
+    cy.get('.ant-tree-treenode-draggable:nth-child(6)')
+      .findByText('Child 1')
+      .should('exist')
+  })
+
+  it('should update the rendered instances when props values from array and previous sibling is updated', () => {
     cy.get('.ant-collapse').setFormFieldValue({
-      // label: 'Prop Key',
-      type: FIELD_TYPE.CODE_MIRROR,
-      value: '{{state.arrayProp}}',
+      label: 'Render next to',
+      type: FIELD_TYPE.SELECT,
+      value: 'Child 1',
     })
-    // cy.findByText(updatedElementName).should('exist')
+    cy.get('.ant-collapse').setFormFieldValue({
+      type: FIELD_TYPE.CODE_MIRROR,
+      value: '{{[{ name: "updated test 1" }, { name: "updated test 2" }]}}',
+    })
+
+    // changed props
+    cy.get('#render-root').findByText('text updated test 1').should('exist')
+    cy.get('#render-root').findByText('text updated test 2').should('exist')
+
+    // For some reason, when the prop is auto updated from the form, theres some delay in the tree view changes
+    // and the element node being queried still has the old value
+    // eslint-disable-next-line cypress/no-unnecessary-waiting
+    cy.wait(2000)
+
+    // changed order
+    cy.get('.ant-tree-treenode-draggable:nth-child(3)')
+      .findByText('Child 2')
+      .should('exist')
+    cy.get('.ant-tree-treenode-draggable:nth-child(4)')
+      .findByText('Child 1')
+      .should('exist')
+    cy.get('.ant-tree-treenode-draggable:nth-child(5)')
+      .findByText(`${COMPONENT_NAME} 0`)
+      .should('exist')
+    cy.get('.ant-tree-treenode-draggable:nth-child(6)')
+      .findByText(`${COMPONENT_NAME} 1`)
+      .should('exist')
+  })
+
+  it('should not render instances when the prop arrary is empty', () => {
+    cy.get('.ant-collapse').setFormFieldValue({
+      type: FIELD_TYPE.CODE_MIRROR,
+      value: '{{[]}}',
+    })
+
+    // rendered instances are removed
+    cy.get('.ant-tree-treenode-draggable').should('have.length', 4)
+
+    // changed props
+    cy.get('#render-root').findByText('text updated test 1').should('not.exist')
+    cy.get('#render-root').findByText('text updated test 2').should('not.exist')
+  })
+
+  it('should not render instances when the prop is not an array', () => {
+    cy.get('.ant-collapse').setFormFieldValue({
+      type: FIELD_TYPE.CODE_MIRROR,
+      value: '{{false}}',
+    })
+
+    // rendered instances are removed
+    cy.get('.ant-tree-treenode-draggable').should('have.length', 4)
+
+    // changed props
+    cy.get('#render-root').findByText('text updated test 1').should('not.exist')
+    cy.get('#render-root').findByText('text updated test 2').should('not.exist')
   })
 })


### PR DESCRIPTION
<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(libs-ui-component): must begin with lowercase` -->

## Description

<!-- This is a short description on the Pull Request -->
Tests for the child mapper logic

- [x] when the data from the evaluated childMapperPropKey is not an array, it should not render childMapperComponent instances
- [x] if it is an array, it should render the instances n times and passing the item data as the props for each instance
- [x] the instances are rendered in the correct position based on the childMapperPreviousSibling
- [x] the rendered instances reacts correctly when the array data and childMapperPreviousSibling is updated

## Video or Image

<!-- Add video or image showing how the new feature works -->

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged -->

Fixes #2801 
