### PR TITLE
feat: state sharing between pages

### DIFF
--- a/apps/platform-e2e/src/e2e/builder.cy.ts
+++ b/apps/platform-e2e/src/e2e/builder.cy.ts
@@ -364,7 +364,7 @@ describe('Element Child Mapper', () => {
   })
 })
 
-describe.only('State variables sharing between pages', () => {
+describe('State variables sharing between pages', () => {
   before(() => {
     cy.resetDatabase()
     loginSession()

--- a/apps/platform-e2e/src/e2e/builder.cy.ts
+++ b/apps/platform-e2e/src/e2e/builder.cy.ts
@@ -363,3 +363,297 @@ describe('Element Child Mapper', () => {
     cy.get('#render-root').findByText('text updated test 2').should('not.exist')
   })
 })
+
+describe.only('State sharing between pages', () => {
+  before(() => {
+    cy.resetDatabase()
+    loginSession()
+
+    cy.request('/api/cypress/type')
+
+    cy.request('/api/cypress/atom')
+      .then(() => cy.request<IAppDTO>('/api/cypress/app'))
+      .then((apps) => {
+        const app = apps.body
+
+        // create regular page
+        cy.visit(`/apps/cypress/${slugify(app.name)}/pages`)
+        cy.getSpinner().should('not.exist')
+
+        cy.getSider().getButton({ icon: 'plus' }).click()
+
+        // eslint-disable-next-line cypress/no-unnecessary-waiting
+        cy.wait(5000)
+
+        cy.findByTestId('create-page-form')
+          .findByLabelText('Name')
+          .type('Testpage')
+        cy.findByTestId('create-page-form')
+          .getButton({ label: 'Create Page' })
+          .click()
+
+        // create a component
+        cy.visit(
+          `/apps/cypress/${slugify(app.name)}/pages/${slugify(
+            IPageKindName.Provider,
+          )}/builder?primarySidebarKey=components`,
+        )
+        // GetRenderedPageAndCommonAppData
+        cy.waitForApiCalls()
+        cy.getSpinner().should('not.exist')
+
+        // GetAtoms
+        // GetComponents
+        cy.waitForApiCalls()
+        cy.getSpinner().should('not.exist')
+
+        cy.getCuiSidebar('Components').getToolbarItem('Add Component').click()
+        cy.findByTestId('create-component-form')
+          .findByLabelText('Name')
+          .type(COMPONENT_NAME)
+        cy.findByTestId('create-component-form')
+          .getButton({ label: 'Create Component' })
+          .click()
+        cy.findByTestId('create-component-form').should('not.exist', {
+          timeout: 10000,
+        })
+        cy.findByText(COMPONENT_NAME).should('exist')
+
+        // add element to component
+        cy.getSider().getButton({ icon: 'edit' }).click()
+        cy.wrap(componentChildren).each((child: ComponentChildData) => {
+          cy.getCuiTreeItemByPrimaryTitle(COMPONENT_NAME).trigger('contextmenu')
+
+          cy.contains(/Add child/).click({ force: true })
+          cy.findByTestId('create-element-form').setFormFieldValue({
+            label: 'Render Type',
+            type: FIELD_TYPE.SELECT,
+            value: 'Atom',
+          })
+          cy.findByTestId('create-element-form').setFormFieldValue({
+            label: 'Atom',
+            type: FIELD_TYPE.SELECT,
+            value: child.atom,
+          })
+          cy.findByTestId('create-element-form').setFormFieldValue({
+            label: 'Name',
+            type: FIELD_TYPE.INPUT,
+            value: child.name,
+          })
+          cy.findByTestId('create-element-form')
+            .getButton({ label: 'Create Element' })
+            .click()
+          cy.findByTestId('create-element-form').should('not.exist', {
+            timeout: 10000,
+          })
+          cy.getCuiTreeItemByPrimaryTitle(child.name).click({ force: true })
+        })
+
+        // Should run after each
+        cy.get(`.ant-tabs [aria-label="setting"]`).click()
+        cy.get('.ant-tabs-tabpane-active form .ql-editor').type(
+          'text {{ props.name ?? rootState.name ?? state.name }}',
+          { parseSpecialCharSequences: false },
+        )
+
+        cy.get('#render-root').findByText('text undefined').should('exist')
+
+        cy.get('[data-cy="codelabui-sidebar-view-header-State"]').click()
+        cy.get('[data-cy="codelabui-toolbar-item-Add Field"]').click()
+
+        cy.get(
+          '[data-cy="codelabui-sidebar-view-content-State"]',
+        ).setFormFieldValue({
+          label: 'Key',
+          type: FIELD_TYPE.INPUT,
+          value: 'name',
+        })
+
+        cy.get(
+          '[data-cy="codelabui-sidebar-view-content-State"]',
+        ).setFormFieldValue({
+          label: 'Type',
+          type: FIELD_TYPE.SELECT,
+          value: 'String',
+        })
+
+        // eslint-disable-next-line cypress/no-unnecessary-waiting
+        cy.wait(1000)
+
+        cy.get(
+          '[data-cy="codelabui-sidebar-view-content-State"]',
+        ).setFormFieldValue({
+          label: 'Default values',
+          type: FIELD_TYPE.CODE_MIRROR,
+          value: 'component state value',
+        })
+
+        cy.get('[data-cy="codelabui-sidebar-view-content-State"]')
+          .getButton({ label: 'Create Field' })
+          .click()
+
+        cy.get('#render-root')
+          .findByText('text component state value')
+          .should('exist')
+
+        // go to builder
+        cy.visit(
+          `/apps/cypress/${slugify(app.name)}/pages/${slugify(
+            IPageKindName.Provider,
+          )}/builder?primarySidebarKey=explorer`,
+        )
+        cy.getSpinner().should('not.exist')
+
+        // select root now so we can update its child later
+        // there is an issue with tree interaction
+        // Increased timeout since builder may take longer to load
+        cy.findByText(ROOT_ELEMENT_NAME, { timeout: 30000 })
+          .should('be.visible')
+          .click({ force: true })
+
+        cy.getCuiSidebar('Explorer').getToolbarItem('Add Element').click()
+
+        cy.findByTestId('create-element-form').setFormFieldValue({
+          label: 'Render Type',
+          type: FIELD_TYPE.SELECT,
+          value: 'Atom',
+        })
+        cy.findByTestId('create-element-form').setFormFieldValue({
+          label: 'Atom',
+          type: FIELD_TYPE.SELECT,
+          value: IAtomType.AntDesignButton,
+        })
+        // eslint-disable-next-line cypress/no-unnecessary-waiting
+        cy.wait(500)
+        // cy.findByTestId('create-element-form').setFormFieldValue({
+        //   label: 'Name',
+        //   type: FIELD_TYPE.INPUT,
+        //   value: ELEMENT_BUTTON,
+        // })
+        cy.findByTestId('create-element-form')
+          .getButton({ label: 'Create Element' })
+          .click()
+        cy.findByTestId('create-element-form').should('not.exist', {
+          timeout: 10000,
+        })
+      })
+  })
+
+  it('should be able to use the state from the provider page', () => {
+    cy.get('[data-cy="codelabui-sidebar-view-header-State"]').click()
+    cy.get('[data-cy="codelabui-toolbar-item-Add Field"]').click()
+
+    cy.get(
+      '[data-cy="codelabui-sidebar-view-content-State"]',
+    ).setFormFieldValue({
+      label: 'Key',
+      type: FIELD_TYPE.INPUT,
+      value: 'name',
+    })
+
+    cy.get(
+      '[data-cy="codelabui-sidebar-view-content-State"]',
+    ).setFormFieldValue({
+      label: 'Type',
+      type: FIELD_TYPE.SELECT,
+      value: 'String',
+    })
+
+    cy.get(
+      '[data-cy="codelabui-sidebar-view-content-State"]',
+    ).setFormFieldValue({
+      label: 'Default values',
+      type: FIELD_TYPE.CODE_MIRROR,
+      value: 'provider state value',
+    })
+
+    cy.get('[data-cy="codelabui-sidebar-view-content-State"]')
+      .getButton({ label: 'Create Field' })
+      .click()
+
+    // go to builder
+    cy.visit(
+      `/apps/cypress/codelab-app/pages/testpage/builder?primarySidebarKey=explorer`,
+    )
+    // GetRenderedPageAndCommonAppData
+    cy.waitForApiCalls()
+    cy.getSpinner().should('not.exist')
+
+    // GetAtoms
+    // GetComponents
+    cy.waitForApiCalls()
+    cy.getSpinner().should('not.exist')
+
+    // eslint-disable-next-line cypress/no-unnecessary-waiting
+    cy.wait(5000)
+
+    // select root now so we can update its child later
+    // there is an issue with tree interaction
+    // Increased timeout since builder may take longer to load
+    cy.findByText(ROOT_ELEMENT_NAME, { timeout: 30000 })
+      .should('be.visible')
+      .click({ force: true })
+
+    cy.getCuiTreeItemByPrimaryTitle('Body').click({ force: true })
+
+    cy.getCuiSidebar('Explorer').getToolbarItem('Add Element').click()
+
+    cy.findByTestId('create-element-form').setFormFieldValue({
+      label: 'Render Type',
+      type: FIELD_TYPE.SELECT,
+      value: 'Component',
+    })
+    cy.findByTestId('create-element-form').setFormFieldValue({
+      label: 'Component',
+      type: FIELD_TYPE.SELECT,
+      value: COMPONENT_NAME,
+    })
+
+    cy.findByTestId('create-element-form').setFormFieldValue({
+      label: 'Name',
+      type: FIELD_TYPE.INPUT,
+      value: COMPONENT_NAME,
+    })
+
+    cy.findByTestId('create-element-form')
+      .getButton({ label: 'Create Element' })
+      .click()
+
+    cy.findByTestId('create-element-form').should('not.exist', {
+      timeout: 10000,
+    })
+
+    cy.getCuiSidebar('Explorer').getToolbarItem('Add Element').click()
+
+    cy.findByTestId('create-element-form').setFormFieldValue({
+      label: 'Render Type',
+      type: FIELD_TYPE.SELECT,
+      value: 'Atom',
+    })
+    cy.findByTestId('create-element-form').setFormFieldValue({
+      label: 'Atom',
+      type: FIELD_TYPE.SELECT,
+      value: IAtomType.AntDesignButton,
+    })
+    // eslint-disable-next-line cypress/no-unnecessary-waiting
+    cy.wait(500)
+    // cy.findByTestId('create-element-form').setFormFieldValue({
+    //   label: 'Name',
+    //   type: FIELD_TYPE.INPUT,
+    //   value: ELEMENT_BUTTON,
+    // })
+    cy.findByTestId('create-element-form')
+      .getButton({ label: 'Create Element' })
+      .click()
+    cy.findByTestId('create-element-form').should('not.exist', {
+      timeout: 10000,
+    })
+
+    // eslint-disable-next-line cypress/no-unnecessary-waiting
+    cy.wait(2000)
+
+    cy.get('#render-root')
+      .findByText('text provider state value')
+      .should('exist')
+  })
+})

--- a/libs/frontend/abstract/core/src/domain/component/component.ref.ts
+++ b/libs/frontend/abstract/core/src/domain/component/component.ref.ts
@@ -47,7 +47,7 @@ export const isComponentInstance = (
   return !isNil(node) && isRefOfType(node, componentRef)
 }
 
-export const isComponentModel = (model: object): model is IComponent => {
+export const isComponentModel = (model?: object): model is IComponent => {
   return (
     !isNil(model) &&
     // `IComponent` is mobx model type

--- a/libs/frontend/abstract/core/src/domain/element/element.model.interface.ts
+++ b/libs/frontend/abstract/core/src/domain/element/element.model.interface.ts
@@ -88,6 +88,8 @@ export interface IElement
   prevSibling?: Nullable<Ref<IElement>>
   propTransformationJs: Nullable<string>
   props: Ref<IProp>
+  // store attached to the provider page
+  providerStore?: Ref<IStore>
   renderForEachPropKey: Nullable<string>
   renderIfExpression: Nullable<string>
   renderType: IElementRenderType | null

--- a/libs/frontend/abstract/core/src/domain/render/action.runner.model.interface.ts
+++ b/libs/frontend/abstract/core/src/domain/render/action.runner.model.interface.ts
@@ -1,6 +1,12 @@
 import type { Ref } from 'mobx-keystone'
 import type { IAction } from '../action'
 import type { IPropData } from '../prop'
+import type { IStore } from '../store'
+
+export interface ActionRunnerThisObject {
+  rootState?: IPropData
+  state: IPropData
+}
 
 export interface IActionRunner {
   actionRef: Ref<IAction>
@@ -12,3 +18,25 @@ export interface IActionRunner {
 
 export const getRunnerId = (storeId: string, actionId: string) =>
   `${storeId}${actionId}`
+
+export const getActionRunnerThisObject = (
+  runner: IActionRunner,
+  store: Ref<IStore>,
+  providerStore?: Ref<IStore>,
+) => {
+  const _this: ActionRunnerThisObject = {
+    state: store.current.state,
+  }
+
+  // If the action used in a regular page is from the provider, the `state` to use
+  // in the action should be the `state` from the provider store
+  if (providerStore) {
+    const isActionFromProvider =
+      runner.actionRef.current.store.id === providerStore.id
+
+    _this[isActionFromProvider ? 'state' : 'rootState'] =
+      providerStore.current.state
+  }
+
+  return _this
+}

--- a/libs/frontend/domain/builder/src/sections/explorer-pane/BuilderPrimarySidebar.tsx
+++ b/libs/frontend/domain/builder/src/sections/explorer-pane/BuilderPrimarySidebar.tsx
@@ -1,5 +1,9 @@
 import { PlusOutlined } from '@ant-design/icons'
-import type { IPageNode, IStore } from '@codelab/frontend/abstract/core'
+import type {
+  IElement,
+  IPageNode,
+  IStore,
+} from '@codelab/frontend/abstract/core'
 import {
   elementRef,
   elementTreeRef,
@@ -68,6 +72,10 @@ export const BuilderPrimarySidebar = observer<{ isLoading?: boolean }>(
     const antdTree = root?.current.treeViewNode
     const isPageTree = antdTree && pageTree
     const store = builderService.selectedNode?.current.store.current
+
+    const providerStore = (
+      builderService.selectedNode?.current as IElement | undefined
+    )?.providerStore?.current
 
     const selectTreeNode = (node: IPageNode) => {
       if (isComponentPageNode(node)) {
@@ -220,6 +228,7 @@ export const BuilderPrimarySidebar = observer<{ isLoading?: boolean }>(
         content: store && (
           <CodeMirrorEditor
             className="mt-1"
+            editable={false}
             language={CodeMirrorLanguage.Json}
             onChange={() => undefined}
             singleLine={false}
@@ -230,6 +239,22 @@ export const BuilderPrimarySidebar = observer<{ isLoading?: boolean }>(
         isLoading: isLoading || !store,
         key: 'Inspector',
         label: 'Inspector',
+      },
+      {
+        content: providerStore && (
+          <CodeMirrorEditor
+            className="mt-1"
+            editable={false}
+            language={CodeMirrorLanguage.Json}
+            onChange={() => undefined}
+            singleLine={false}
+            title="Current root props"
+            value={providerStore.jsonString}
+          />
+        ),
+        isLoading: isLoading || !store,
+        key: 'InspectorRoot',
+        label: 'Inspector Root',
       },
     ]
 

--- a/libs/frontend/domain/element/src/store/element.model.ts
+++ b/libs/frontend/domain/element/src/store/element.model.ts
@@ -210,6 +210,12 @@ export class Element
   }
 
   @computed
+  get providerStore(): Ref<IStore> | undefined {
+    return this.renderService.activeRenderer?.current.providerTree?.current
+      .rootElement.current.store
+  }
+
+  @computed
   get children(): Array<IElement> {
     const firstChild = this.firstChild
 

--- a/libs/frontend/domain/renderer/src/action-runner.model.ts
+++ b/libs/frontend/domain/renderer/src/action-runner.model.ts
@@ -1,4 +1,5 @@
 import type {
+  ActionRunnerThisObject,
   IAction,
   IActionRunner,
   IApiAction,
@@ -152,7 +153,7 @@ export class ActionRunner
     return async function (...args: Array<unknown>) {
       const overrideConfig = args[1] as IPropData
       // @ts-expect-error: due to not using arrow function
-      const _this = this as { state: IPropData; rootState?: IPropData }
+      const _this = this as ActionRunnerThisObject
 
       const evaluatedConfig = replaceStateInProps(
         config,

--- a/libs/frontend/domain/renderer/src/element-runtime-props.model.ts
+++ b/libs/frontend/domain/renderer/src/element-runtime-props.model.ts
@@ -79,6 +79,7 @@ export class ElementRuntimeProps
     return replaceStateInProps(
       this.renderedTypedProps,
       this.node.store.current.state,
+      this.node.providerStore?.current.state,
       injectedProps,
     )
   }
@@ -91,6 +92,7 @@ export class ElementRuntimeProps
     return replaceStateInProps(
       this.props,
       this.node.store.current.state,
+      this.node.providerStore?.current.state,
       injectedProps,
     )
   }
@@ -108,6 +110,7 @@ export class ElementRuntimeProps
       const evaluatedExpression = evaluateExpression(
         this.node.childMapperPropKey,
         this.node.store.current.state,
+        this.node.providerStore?.current.state,
         injectedProps,
       )
 
@@ -122,6 +125,7 @@ export class ElementRuntimeProps
 
     const allPropsOptions = mergeProps(this.node.store.current.state, {
       props: injectedProps,
+      rootState: this.node.providerStore?.current.state,
     })
 
     const evaluatedChildMapperProp = get(

--- a/libs/frontend/domain/renderer/src/element/element-wrapper.ts
+++ b/libs/frontend/domain/renderer/src/element/element-wrapper.ts
@@ -1,10 +1,10 @@
 import type {
   IComponentType,
   IElement,
-  IPropData,
   IRenderer,
 } from '@codelab/frontend/abstract/core'
 import {
+  getActionRunnerThisObject,
   getRunnerId,
   isAtomInstance,
   RendererType,
@@ -44,24 +44,17 @@ export const ElementWrapper = observer<ElementWrapperProps>(
       const actionRunnerId = getRunnerId(store.id, postRenderAction.id)
       const postRenderActionRunner = renderer.actionRunners.get(actionRunnerId)
 
-      const _this: { state: IPropData; rootState?: IPropData } = {
-        state: store.current.state,
+      if (postRenderActionRunner) {
+        const _this = getActionRunnerThisObject(
+          postRenderActionRunner,
+          element.store,
+          element.providerStore,
+        )
+
+        postRenderActionRunner.runner.bind(_this)
+
+        postRenderActionRunner.runner()
       }
-
-      // If the action used in a regular page is from the provider, the `state` to use
-      // in the action should be the `state` from the provider store
-      if (element.providerStore) {
-        const isActionFromProvider =
-          postRenderActionRunner?.actionRef.current.store.id ===
-          element.providerStore.id
-
-        _this[isActionFromProvider ? 'state' : 'rootState'] =
-          element.providerStore.current.state
-      }
-
-      const runner = postRenderActionRunner?.runner.bind(_this)
-
-      runner?.()
     }, [])
 
     const { atomService } = useStore()

--- a/libs/frontend/domain/renderer/src/element/element-wrapper.ts
+++ b/libs/frontend/domain/renderer/src/element/element-wrapper.ts
@@ -51,9 +51,9 @@ export const ElementWrapper = observer<ElementWrapperProps>(
           element.providerStore,
         )
 
-        postRenderActionRunner.runner.bind(_this)
+        const runner = postRenderActionRunner.runner.bind(_this)
 
-        postRenderActionRunner.runner()
+        runner()
       }
     }, [])
 

--- a/libs/frontend/domain/renderer/src/element/element-wrapper.ts
+++ b/libs/frontend/domain/renderer/src/element/element-wrapper.ts
@@ -1,6 +1,7 @@
 import type {
   IComponentType,
   IElement,
+  IPropData,
   IRenderer,
 } from '@codelab/frontend/abstract/core'
 import {
@@ -42,7 +43,23 @@ export const ElementWrapper = observer<ElementWrapperProps>(
 
       const actionRunnerId = getRunnerId(store.id, postRenderAction.id)
       const postRenderActionRunner = renderer.actionRunners.get(actionRunnerId)
-      const runner = postRenderActionRunner?.runner.bind(store.current.state)
+
+      const _this: { state: IPropData; rootState?: IPropData } = {
+        state: store.current.state,
+      }
+
+      // If the action used in a regular page is from the provider, the `state` to use
+      // in the action should be the `state` from the provider store
+      if (element.providerStore) {
+        const isActionFromProvider =
+          postRenderActionRunner?.actionRef.current.store.id ===
+          element.providerStore.id
+
+        _this[isActionFromProvider ? 'state' : 'rootState'] =
+          element.providerStore.current.state
+      }
+
+      const runner = postRenderActionRunner?.runner.bind(_this)
 
       runner?.()
     }, [])

--- a/libs/frontend/domain/renderer/src/renderer.model.ts
+++ b/libs/frontend/domain/renderer/src/renderer.model.ts
@@ -203,9 +203,9 @@ export class Renderer
           element.providerStore,
         )
 
-        preRenderActionRunner.runner.bind(_this)
+        const runner = preRenderActionRunner.runner.bind(_this)
 
-        preRenderActionRunner.runner()
+        runner()
       }
     }
 

--- a/libs/frontend/domain/renderer/src/typedPropTransformers/action-type-transformer.ts
+++ b/libs/frontend/domain/renderer/src/typedPropTransformers/action-type-transformer.ts
@@ -1,9 +1,10 @@
-import {
-  getRunnerId,
-  type IPageNode,
-  type ITypedPropTransformer,
-  type TypedProp,
+import type {
+  IPageNode,
+  IPropData,
+  ITypedPropTransformer,
+  TypedProp,
 } from '@codelab/frontend/abstract/core'
+import { getRunnerId, isElementPageNode } from '@codelab/frontend/abstract/core'
 import { hasStateExpression } from '@codelab/frontend/shared/utils'
 import { ExtendedModel, model } from 'mobx-keystone'
 import { BaseRenderPipe } from '../renderPipes/render-pipe.base'
@@ -33,17 +34,39 @@ export class ActionTypeTransformer
       return prop.value
     }
 
-    const state = node.store.current.state
+    const providerStore = isElementPageNode(node)
+      ? node.providerStore
+      : undefined
 
     const actionRunner = this.renderer.actionRunners.get(
       getRunnerId(node.store.id, prop.value),
     )
 
+    const rootActionRunner = providerStore
+      ? this.renderer.actionRunners.get(
+          getRunnerId(providerStore.id, prop.value),
+        )
+      : undefined
+
     const fallback = () =>
       console.error(`fail to call action with id ${prop.value}`)
 
-    const runner = actionRunner?.runner || fallback
+    const runner = actionRunner ?? rootActionRunner
 
-    return runner.bind(state)
+    const _this: { state: IPropData; rootState?: IPropData } = {
+      state: node.store.current.state,
+    }
+
+    // If the action used in a regular page is from the provider, the `state` to use
+    // in the action should be the `state` from the provider store
+    if (providerStore) {
+      const isActionFromProvider =
+        runner?.actionRef.current.store.id === providerStore.id
+
+      _this[isActionFromProvider ? 'state' : 'rootState'] =
+        providerStore.current.state
+    }
+
+    return runner?.runner.bind(_this) ?? fallback
   }
 }

--- a/libs/frontend/domain/renderer/src/typedPropTransformers/action-type-transformer.ts
+++ b/libs/frontend/domain/renderer/src/typedPropTransformers/action-type-transformer.ts
@@ -1,10 +1,13 @@
 import type {
   IPageNode,
-  IPropData,
   ITypedPropTransformer,
   TypedProp,
 } from '@codelab/frontend/abstract/core'
-import { getRunnerId, isElementPageNode } from '@codelab/frontend/abstract/core'
+import {
+  getActionRunnerThisObject,
+  getRunnerId,
+  isElementPageNode,
+} from '@codelab/frontend/abstract/core'
 import { hasStateExpression } from '@codelab/frontend/shared/utils'
 import { ExtendedModel, model } from 'mobx-keystone'
 import { BaseRenderPipe } from '../renderPipes/render-pipe.base'
@@ -38,7 +41,7 @@ export class ActionTypeTransformer
       ? node.providerStore
       : undefined
 
-    const actionRunner = this.renderer.actionRunners.get(
+    const localActionRunner = this.renderer.actionRunners.get(
       getRunnerId(node.store.id, prop.value),
     )
 
@@ -51,22 +54,18 @@ export class ActionTypeTransformer
     const fallback = () =>
       console.error(`fail to call action with id ${prop.value}`)
 
-    const runner = actionRunner ?? rootActionRunner
+    const actionRunner = localActionRunner ?? rootActionRunner
 
-    const _this: { state: IPropData; rootState?: IPropData } = {
-      state: node.store.current.state,
+    if (actionRunner) {
+      const _this = getActionRunnerThisObject(
+        actionRunner,
+        node.store,
+        providerStore,
+      )
+
+      return actionRunner.runner.bind(_this)
     }
 
-    // If the action used in a regular page is from the provider, the `state` to use
-    // in the action should be the `state` from the provider store
-    if (providerStore) {
-      const isActionFromProvider =
-        runner?.actionRef.current.store.id === providerStore.id
-
-      _this[isActionFromProvider ? 'state' : 'rootState'] =
-        providerStore.current.state
-    }
-
-    return runner?.runner.bind(_this) ?? fallback
+    return fallback
   }
 }

--- a/libs/frontend/domain/renderer/src/utils/should-render-element.ts
+++ b/libs/frontend/domain/renderer/src/utils/should-render-element.ts
@@ -5,12 +5,17 @@ import {
 } from '@codelab/frontend/shared/utils'
 
 export const shouldRenderElement = (
-  { renderIfExpression, store }: IElement,
+  { providerStore, renderIfExpression, store }: IElement,
   props: IPropData = {},
 ) => {
   if (!renderIfExpression || !hasStateExpression(renderIfExpression)) {
     return true
   }
 
-  return evaluateExpression(renderIfExpression, store.current.state, props)
+  return evaluateExpression(
+    renderIfExpression,
+    store.current.state,
+    providerStore?.current.state,
+    props,
+  )
 }

--- a/libs/frontend/domain/type/src/interface-form/fields/select-action/SelectAction.tsx
+++ b/libs/frontend/domain/type/src/interface-form/fields/select-action/SelectAction.tsx
@@ -1,4 +1,5 @@
 /* eslint-disable react/jsx-props-no-spreading */
+import { isElementPageNodeRef } from '@codelab/frontend/abstract/core'
 import { useStore } from '@codelab/frontend/presentation/container'
 import type { UniformSelectFieldProps } from '@codelab/shared/abstract/types'
 import React from 'react'
@@ -13,10 +14,19 @@ export type SelectActionProps = Pick<
 
 export const SelectAction = (fieldProps: SelectActionProps) => {
   const { actionService, builderService } = useStore()
-  const store = builderService.selectedNode?.current.store.current
+  const selectedNode = builderService.selectedNode
+  const store = selectedNode?.current.store.current
+
+  const providerStore = isElementPageNodeRef(selectedNode)
+    ? selectedNode.current.providerStore?.current
+    : undefined
 
   const actions = store
-    ? actionService.actionsList.filter((action) => action.store.id === store.id)
+    ? actionService.actionsList.filter((action) => {
+        return (
+          action.store.id === store.id || action.store.id === providerStore?.id
+        )
+      })
     : actionService.actionsList
 
   const options = actions.map((action) => ({

--- a/libs/shared/data/test/src/page.data.ts
+++ b/libs/shared/data/test/src/page.data.ts
@@ -13,6 +13,9 @@ export const providerPageData = (app: IEntity, store: IEntity): IPageDTO => ({
   id: v4(),
   kind: IPageKind.Provider,
   name: IPageKindName.Provider,
+  pageContentContainer: {
+    id: providerElementData.id,
+  },
   rootElement: providerElementData,
   store,
   url: IPageKindName.Provider,


### PR DESCRIPTION
<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(libs-ui-component): must begin with lowercase` -->

## Description

<!-- This is a short description on the Pull Request -->

State from the provider page can be accessed via `rootState.[propName]`. The state from the provider page will be included on evaluating the runtime props of an element.

The actions from the provider page are also included in the options to choose from in the SelectActions fields in a regular page.

Also updated the inspector tab in the explorer to show the state values from the local store, component store, and provider store so users can see all the state values it can use

Added e2e tests for testing that the state created from the provider page is accessible in a regular page.

## Video or Image

<!-- Add video or image showing how the new feature works -->

Using the `products` state from the provider as the child mapper prop in a regular page.

https://github.com/codelab-app/platform/assets/27695022/5332e43f-bbc1-4073-ade2-b1ba14125764

<br />

Updated inspector to show states from the provider and component as well

https://github.com/codelab-app/platform/assets/27695022/a27c5ef5-2dba-4c0e-ad65-b4d6dc161aaa

<br />

Using an action from the provider as an onclick handler in a regular page


https://github.com/codelab-app/platform/assets/27695022/bedfe417-4a14-4761-8515-bf6bf8988b51




## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged -->

Fixes #2811 
