### PR TITLE
fix: controlled components

### DIFF
--- a/libs/frontend/domain/renderer/src/element/element-wrapper.ts
+++ b/libs/frontend/domain/renderer/src/element/element-wrapper.ts
@@ -16,7 +16,7 @@ import React, { useEffect } from 'react'
 import { ErrorBoundary } from 'react-error-boundary'
 import { shouldRenderElement } from '../utils'
 import { mapOutput } from '../utils/render-output-utils'
-import { getStyledComponent } from './get-styled-components'
+import { renderComponentWithStyles } from './get-styled-components'
 import { extractValidProps, getReactComponent } from './wrapper.utils'
 
 export interface ElementWrapperProps {
@@ -91,12 +91,7 @@ export const ElementWrapper = observer<ElementWrapperProps>(
 
       const extractedProps = extractValidProps(ReactComponent, renderOutput)
 
-      const StyledReactComponent = getStyledComponent(
-        ReactComponent,
-        extractedProps['css'],
-      )
-
-      return React.createElement(StyledReactComponent, extractedProps, children)
+      return renderComponentWithStyles(ReactComponent, extractedProps, children)
     })
 
     return React.createElement(

--- a/libs/frontend/domain/renderer/src/element/element-wrapper.ts
+++ b/libs/frontend/domain/renderer/src/element/element-wrapper.ts
@@ -21,6 +21,7 @@ import { extractValidProps, getReactComponent } from './wrapper.utils'
 
 export interface ElementWrapperProps {
   element: IElement
+  key: string
   /**
    * Props passed in from outside the component
    */

--- a/libs/frontend/domain/renderer/src/element/get-styled-components.ts
+++ b/libs/frontend/domain/renderer/src/element/get-styled-components.ts
@@ -1,46 +1,27 @@
-import type { IComponentType } from '@codelab/frontend/abstract/core'
+import type { IComponentType, IPropData } from '@codelab/frontend/abstract/core'
 import React from 'react'
-import type { AnyStyledComponent } from 'styled-components'
 import styled from 'styled-components'
-import { htmlAtoms } from '../atoms'
+
+const ReusableStyledComponent = styled(React.Fragment)`
+  ${(props: IPropData) => props['css']}
+`
 
 /**
  * Only wrap the component with styled() if it's a valid component (not a string or React.Fragment)
  */
-export const getStyledComponent = (
+export const renderComponentWithStyles = (
   ReactComponent: IComponentType,
-  cssString: string | null | undefined,
+  extractedProps: IPropData,
+  children: React.ReactNode,
 ) => {
-  const isHtmlAtom = Object.values(htmlAtoms).includes(ReactComponent)
-
-  const isReactComponent =
-    ReactComponent.$$typeof !== React.Fragment.$$typeof &&
-    typeof ReactComponent === 'object'
-
-  if (
-    (isReactComponent || isHtmlAtom) &&
-    // Wrap if contains cssString
-    cssString
-  ) {
-    return styled(ReactComponent as AnyStyledComponent)`
-      ${cssString}
-    `
+  // do not wrap with styled() if it's React.Fragment
+  if (ReactComponent === React.Fragment) {
+    return React.createElement(ReactComponent, null, children)
   }
 
-  // styled() uses hooks internally. Therefore, we need to always wrap the component
-  // with styled, otherwise the number of hooks will be different between the
-  // prev and next render, which will cause errors.
-  // This can happen if an element is rendered conditionally (renderIf)
-  const Wrapper = (props: React.PropsWithChildren) => {
-    // Don't pass props to React.Fragment
-    if (ReactComponent === React.Fragment) {
-      return React.createElement(ReactComponent, null, props.children)
-    }
+  const props = { ...extractedProps, as: ReactComponent }
 
-    return React.createElement(ReactComponent, props, props.children)
-  }
-
-  return styled(Wrapper)``
+  return React.createElement(ReusableStyledComponent, props, children)
 }
 
 export const jsonStringToCss = (json: string | null | undefined) => {

--- a/libs/frontend/domain/renderer/src/renderer.model.ts
+++ b/libs/frontend/domain/renderer/src/renderer.model.ts
@@ -187,6 +187,7 @@ export class Renderer
   renderElement = (element: IElement): ReactElement => {
     const wrapperProps: ElementWrapperProps = {
       element,
+      key: element.id,
       renderer: this,
     }
 


### PR DESCRIPTION
<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(libs-ui-component): must begin with lowercase` -->

## Description

The entire user component tree was producing new nodes on each re-render. This happened because we dynamically wrapped all elements with `styled()`. This is not how the styled-components were intended to use, because `styled()` produces each time new component (impossible to use `useMemo` for it because then error is thrown about changed rendered hooks count). This was the reason why it was impossible to use controlled components (the input loses focus on each new key pressed because new input is created on each state update). Now the styled component is created only once, and using `as` property we pass to it which component we want to render and by `css` prop we control set of css rules to be applied.
Also, to avoid script errors and allow React to effectively patch user elements - added `key` attribute for each `ElementWrapper` component.

## Video or Image

<!-- Add video or image showing how the new feature works -->


https://github.com/codelab-app/platform/assets/74900868/f5976e96-34a5-4c37-b44c-e9039a7a5a0a

A practical example of using the controlled component:


https://github.com/codelab-app/platform/assets/74900868/b3c7661a-29bb-4e2d-bfa8-20cd87c3b5f5



## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged -->

Fixes #2834
