### PR TITLE
feat: add atom parent and child validation

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -10,6 +10,6 @@ plugins:
   - path: .yarn/plugins/@yarnpkg/plugin-after-install.cjs
     spec: 'https://raw.githubusercontent.com/mhassan1/yarn-plugin-after-install/v0.4.0/bundles/@yarnpkg/plugin-after-install.js'
 
-afterInstall: ./scripts/yarn/after-install.sh
+# afterInstall: ./scripts/yarn/after-install.sh
 
 yarnPath: .yarn/releases/yarn-3.5.1.cjs

--- a/dist/libs/tools/workspace/package.json
+++ b/dist/libs/tools/workspace/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "tools-workspace",
+  "name": "@codelab/tools-workspace",
   "version": "0.0.1",
   "type": "commonjs",
   "generators": "./generators.json",

--- a/libs/frontend/abstract/core/src/domain/atom/atom.repo.interface.ts
+++ b/libs/frontend/abstract/core/src/domain/atom/atom.repo.interface.ts
@@ -1,6 +1,7 @@
 import type {
   AtomFragment,
   AtomOptions,
+  AtomType,
   AtomWhere,
 } from '@codelab/shared/abstract/codegen'
 import type { IRepository } from '../../service'
@@ -13,6 +14,11 @@ export type IAtomRepository = IRepository<
   AtomOptions
 > & {
   findOptions(): Promise<
-    Array<Pick<IAtom, 'id' | 'name' | 'requiredParents' | 'type'>>
+    Array<{
+      id: string
+      name: string
+      type: AtomType
+      requiredParents: Array<{ id: string; type: AtomType }>
+    }>
   >
 }

--- a/libs/frontend/abstract/core/src/domain/atom/atom.repo.interface.ts
+++ b/libs/frontend/abstract/core/src/domain/atom/atom.repo.interface.ts
@@ -12,5 +12,7 @@ export type IAtomRepository = IRepository<
   AtomWhere,
   AtomOptions
 > & {
-  findOptions(): Promise<Array<Pick<IAtom, 'id' | 'name' | 'type'>>>
+  findOptions(): Promise<
+    Array<Pick<IAtom, 'id' | 'name' | 'type' | 'requiredParents'>>
+  >
 }

--- a/libs/frontend/abstract/core/src/domain/atom/atom.repo.interface.ts
+++ b/libs/frontend/abstract/core/src/domain/atom/atom.repo.interface.ts
@@ -13,6 +13,6 @@ export type IAtomRepository = IRepository<
   AtomOptions
 > & {
   findOptions(): Promise<
-    Array<Pick<IAtom, 'id' | 'name' | 'type' | 'requiredParents'>>
+    Array<Pick<IAtom, 'id' | 'name' | 'requiredParents' | 'type'>>
   >
 }

--- a/libs/frontend/abstract/core/src/domain/atom/atom.service.interface.ts
+++ b/libs/frontend/abstract/core/src/domain/atom/atom.service.interface.ts
@@ -33,6 +33,6 @@ export interface IAtomService
   add(atomDTO: IAtomDTO): IAtom
   delete(ids: Array<string>): Promise<number>
   getOptions(): Promise<
-    Array<Pick<IAtom, 'id' | 'name' | 'type' | 'requiredParents'>>
+    Array<Pick<IAtom, 'id' | 'name' | 'requiredParents' | 'type'>>
   >
 }

--- a/libs/frontend/abstract/core/src/domain/atom/atom.service.interface.ts
+++ b/libs/frontend/abstract/core/src/domain/atom/atom.service.interface.ts
@@ -32,5 +32,7 @@ export interface IAtomService
 
   add(atomDTO: IAtomDTO): IAtom
   delete(ids: Array<string>): Promise<number>
-  getOptions(): Promise<Array<Pick<IAtom, 'id' | 'name' | 'type'>>>
+  getOptions(): Promise<
+    Array<Pick<IAtom, 'id' | 'name' | 'type' | 'requiredParents'>>
+  >
 }

