### PR TITLE
fix: re-render overlay on resize and scroll

### DIFF
--- a/libs/frontend/domain/builder/src/sections/content/Builder.tsx
+++ b/libs/frontend/domain/builder/src/sections/content/Builder.tsx
@@ -38,7 +38,7 @@ export const Builder = observer(() => {
     setSelectedNode: builderService.setSelectedNode.bind(builderService),
   })
 
-  const { isOver, over, setNodeRef } = useDroppable({
+  const { isOver, node, over, setNodeRef } = useDroppable({
     id: elementTree?.rootElement.id ?? '',
   })
 
@@ -140,6 +140,7 @@ export const Builder = observer(() => {
           <BuilderClickOverlay
             builderService={builderService}
             elementService={elementService}
+            renderContainerRef={node}
           />
         </StyledBuilderResizeContainer>
         <ResizeHandle />

--- a/libs/frontend/domain/builder/src/sections/overlay-toolbar/BuilderClickOverlay.tsx
+++ b/libs/frontend/domain/builder/src/sections/overlay-toolbar/BuilderClickOverlay.tsx
@@ -6,6 +6,7 @@ import type {
 import { elementRef, isElementRef } from '@codelab/frontend/abstract/core'
 import { queryRenderedElementById } from '@codelab/frontend/domain/renderer'
 import { ClickOverlay } from '@codelab/frontend/presentation/view'
+import { isServer } from '@codelab/shared/utils'
 import { Button } from 'antd'
 import { observer } from 'mobx-react-lite'
 import React from 'react'
@@ -45,10 +46,17 @@ const StyledOverlayButtonGroup = styled.div`
 export const BuilderClickOverlay = observer<{
   builderService: IBuilderService
   elementService: IElementService
-}>(({ builderService, elementService }) => {
+  renderContainerRef: React.MutableRefObject<HTMLElement | null>
+}>(({ builderService, elementService, renderContainerRef }) => {
   const selectedNode = builderService.selectedNode
 
-  if (!selectedNode || !isElementRef(selectedNode)) {
+  if (isServer || !selectedNode || !isElementRef(selectedNode)) {
+    return null
+  }
+
+  const element = queryRenderedElementById(selectedNode.id)
+
+  if (!element) {
     return null
   }
 
@@ -56,14 +64,6 @@ export const BuilderClickOverlay = observer<{
     <StyledOverlayContainer className="click-overlay-toolbar">
       <StyledSpan>{selectedNode.current.name}</StyledSpan>
       <StyledOverlayButtonGroup>
-        {/* <Button
-          icon={<PlusOutlined />}
-          onClick={(e) => {
-            e.stopPropagation()
-          }}
-          size="small"
-          type="text"
-        /> */}
         <Button
           danger
           icon={<DeleteOutlined />}
@@ -81,8 +81,8 @@ export const BuilderClickOverlay = observer<{
   return (
     <ClickOverlay
       content={content}
-      getOverlayElement={queryRenderedElementById}
-      nodeId={selectedNode.id}
+      element={element}
+      renderContainerRef={renderContainerRef}
     />
   )
 })

--- a/libs/frontend/domain/builder/src/sections/overlay-toolbar/BuilderHoverOverlay.tsx
+++ b/libs/frontend/domain/builder/src/sections/overlay-toolbar/BuilderHoverOverlay.tsx
@@ -1,60 +1,60 @@
-import type { IBuilderService } from '@codelab/frontend/abstract/core'
-import { isElementRef } from '@codelab/frontend/abstract/core'
-import { queryRenderedElementById } from '@codelab/frontend/domain/renderer'
-import { HoverOverlay } from '@codelab/frontend/presentation/view'
-import { observer } from 'mobx-react-lite'
-import React from 'react'
-import styled from 'styled-components'
+// import type { IBuilderService } from '@codelab/frontend/abstract/core'
+// import { isElementRef } from '@codelab/frontend/abstract/core'
+// import { queryRenderedElementById } from '@codelab/frontend/domain/renderer'
+// import { HoverOverlay } from '@codelab/frontend/presentation/view'
+// import { observer } from 'mobx-react-lite'
+// import React from 'react'
+// import styled from 'styled-components'
 
-export const BuilderHoverOverlay = observer<{
-  builderService: IBuilderService
-}>(({ builderService }) => {
-  const hoveredNode = builderService.hoveredNode
+// export const BuilderHoverOverlay = observer<{
+//   builderService: IBuilderService
+// }>(({ builderService }) => {
+//   const hoveredNode = builderService.hoveredNode
 
-  if (!hoveredNode || !isElementRef(hoveredNode)) {
-    return null
-  }
+//   if (!hoveredNode || !isElementRef(hoveredNode)) {
+//     return null
+//   }
 
-  if (hoveredNode.current.id === builderService.selectedNode?.current.id) {
-    return null
-  }
+//   if (hoveredNode.current.id === builderService.selectedNode?.current.id) {
+//     return null
+//   }
 
-  const StyledOverlayContainer = styled.div`
-    display: flex;
-    flex-direction: row;
-    align-items: center;
-    max-height: 20px;
-    justify-content: space-between;
-    & > *:not(:last-child) {
-      margin-right: 0.3rem;
-    }
+//   const StyledOverlayContainer = styled.div`
+//     display: flex;
+//     flex-direction: row;
+//     align-items: center;
+//     max-height: 20px;
+//     justify-content: space-between;
+//     & > *:not(:last-child) {
+//       margin-right: 0.3rem;
+//     }
 
-    .click-overlay-toolbar--button-group {
-    }
-  `
+//     .click-overlay-toolbar--button-group {
+//     }
+//   `
 
-  const StyledSpan = styled.p`
-    height: 20px;
-    min-width: 50px;
-    margin: 0;
-    font-size: 15px;
-    overflow: hidden;
-    white-space: nowrap;
-  `
+//   const StyledSpan = styled.p`
+//     height: 20px;
+//     min-width: 50px;
+//     margin: 0;
+//     font-size: 15px;
+//     overflow: hidden;
+//     white-space: nowrap;
+//   `
 
-  const content = (
-    <StyledOverlayContainer className="click-overlay-toolbar">
-      <StyledSpan>{hoveredNode.current.name}</StyledSpan>
-    </StyledOverlayContainer>
-  )
+//   const content = (
+//     <StyledOverlayContainer className="click-overlay-toolbar">
+//       <StyledSpan>{hoveredNode.current.name}</StyledSpan>
+//     </StyledOverlayContainer>
+//   )
 
-  return (
-    <HoverOverlay
-      content={content}
-      getOverlayElement={queryRenderedElementById}
-      nodeId={hoveredNode.id}
-    />
-  )
-})
+//   return (
+//     <HoverOverlay
+//       content={content}
+//       getOverlayElement={queryRenderedElementById}
+//       nodeId={hoveredNode.id}
+//     />
+//   )
+// })
 
-BuilderHoverOverlay.displayName = 'ElementBuilderHoverOverlay'
+// BuilderHoverOverlay.displayName = 'ElementBuilderHoverOverlay'

--- a/libs/frontend/presentation/view/components/hoverOverlay/ClickOverlay.tsx
+++ b/libs/frontend/presentation/view/components/hoverOverlay/ClickOverlay.tsx
@@ -1,22 +1,21 @@
-import { isServer } from '@codelab/shared/utils'
+import { useScroll } from '@codelab/frontend/shared/utils'
 import React from 'react'
+import useResizeObserver from 'use-resize-observer/polyfilled'
 import type { OverlayProps } from './overlay.interface'
 import { OverlayToolbar } from './OverlayToolbar'
 
 export const ClickOverlay = ({
   content,
-  getOverlayElement,
-  nodeId,
+  element,
+  renderContainerRef,
 }: OverlayProps) => {
-  if (!nodeId || isServer) {
-    return null
-  }
-
-  const element = getOverlayElement(nodeId)
-
-  if (!element) {
-    return null
-  }
+  // Make sure we re-render overlay when:
+  // - element is resized
+  // - the page is resized
+  // - the content is scrolled
+  useResizeObserver({ ref: element })
+  useResizeObserver({ ref: renderContainerRef.current })
+  useScroll()
 
   const elementRect = element.getBoundingClientRect()
 

--- a/libs/frontend/presentation/view/components/hoverOverlay/HoverOverlay.tsx
+++ b/libs/frontend/presentation/view/components/hoverOverlay/HoverOverlay.tsx
@@ -1,39 +1,39 @@
-import { isServer } from '@codelab/shared/utils'
-import React from 'react'
-import type { OverlayProps } from './overlay.interface'
-import { OverlayToolbar } from './OverlayToolbar'
+// import { isServer } from '@codelab/shared/utils'
+// import React from 'react'
+// import type { OverlayProps } from './overlay.interface'
+// import { OverlayToolbar } from './OverlayToolbar'
 
-export const HoverOverlay = ({
-  content,
-  getOverlayElement,
-  nodeId,
-}: OverlayProps) => {
-  if (!nodeId || isServer) {
-    return null
-  }
+// export const HoverOverlay = ({
+//   content,
+//   getOverlayElement,
+//   nodeId,
+// }: OverlayProps) => {
+//   if (!nodeId || isServer) {
+//     return null
+//   }
 
-  const element = getOverlayElement(nodeId)
+//   const element = getOverlayElement(nodeId)
 
-  if (!element) {
-    return null
-  }
+//   if (!element) {
+//     return null
+//   }
 
-  return (
-    <OverlayToolbar
-      containerProps={{
-        style: {
-          border: '1px solid rgb(41, 205, 255)',
-        },
-      }}
-      overlayElement={element}
-      toolbarProps={{
-        style: {
-          background: 'rgb(41, 205, 255)',
-          color: 'rgb(255, 255, 255)',
-        },
-      }}
-    >
-      <div>{content}</div>
-    </OverlayToolbar>
-  )
-}
+//   return (
+//     <OverlayToolbar
+//       containerProps={{
+//         style: {
+//           border: '1px solid rgb(41, 205, 255)',
+//         },
+//       }}
+//       overlayElement={element}
+//       toolbarProps={{
+//         style: {
+//           background: 'rgb(41, 205, 255)',
+//           color: 'rgb(255, 255, 255)',
+//         },
+//       }}
+//     >
+//       <div>{content}</div>
+//     </OverlayToolbar>
+//   )
+// }

--- a/libs/frontend/presentation/view/components/hoverOverlay/OverlayToolbar.tsx
+++ b/libs/frontend/presentation/view/components/hoverOverlay/OverlayToolbar.tsx
@@ -1,7 +1,5 @@
-import { useScroll } from '@codelab/frontend/shared/utils'
 import type { CSSProperties, RefObject } from 'react'
 import React from 'react'
-import useResizeObserver from 'use-resize-observer/polyfilled'
 
 interface OverlayToolbarProps {
   children?: React.ReactNode
@@ -30,11 +28,6 @@ export const OverlayToolbar = ({
   const element = Object.hasOwnProperty.call(overlayElement, 'current')
     ? (overlayElement as RefObject<HTMLElement>).current
     : (overlayElement as HTMLElement)
-
-  // Make sure we re-render when the element changes its size and when we scroll
-  // But we don't actually care about the values, we take what we need from getBoundingClientRect
-  useResizeObserver({ ref: element })
-  useScroll()
 
   // This is not very good for performance, if we can find a way to track movement with
   // IntersectionObserver and only update the rect then, it would be much better

--- a/libs/frontend/presentation/view/components/hoverOverlay/index.ts
+++ b/libs/frontend/presentation/view/components/hoverOverlay/index.ts
@@ -1,3 +1,3 @@
 export * from './ClickOverlay'
-export * from './HoverOverlay'
+// export * from './HoverOverlay'
 export * from './OverlayToolbar'

--- a/libs/frontend/presentation/view/components/hoverOverlay/overlay.interface.ts
+++ b/libs/frontend/presentation/view/components/hoverOverlay/overlay.interface.ts
@@ -1,9 +1,7 @@
-import type { Nullable } from '@codelab/shared/abstract/types'
 import type React from 'react'
 
 export interface OverlayProps {
   content?: React.ReactNode
-  nodeId?: string
-
-  getOverlayElement(nodeId: string): Nullable<HTMLElement>
+  element: HTMLElement
+  renderContainerRef: React.MutableRefObject<HTMLElement | null>
 }


### PR DESCRIPTION
<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(libs-ui-component): must begin with lowercase` -->

## Description

Rerender overlay when:
- element is resized
- the page is resized
- the content is scrolled

Also commented out unused components.

## Video or Image

Before: 

https://github.com/codelab-app/platform/assets/74900868/5b8aa52f-1ed3-410b-9971-f0d619f127ba

After:

https://github.com/codelab-app/platform/assets/74900868/2e435cf5-cc4d-4e08-9a61-d2a0cf3dac5e

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged -->

Fixes #2844 
Fixes #2855 
