### PR TITLE
fix: select link element

### DIFF
--- a/libs/frontend/domain/element/src/components/SelectLinkElement.tsx
+++ b/libs/frontend/domain/element/src/components/SelectLinkElement.tsx
@@ -20,6 +20,8 @@ export const SelectLinkElement = observer(
   ({
     allElementOptions,
     name,
+    // Somehow if `onChange` with undefined value is passed into the
+    // uniform-antd SelectField it fails because it will still try to run the `onChange`
     onChange = noop,
     required,
     targetElementId,

--- a/libs/frontend/domain/element/src/components/SelectLinkElement.tsx
+++ b/libs/frontend/domain/element/src/components/SelectLinkElement.tsx
@@ -1,7 +1,6 @@
 import type { ICreateElementData } from '@codelab/frontend/abstract/core'
 import type { SelectElementProps } from '@codelab/frontend/domain/type'
 import { SelectChildElement } from '@codelab/frontend/domain/type'
-import noop from 'lodash/noop'
 import { observer } from 'mobx-react-lite'
 import { useForm } from 'uniforms'
 import type { SelectFieldProps } from 'uniforms-antd'
@@ -20,9 +19,7 @@ export const SelectLinkElement = observer(
   ({
     allElementOptions,
     name,
-    // Somehow if `onChange` with undefined value is passed into the
-    // uniform-antd SelectField it fails because it will still try to run the `onChange`
-    onChange = noop,
+    onChange,
     required,
     targetElementId,
   }: SelectLinkElementProps) => {
@@ -40,10 +37,13 @@ export const SelectLinkElement = observer(
             allElementOptions={allElementOptions}
             allowClear
             disableWhenOneOpt={false}
-            onChange={onChange}
             targetElementId={parentElementId}
             // eslint-disable-next-line react/jsx-props-no-spreading, @typescript-eslint/no-explicit-any
             {...(props as any)}
+            // Somehow if `onChange` with undefined value is passed into the
+            // uniform-antd SelectField it fails because it will still try to run the `onChange`
+            // eslint-disable-next-line react/jsx-props-no-spreading
+            {...(onChange ? { onChange } : {})}
           />
         )}
         name={name}

--- a/libs/frontend/domain/element/src/components/SelectLinkElement.tsx
+++ b/libs/frontend/domain/element/src/components/SelectLinkElement.tsx
@@ -19,7 +19,6 @@ export const SelectLinkElement = observer(
   ({
     allElementOptions,
     name,
-    onChange,
     required,
     targetElementId,
   }: SelectLinkElementProps) => {
@@ -37,7 +36,6 @@ export const SelectLinkElement = observer(
             allElementOptions={allElementOptions}
             allowClear
             disableWhenOneOpt={false}
-            onChange={onChange}
             targetElementId={parentElementId}
             // eslint-disable-next-line react/jsx-props-no-spreading, @typescript-eslint/no-explicit-any
             {...(props as any)}

--- a/libs/frontend/domain/element/src/components/SelectLinkElement.tsx
+++ b/libs/frontend/domain/element/src/components/SelectLinkElement.tsx
@@ -1,6 +1,7 @@
 import type { ICreateElementData } from '@codelab/frontend/abstract/core'
 import type { SelectElementProps } from '@codelab/frontend/domain/type'
 import { SelectChildElement } from '@codelab/frontend/domain/type'
+import noop from 'lodash/noop'
 import { observer } from 'mobx-react-lite'
 import { useForm } from 'uniforms'
 import type { SelectFieldProps } from 'uniforms-antd'
@@ -19,6 +20,7 @@ export const SelectLinkElement = observer(
   ({
     allElementOptions,
     name,
+    onChange = noop,
     required,
     targetElementId,
   }: SelectLinkElementProps) => {
@@ -36,6 +38,7 @@ export const SelectLinkElement = observer(
             allElementOptions={allElementOptions}
             allowClear
             disableWhenOneOpt={false}
+            onChange={onChange}
             targetElementId={parentElementId}
             // eslint-disable-next-line react/jsx-props-no-spreading, @typescript-eslint/no-explicit-any
             {...(props as any)}


### PR DESCRIPTION
<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(libs-ui-component): must begin with lowercase` -->

## Description

<!-- This is a short description on the Pull Request -->
It seems this was caused due to some changes for the SelectLinkElement component that is used for the child mapper logic.

Somehow if the `onChange` passed to the uniform-antd's SelectField is `undefined`, it still tries to run the [props.onChange](https://github.com/vazco/uniforms/blob/master/packages/uniforms-antd/src/SelectField.tsx#L76). Its probably some bug in uniform-antd. But this can be fixed on our end by not setting the `onChange` prop if it is undefined

## Video or Image

<!-- Add video or image showing how the new feature works -->


https://github.com/codelab-app/platform/assets/27695022/b656b4e2-d0d3-46cf-9904-eae14b3a244a



## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged -->

Fixes #2822 