--- a/libs/frontend/abstract/core/src/domain/atom/atom.service.interface.ts
+++ b/libs/frontend/abstract/core/src/domain/atom/atom.service.interface.ts
@@ -1,4 +1,8 @@
-import type { AtomOptions, AtomWhere } from '@codelab/shared/abstract/codegen'
+import type {
+  AtomOptions,
+  AtomType,
+  AtomWhere,
+} from '@codelab/shared/abstract/codegen'
 import type { IAtomDTO } from '@codelab/shared/abstract/core'
 import type { Maybe } from '@codelab/shared/abstract/types'
 import type { ArraySet, ObjectMap, Ref } from 'mobx-keystone'
@@ -33,6 +37,11 @@ export interface IAtomService
   add(atomDTO: IAtomDTO): IAtom
   delete(ids: Array<string>): Promise<number>
   getOptions(): Promise<
-    Array<Pick<IAtom, 'id' | 'name' | 'requiredParents' | 'type'>>
+    Array<{
+      id: string
+      name: string
+      type: AtomType
+      requiredParents: Array<{ id: string; type: AtomType }>
+    }>
   >
 }

--- a/libs/frontend/domain/atom/src/graphql/atom.endpoints.graphql
+++ b/libs/frontend/domain/atom/src/graphql/atom.endpoints.graphql
@@ -31,6 +31,10 @@ query GetAtomOptions {
     id
     name
     type
+    requiredParents {
+      id
+      type
+    }
   }
 }
 

--- a/libs/frontend/domain/atom/src/graphql/atom.endpoints.graphql.gen.ts
+++ b/libs/frontend/domain/atom/src/graphql/atom.endpoints.graphql.gen.ts
@@ -5,8 +5,6 @@ import { GraphQLClient } from 'graphql-request'
 import { GraphQLClientRequestHeaders } from 'graphql-request/build/cjs/types'
 import { gql } from 'graphql-tag'
 import { AtomFragmentDoc } from '../../../../abstract/core/src/domain/atom/atom.fragment.graphql.gen'
-import { Atom } from '@codelab/backend/domain/atom'
-import { IAtom } from '@codelab/frontend/abstract/core'
 export type CreateAtomsMutationVariables = Types.Exact<{
   input: Array<Types.AtomCreateInput> | Types.AtomCreateInput
 }>
