### PR TITLE
fix: useMemo missing dependencies

### DIFF
--- a/libs/frontend/presentation/container/src/routerHooks/useCurrentApp.hook.ts
+++ b/libs/frontend/presentation/container/src/routerHooks/useCurrentApp.hook.ts
@@ -23,5 +23,5 @@ export const useCurrentApp = () => {
     const app = appService.appsList.find(({ name }) => name === appName)
 
     return { _compoundName, app, appName, appSlug, userName }
-  }, [appName])
+  }, [appName, appService.appsList])
 }


### PR DESCRIPTION
<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(libs-ui-component): must begin with lowercase` -->

## Description

`useCurrentApp` hook used inside `useMemo` with missing dependency.
The first time `useCurrentApp` was executed - app was not loaded yet and it memoized `app` as `undefined`. But after app finished loading - the memo was not trigered to update and still returned `undefind`.
Because of this app.id was not populated on form and domain was impossible to create

## Video or Image

<!-- Add video or image showing how the new feature works -->

https://github.com/codelab-app/platform/assets/74900868/a4b1d119-9b4f-4f8f-a502-71f15962e1d2

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged -->

Fixes #2829 
