### PR TITLE
fix: user types export on app export

### DIFF
--- a/apps/platform/pages/api/export/app.ts
+++ b/apps/platform/pages/api/export/app.ts
@@ -12,11 +12,8 @@ const exportApp: NextApiHandler = async (req, res) => {
     }
 
     const { id } = req.query
-
-    const exportedApp = await exportUserData({
-      id: String(id),
-    })
-
+    const owner = { auth0Id: session.user.sub }
+    const exportedApp = await exportUserData({ id: String(id) }, owner)
     const appName = exportedApp.apps[0]?.name
     const userName = session.user.name
     const filename = `${userName}-${appName}.json`

--- a/libs/backend/application/type/src/use-case/import/import-user-types.ts
+++ b/libs/backend/application/type/src/use-case/import/import-user-types.ts
@@ -1,0 +1,20 @@
+import { FieldRepository, TypeFactory } from '@codelab/backend/domain/type'
+import type {
+  IAuth0Owner,
+  IFieldDTO,
+  ITypeDTO,
+} from '@codelab/shared/abstract/core'
+
+export const importUserTypes = async (
+  fields: Array<IFieldDTO>,
+  types: Array<ITypeDTO>,
+  owner: IAuth0Owner,
+): Promise<void> => {
+  const fieldRepository = new FieldRepository()
+
+  for (const type of types) {
+    await TypeFactory.save({ ...type, owner })
+  }
+
+  await fieldRepository.add(fields)
+}

--- a/libs/backend/application/type/src/use-case/import/index.ts
+++ b/libs/backend/application/type/src/use-case/import/index.ts
@@ -1,0 +1,1 @@
+export * from './import-user-types'

--- a/libs/backend/application/type/src/use-case/index.ts
+++ b/libs/backend/application/type/src/use-case/index.ts
@@ -1,4 +1,5 @@
 export * from './export'
 export * from './extract/extract-ant-design-fields'
 export * from './extract/extract-html-fields'
+export * from './import'
 export * from './seed-empty-api'

--- a/libs/backend/application/user/src/use-case/export-user-data.ts
+++ b/libs/backend/application/user/src/use-case/export-user-data.ts
@@ -3,6 +3,7 @@ import type { IUserDataExport } from '@codelab/backend/abstract/core'
 import { exportApps, exportComponents } from '@codelab/backend/application/app'
 import { exportResources } from '@codelab/backend/application/resource'
 import { exportUserTypes } from '@codelab/backend/application/type'
+import type { IAuth0Owner } from '@codelab/shared/abstract/core'
 
 const nameComparator = (a: { name: string }, b: { name: string }) =>
   a.name.localeCompare(b.name)
@@ -23,10 +24,9 @@ const sortExportData = (exportData: IUserDataExport) => {
   return exportData
 }
 
-export const exportUserData = async (where: AppWhere) => {
+export const exportUserData = async (where: AppWhere, owner?: IAuth0Owner) => {
   const appsData = await exportApps(where)
-  // TODO: Need to export only types used by app
-  const typesData = await exportUserTypes()
+  const typesData = await exportUserTypes(owner)
   const resourcesData = await exportResources()
   const components = await exportComponents(where)
 

--- a/libs/backend/application/user/src/use-case/import-user-data.ts
+++ b/libs/backend/application/user/src/use-case/import-user-data.ts
@@ -2,15 +2,18 @@ import 'isomorphic-fetch'
 import type { IUserDataExport } from '@codelab/backend/abstract/core'
 import { importApps, importComponents } from '@codelab/backend/application/app'
 import { importResources } from '@codelab/backend/application/resource'
+import { importUserTypes } from '@codelab/backend/application/type'
 import type { IAuth0Owner } from '@codelab/shared/abstract/core'
 
 export const importUserData = async (
   data: IUserDataExport,
   owner: IAuth0Owner,
 ) => {
-  const { apps, components, resources } = data
+  const { apps, components, fields, resources, types } = data
 
   await importResources(resources, owner)
+
+  await importUserTypes(fields, types, owner)
 
   await importApps(apps, owner)
 

--- a/libs/backend/infra/adapter/neo4j/src/cypher/type/getTypeDescendantsOGM.cypher
+++ b/libs/backend/infra/adapter/neo4j/src/cypher/type/getTypeDescendantsOGM.cypher
@@ -13,7 +13,7 @@ CALL apoc.path.subgraphAll(
   type,
   {
     relationshipFilter: '>ARRAY_ITEM_TYPE|>UNION_TYPE_CHILD|>INTERFACE_FIELD|>FIELD_TYPE',
-    labelFilter: '>TYPE|>FIELD'
+    labelFilter: '>Type|>Field'
   }
 ) YIELD nodes
 


### PR DESCRIPTION
<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(libs-ui-component): must begin with lowercase` -->

## Description

- Fixed cypher query to get type descendants (`labelFilter` is case sensetive)
- Fixed export of user types and added condition to export only types owned by user
- Implemented import of user types

## Video or Image

See video in the issue to see how it worked before.
Now all types exported successfully:


https://github.com/codelab-app/platform/assets/74900868/6d61c1dd-bd7b-4834-87ab-43a5c32504b7


## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged -->

Fixes #2817 