@@ -39,7 +37,11 @@ export type GetAtomsQuery = {
 export type GetAtomOptionsQueryVariables = Types.Exact<{ [key: string]: never }>
 
 export type GetAtomOptionsQuery = {
-  atoms: Array<Pick<IAtom, 'id' | 'name' | 'type' | 'requiredParents'>>
+  atoms: Array<{
+    id: string
+    type: Types.AtomType
+    requiredParents: Array<{ id: string; type: Types.AtomType }>
+  }>
 }
 
 export type UpdateAtomsMutationVariables = Types.Exact<{

--- a/libs/frontend/domain/atom/src/graphql/atom.endpoints.graphql.gen.ts
+++ b/libs/frontend/domain/atom/src/graphql/atom.endpoints.graphql.gen.ts
@@ -39,6 +39,7 @@ export type GetAtomOptionsQueryVariables = Types.Exact<{ [key: string]: never }>
 export type GetAtomOptionsQuery = {
   atoms: Array<{
     id: string
+    name: string
     type: Types.AtomType
     requiredParents: Array<{ id: string; type: Types.AtomType }>
   }>

--- a/libs/frontend/domain/atom/src/graphql/atom.endpoints.graphql.gen.ts
+++ b/libs/frontend/domain/atom/src/graphql/atom.endpoints.graphql.gen.ts
@@ -6,6 +6,7 @@ import { GraphQLClientRequestHeaders } from 'graphql-request/build/cjs/types'
 import { gql } from 'graphql-tag'
 import { AtomFragmentDoc } from '../../../../abstract/core/src/domain/atom/atom.fragment.graphql.gen'
 import { Atom } from '@codelab/backend/domain/atom'
+import { IAtom } from '@codelab/frontend/abstract/core'
 export type CreateAtomsMutationVariables = Types.Exact<{
   input: Array<Types.AtomCreateInput> | Types.AtomCreateInput
 }>
@@ -38,12 +39,7 @@ export type GetAtomsQuery = {
 export type GetAtomOptionsQueryVariables = Types.Exact<{ [key: string]: never }>
 
 export type GetAtomOptionsQuery = {
-  atoms: Array<{
-    id: string
-    name: string
-    type: Types.AtomType
-    requiredParents: Array<Atom>
-  }>
+  atoms: Array<Pick<IAtom, 'id' | 'name' | 'type' | 'requiredParents'>>
 }
 
 export type UpdateAtomsMutationVariables = Types.Exact<{

--- a/libs/frontend/domain/atom/src/graphql/atom.endpoints.graphql.gen.ts
+++ b/libs/frontend/domain/atom/src/graphql/atom.endpoints.graphql.gen.ts
@@ -5,6 +5,7 @@ import { GraphQLClient } from 'graphql-request'
 import { GraphQLClientRequestHeaders } from 'graphql-request/build/cjs/types'
 import { gql } from 'graphql-tag'
 import { AtomFragmentDoc } from '../../../../abstract/core/src/domain/atom/atom.fragment.graphql.gen'
+import { Atom } from '@codelab/backend/domain/atom'
 export type CreateAtomsMutationVariables = Types.Exact<{
   input: Array<Types.AtomCreateInput> | Types.AtomCreateInput
 }>
@@ -37,7 +38,12 @@ export type GetAtomsQuery = {
 export type GetAtomOptionsQueryVariables = Types.Exact<{ [key: string]: never }>
 
 export type GetAtomOptionsQuery = {
-  atoms: Array<{ id: string; name: string; type: Types.AtomType }>
+  atoms: Array<{
+    id: string
+    name: string
+    type: Types.AtomType
+    requiredParents: Array<Atom>
+  }>
 }
 
 export type UpdateAtomsMutationVariables = Types.Exact<{
@@ -87,6 +93,10 @@ export const GetAtomOptionsDocument = gql`
       id
       name
       type
+      requiredParents {
+        id
+        type
+      }
     }
   }
 `

--- a/libs/frontend/domain/atom/src/store/atom.repo.ts
+++ b/libs/frontend/domain/atom/src/store/atom.repo.ts
@@ -58,8 +58,6 @@ export class AtomRepository extends Model({}) implements IAtomRepository {
     return sortBy(
       atoms.filter(({ type }) => filterNotHookType(type)),
       'name',
-    ) as unknown as Array<
-      Pick<IAtom, 'id' | 'name' | 'requiredParents' | 'type'>
-    >
+    )
   }
 }

--- a/libs/frontend/domain/atom/src/store/atom.repo.ts
+++ b/libs/frontend/domain/atom/src/store/atom.repo.ts
@@ -58,6 +58,8 @@ export class AtomRepository extends Model({}) implements IAtomRepository {
     return sortBy(
       atoms.filter(({ type }) => filterNotHookType(type)),
       'name',
-    )
+    ) as unknown as Array<
+      Pick<IAtom, 'id' | 'name' | 'requiredParents' | 'type'>
+    >
   }
 }

--- a/libs/frontend/domain/element/src/use-cases/element/move-element/MoveElementForm.tsx
+++ b/libs/frontend/domain/element/src/use-cases/element/move-element/MoveElementForm.tsx
@@ -20,7 +20,7 @@ export interface MoveElementFormProps {
 
 /** Not intended to be used in a modal */
 export const MoveElementForm = observer<MoveElementFormProps>(({ element }) => {
-  const { builderService, elementService } = useStore()
+  const { atomService, builderService, elementService } = useStore()
   const elementTree = builderService.activeElementTree
 
   // Cache it only once, don't pass it with every change to the form, because that will cause lag when auto-saving
@@ -64,7 +64,17 @@ export const MoveElementForm = observer<MoveElementFormProps>(({ element }) => {
     return Promise.resolve()
   }
 
-  const elementOptions = elementTree?.elements.map(mapElementOption)
+  const elementAtomRequiredParents = atomService.atoms
+    .get(element.renderType?.id || '')
+    ?.requiredParents.map((parent) => parent.id)
+
+  const elementOptions = elementAtomRequiredParents?.length
+    ? elementTree?.elements
+        .filter((el) =>
+          elementAtomRequiredParents.includes(el.renderType?.id || ''),
+        )
+        .map(mapElementOption)
+    : elementTree?.elements.map(mapElementOption)
 
   return (
     <MoveElementAutoForm<MoveData>

--- a/libs/frontend/domain/type/src/interface-form/fields/select-atom/SelectAtom.tsx
+++ b/libs/frontend/domain/type/src/interface-form/fields/select-atom/SelectAtom.tsx
@@ -5,7 +5,7 @@ import type { UniformSelectFieldProps } from '@codelab/shared/abstract/types'
 import { useAsync } from '@react-hookz/web'
 import compact from 'lodash/compact'
 import uniqBy from 'lodash/uniqBy'
-import React from 'react'
+import React, { useMemo } from 'react'
 import { useField } from 'uniforms'
 import { SelectField } from 'uniforms-antd'
 
@@ -23,21 +23,23 @@ export const SelectAtom = ({ error, label, name, parent }: SelectAtomProps) => {
   const { atomService } = useStore()
   const [fieldProps] = useField<{ value?: string }>(name, {})
 
-  // On update mode, the current selected type can be used
-  // to show the type name instead of showing just the id
-  const currentAtom = fieldProps.value
-    ? atomService.atoms.get(fieldProps.value)
-    : undefined
-
   const [{ error: queryError, result = [], status }, getAtoms] = useAsync(() =>
     atomService.getOptions(),
   )
 
-  const allAtoms = uniqBy(compact([currentAtom, ...result]), 'id')
+  const options = useMemo(() => {
+    // On update mode, the current selected type can be used
+    // to show the type name instead of showing just the id
+    const currentAtom = fieldProps.value
+      ? atomService.atoms.get(fieldProps.value)
+      : undefined
 
-  const options = parent
-    ? filterAtoms(allAtoms, parent)
-    : allAtoms.map((atom) => ({ label: atom.name, value: atom.id }))
+    const allAtoms = uniqBy(compact([currentAtom, ...result]), 'id')
+
+    return parent
+      ? filterAtoms(allAtoms, parent)
+      : allAtoms.map((atom) => ({ label: atom.name, value: atom.id }))
+  }, [result, parent])
 
   return (
     <SelectField

--- a/libs/frontend/domain/type/src/interface-form/fields/select-atom/SelectAtom.tsx
+++ b/libs/frontend/domain/type/src/interface-form/fields/select-atom/SelectAtom.tsx
@@ -1,5 +1,6 @@
 import type { IAtom } from '@codelab/frontend/abstract/core'
 import { useStore } from '@codelab/frontend/presentation/container'
+import type { AtomType } from '@codelab/shared/abstract/codegen'
 import type { UniformSelectFieldProps } from '@codelab/shared/abstract/types'
 import { useAsync } from '@react-hookz/web'
 import compact from 'lodash/compact'
@@ -58,7 +59,15 @@ export const SelectAtom = ({ error, label, name, parent }: SelectAtomProps) => {
 }
 
 const filterAtoms = (
-  allAtoms: Array<Pick<IAtom, 'id' | 'name' | 'requiredParents' | 'type'>>,
+  allAtoms: Array<
+    | IAtom
+    | {
+        id: string
+        name: string
+        type: AtomType
+        requiredParents: Array<{ id: string; type: AtomType }>
+      }
+  >,
   parent: IAtom,
 ) => {
   const atomsRequiringCurrentParent = allAtoms
@@ -100,5 +109,12 @@ const filterAtoms = (
 }
 
 const mapAtomOptions = (
-  atom: Pick<IAtom, 'id' | 'name' | 'requiredParents' | 'type'>,
+  atom:
+    | IAtom
+    | {
+        id: string
+        name: string
+        type: AtomType
+        requiredParents: Array<{ id: string; type: AtomType }>
+      },
 ) => ({ label: atom.name, value: atom.id })

--- a/libs/shared/abstract/codegen/src/types.api.graphql.gen.ts
+++ b/libs/shared/abstract/codegen/src/types.api.graphql.gen.ts
@@ -23057,6 +23057,7 @@ export type GetAtomOptionsQuery = {
     id: string
     name: string
     type: AtomType
+    requiredParents: Array<{ __typename?: 'Atom'; id: string; type: AtomType }>
   }>
 }
 

--- a/libs/tools/workspace/package.json
+++ b/libs/tools/workspace/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "tools-workspace",
+  "name": "@codelab/tools-workspace",
   "version": "0.0.1",
   "type": "commonjs",
   "generators": "./generators.json",

--- a/package.json
+++ b/package.json
@@ -196,7 +196,7 @@
     "@babel/plugin-transform-typescript": "^7.20.13",
     "@babel/preset-react": "^7.18.6",
     "@babel/types": "7.18.2",
-    "@codelab/workspace": "file:./dist/libs/tools/workspace",
+    "@codelab/tools-workspace": "file:./dist/libs/tools/workspace",
     "@commitlint/cli": "17.6.5",
     "@commitlint/config-conventional": "17.6.5",
     "@graphql-codegen/cli": "4.0.1",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "license": "MIT",
   "sideEffects": false,
   "scripts": {
+    "preinstall": "nx build tools-workspace",
     "e2e": "yarn cli tasks e2e --stage dev",
     "cli": "nx build cli && node ./dist/apps/cli/main.js",
     "docker:up": "scripts/docker/up.sh",

--- a/scripts/yarn/after-install.sh
+++ b/scripts/yarn/after-install.sh
@@ -5,15 +5,16 @@ set -x
 # Yarn 3 have trouble disabling scripts
 # Postinstall is cached! https://github.com/yarnpkg/yarn/issues/7762
 # So we use afterinstall plugin
-# if [ "$CI" != true ] && [ "$VERCEL" != "1" ]; then
+if [ "$CI" != true ] && [ "$VERCEL" != "1" ]; then
 
-#   # Never run husky on CI
-#   # if [ "$CI" != true ]; then
-#   #   yarn husky install
-#   # fi
+  # Never run husky on CI
+  # if [ "$CI" != true ]; then
+  #   yarn husky install
+  # fi
 
-#   # nx run-many --target=build --projects=cli,tools-workspace
+  # nx build tools-workspace && yarn link tools-workspace
+  # nx run-many --target=build --projects=cli,tools-workspace
 
-#   # Build CLI for later use
-#   nx build cli
-# fi
+  # Build CLI for later use
+  # nx build cli
+fi

--- a/yarn.lock
+++ b/yarn.lock
@@ -5690,9 +5690,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@codelab/workspace@file:./dist/libs/tools/workspace::locator=codelab%40workspace%3A.":
+"@codelab/tools-workspace@file:./dist/libs/tools/workspace::locator=codelab%40workspace%3A.":
   version: 0.0.1
-  resolution: "@codelab/workspace@file:./dist/libs/tools/workspace#./dist/libs/tools/workspace::hash=de9c0e&locator=codelab%40workspace%3A."
+  resolution: "@codelab/tools-workspace@file:./dist/libs/tools/workspace#./dist/libs/tools/workspace::hash=dce467&locator=codelab%40workspace%3A."
   dependencies:
     "@graphql-codegen/core": 4.0.0
     "@graphql-tools/graphql-file-loader": 8.0.0
@@ -5702,9 +5702,24 @@ __metadata:
     lodash: 4.17.21
   peerDependencies:
     tslib: 2.3.1
-  checksum: 06d1d8abc83012c7f2816429c8b29785e9f83a40bb788e51b7c7b213b0be166e963e8f29efcc73fbadc6d025b86592bb2a4d6ea4f5b89b11bca5039c08a7b02b
+  checksum: 3bf8bdcd5b9161cab7b12afa98d1809f1893d03beffb973adf1488ff109f07785dcd3392ef2ce3307c70bab5f339240fc03460f4f5b2284d59dbf700db4e87d8
   languageName: node
   linkType: hard
+
+"@codelab/tools-workspace@workspace:dist/libs/tools/workspace":
+  version: 0.0.0-use.local
+  resolution: "@codelab/tools-workspace@workspace:dist/libs/tools/workspace"
+  dependencies:
+    "@graphql-codegen/core": 4.0.0
+    "@graphql-tools/graphql-file-loader": 8.0.0
+    "@graphql-tools/load": 8.0.0
+    "@graphql-tools/url-loader": 8.0.0
+    graphql: 16.6.0
+    lodash: 4.17.21
+  peerDependencies:
+    tslib: 2.3.1
+  languageName: unknown
+  linkType: soft
 
 "@codemirror/autocomplete@npm:6.1.0, @codemirror/autocomplete@npm:^6.0.0":
   version: 6.1.0
@@ -21096,7 +21111,7 @@ __metadata:
     "@babel/preset-react": ^7.18.6
     "@babel/runtime": 7.18.3
     "@babel/types": 7.18.2
-    "@codelab/workspace": "file:./dist/libs/tools/workspace"
+    "@codelab/tools-workspace": "file:./dist/libs/tools/workspace"
     "@codemirror/autocomplete": 6.1.0
     "@codemirror/lang-css": 6.0.0
     "@codemirror/lang-html": 6.1.0
@@ -43306,21 +43321,6 @@ __metadata:
   checksum: 32780123bc6ce8b6a2231d860445c994a02a720abf38df5583ea957aa6626873cd1c4dd8af62314da4cf16ede00c379a765707a3b06f04b8808c38efdae1c785
   languageName: node
   linkType: hard
-
-"tools-workspace@workspace:dist/libs/tools/workspace":
-  version: 0.0.0-use.local
-  resolution: "tools-workspace@workspace:dist/libs/tools/workspace"
-  dependencies:
-    "@graphql-codegen/core": 4.0.0
-    "@graphql-tools/graphql-file-loader": 8.0.0
-    "@graphql-tools/load": 8.0.0
-    "@graphql-tools/url-loader": 8.0.0
-    graphql: 16.6.0
-    lodash: 4.17.21
-  peerDependencies:
-    tslib: 2.3.1
-  languageName: unknown
-  linkType: soft
 
 "totalist@npm:^1.0.0":
   version: 1.1.0


### PR DESCRIPTION
<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(libs-ui-component): must begin with lowercase` -->

## Description

Some atoms can only under certain atoms. For example, Form.Item goes under Form. We are using the `requiredParents` field to validate if a child atom can go under a parent atom. Below are four cases that we're handling:

1. Only display the atoms if their required parents include the parent 

[![LOOM DEMO](http://cdn.loom.com/sessions/thumbnails/c13139bd66a64fa1b143a77b6f5d2ed2-00001.gif)](https://www.loom.com/share/c13139bd66a64fa1b143a77b6f5d2ed2)

2. Only display the atoms if the required parents of the parent doesn't include the atom 

[![LOOM DEMO](http://cdn.loom.com/sessions/thumbnails/c7e5c8e42dcf4a69984ab2ce1f17a09f-00001.gif)](https://www.loom.com/share/c7e5c8e42dcf4a69984ab2ce1f17a09f)

3. Only display the atoms without required parents 

[![LOOM DEMO](http://cdn.loom.com/sessions/thumbnails/47b820a95cc34396aae0c8d4d929daaa-00001.gif)](https://www.loom.com/share/47b820a95cc34396aae0c8d4d929daaa)

4. Only display the required parents of the atoms in the parent element dropdown 

[![LOOM DEMO](http://cdn.loom.com/sessions/thumbnails/ed345a1f236041c4b3d312a7d9a0175b-00001.gif)](https://www.loom.com/share/ed345a1f236041c4b3d312a7d9a0175b)

<!-- Add video or image showing how the new feature works -->

## Related Issue(s)

Fixes [#1871 Atom parent and child validation](https://github.com/codelab-app/platform/issues/1871)

