### PR TITLE
fix: elements not rendered conditionally

### DIFF
--- a/libs/frontend/domain/renderer/src/element/get-styled-components.ts
+++ b/libs/frontend/domain/renderer/src/element/get-styled-components.ts
@@ -20,7 +20,20 @@ export const getStyledComponent = (
     `
   }
 
-  return ReactComponent
+  // styled() uses hooks internally. Therefore, we need to always wrap the component
+  // with styled, otherwise the number of hooks will be different between the
+  // prev and next render, which will cause errors.
+  // This can happen if an element is rendered conditionally (renderIf)
+  const Wrapper = (props: React.PropsWithChildren) => {
+    // Don't pass props to React.Fragment
+    if (ReactComponent === React.Fragment) {
+      return React.createElement(ReactComponent, null, props.children)
+    }
+
+    return React.createElement(ReactComponent, props, props.children)
+  }
+
+  return styled(Wrapper)``
 }
 
 export const jsonStringToCss = (json: string | null | undefined) => {


### PR DESCRIPTION
<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(libs-ui-component): must begin with lowercase` -->

## Description
Turned out that the issue is caused by `styled` from `styled-component` that we wrap the elements before rendering. When an element is rendered conditionally, a `Framgent` component is rendered, which is not wrapped with `styled` anymore. `styled` uses hooks internally so this causes a mismatch in the number of hooks rendered in each render. 

## Video or Image

<!-- Add video or image showing how the new feature works -->

https://github.com/codelab-app/platform/assets/48331678/aa6c7aae-49f2-44af-b33f-db4ebfdd58ac



## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged -->

Fixes #2807 
