### PR TITLE
fix: download components when exported from ui

### DIFF
--- a/apps/platform/pages/api/export/component.ts
+++ b/apps/platform/pages/api/export/component.ts
@@ -13,7 +13,16 @@ const exportComponent: NextApiHandler = async (req, res) => {
 
     const { id } = req.query
 
-    await new ExportAdminDataService().exportComponent(String(id))
+    const componentData = await new ExportAdminDataService().exportComponent(
+      String(id),
+    )
+
+    const componentName = componentData.component.name
+    const filename = `${componentName}.json`
+
+    res.setHeader('Content-Type', 'application/json')
+    res.setHeader('Content-Disposition', `attachment; filename=${filename}`)
+    res.write(JSON.stringify(componentData), 'utf-8')
 
     return res.end()
   } catch (error) {

--- a/libs/backend/application/admin/src/use-case/export-admin-data.service.ts
+++ b/libs/backend/application/admin/src/use-case/export-admin-data.service.ts
@@ -166,7 +166,7 @@ export class ExportAdminDataService extends UseCase<
   async exportComponent(id: string) {
     const componentsData = await this.extractComponentsData({ id })
 
-    if (!componentsData.length) {
+    if (!componentsData.length || !componentsData[0]) {
       throw new Error(`Component with id ${id} not found`)
     }
 

--- a/libs/backend/application/admin/src/use-case/export-admin-data.service.ts
+++ b/libs/backend/application/admin/src/use-case/export-admin-data.service.ts
@@ -166,9 +166,11 @@ export class ExportAdminDataService extends UseCase<
   async exportComponent(id: string) {
     const componentsData = await this.extractComponentsData({ id })
 
-    if (componentsData[0]) {
-      this.saveComponentAsFile(componentsData[0])
+    if (!componentsData.length) {
+      throw new Error(`Component with id ${id} not found`)
     }
+
+    return componentsData[0]
   }
 
   saveComponentAsFile(componentData: IComponentExportData) {

--- a/libs/frontend/domain/component/src/use-cases/get-components/columns/ActionColumn.tsx
+++ b/libs/frontend/domain/component/src/use-cases/get-components/columns/ActionColumn.tsx
@@ -7,9 +7,9 @@ import {
   ListItemDeleteButton,
   ListItemEditButton,
 } from '@codelab/frontend/presentation/view'
-import { useAsync } from '@react-hookz/web'
-import { Button, message, Space } from 'antd'
+import { Space } from 'antd'
 import { observer } from 'mobx-react-lite'
+import Link from 'next/link'
 import { useRouter } from 'next/router'
 import React from 'react'
 import type { ComponentColumnData } from './types'
@@ -21,10 +21,6 @@ export interface ActionColumnProps {
 export const ActionColumn = observer<ActionColumnProps>(({ component }) => {
   const router = useRouter()
   const { componentService } = useStore()
-
-  const [{ status }, exportComponent] = useAsync(() =>
-    fetch(`/api/export/component?id=${component.id}`),
-  )
 
   const onEdit = () => {
     componentService.updateModal.open(componentRef(component.id))
@@ -41,21 +37,14 @@ export const ActionColumn = observer<ActionColumnProps>(({ component }) => {
     })
   }
 
-  const onExport = async () => {
-    exportComponent
-      .execute()
-      .then(() => message.success('Export success!'))
-      .catch(() => message.error('Export failed!'))
-  }
-
   return (
     <Space size="middle">
       <ListItemButton icon={<ApartmentOutlined />} onClick={onBuilder} />
       <ListItemEditButton onClick={onEdit} />
       <ListItemDeleteButton onClick={onDelete} />
-      <Button loading={status === 'loading'} onClick={onExport} type="text">
-        Export
-      </Button>
+      <Link href={`/api/export/component?id=${component.id}`}>
+        <span>Export</span>
+      </Link>
     </Space>
   )
 })


### PR DESCRIPTION
<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(libs-ui-component): must begin with lowercase` -->

## Description
The current implementation of component export saves the exported component to the codebase. This pr changes the implementation to download the file instead. 

<!-- This is a short description on the Pull Request -->

## Video or Image

<!-- Add video or image showing how the new feature works -->

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged -->

Fixes #2796 
