### PR TITLE
fix: failing e2e specs

### DIFF
--- a/apps/platform-e2e/src/e2e/component.cy.ts
+++ b/apps/platform-e2e/src/e2e/component.cy.ts
@@ -76,6 +76,8 @@ describe('Component CRUD', () => {
 
     it('should be able to define property on component', () => {
       cy.getSider().getButton({ icon: 'edit' }).click()
+      cy.getCuiTreeItemByPrimaryTitle(COMPONENT_NAME).should('be.visible')
+      cy.getSpinner().should('not.exist')
       cy.get(`.ant-tabs [aria-label="setting"]`).click()
       cy.get('.ant-tabs-tabpane-active').contains(/Add/).click()
       cy.getModal().setFormFieldValue({
@@ -155,10 +157,6 @@ describe('Component CRUD', () => {
       // GetAtoms
       cy.waitForApiCalls()
       cy.getSpinner().should('not.exist')
-
-      cy.get('[data-node-key="custom-components"] .ant-tabs-tab-btn').click({
-        force: true,
-      })
 
       cy.findByText(COMPONENT_NAME).click({ force: true })
       cy.get(`.ant-tabs [aria-label="node-index"]`).click()

--- a/apps/platform-e2e/src/e2e/providers-page.cy.ts
+++ b/apps/platform-e2e/src/e2e/providers-page.cy.ts
@@ -25,8 +25,14 @@ const mainPageElements = [
 
 const openPageByName = (name: string) => {
   // Takes a while to load the pages
-  cy.contains('.ant-list-item a', name).should('exist', { timeout: 15000 })
-  cy.contains('.ant-list-item a', name).click()
+  cy.getSpinner().should('not.exist')
+  cy.getCuiTreeItemByPrimaryTitle(name)
+    .should('exist', { timeout: 15000 })
+    .click()
+  cy.getCuiTreeItemByPrimaryTitle(name).within(() => {
+    cy.getToolbarItem('Open Builder').click()
+  })
+
   cy.getSpinner().should('not.exist')
   cy.contains('.ant-tree-list', ROOT_ELEMENT_NAME, { timeout: 15000 }).should(
     'be.visible',
@@ -52,9 +58,8 @@ describe('_app page', () => {
     cy.getModal().should('not.exist')
 
     cy.findByText(appName).click()
-    cy.getListItem(IPageKindName.Provider)
-      .findByText(IPageKindName.Provider)
-      .should('be.visible')
+
+    cy.getCuiTreeItemByPrimaryTitle(IPageKindName.Provider).should('be.visible')
   })
 
   it('should be able to add card component to the _app page', () => {
@@ -77,16 +82,15 @@ describe('_app page', () => {
     // Otherwise, there is a risk that `cy.go('back')` will prevent the request from being sent
     cy.waitForApiCalls()
 
-    cy.get('li[title="Pages"]').should('be.visible').click()
+    cy.getCuiNavigationBarItem('Pages').click()
 
     cy.getSpinner().should('not.exist')
-    cy.getListItem(IPageKindName.Provider)
-      .findByText(IPageKindName.Provider)
-      .should('be.visible')
+
+    cy.getCuiTreeItemByPrimaryTitle(IPageKindName.Provider).should('be.visible')
   })
 
   it('should be able to create simple page', () => {
-    cy.getSider().getButton({ icon: 'plus' }).click()
+    cy.getCuiSidebar('Pages').getToolbarItem('Create Page').click()
     cy.findByTestId('create-page-form').findByLabelText('Name').type(pageName)
     cy.findByTestId('create-page-form')
       .getButton({ label: 'Create Page' })

--- a/apps/platform-e2e/src/e2e/types.cy.ts
+++ b/apps/platform-e2e/src/e2e/types.cy.ts
@@ -171,13 +171,6 @@ describe('Types CRUD', () => {
         value: primitiveTypeName,
       })
 
-      // should show error because nullable is false by default
-      cy.getModal()
-        .getModalAction(/Create/)
-        .click()
-
-      cy.getModal().findByText('Default values is required if not nullable')
-
       cy.getModal().setFormFieldValue({
         label: 'Default values',
         type: FIELD_TYPE.CODE_MIRROR,
@@ -190,6 +183,7 @@ describe('Types CRUD', () => {
 
       cy.getModal().should('not.exist')
 
+      cy.getCuiTreeItemByPrimaryTitle(interfaceTypeName).click()
       cy.getCuiTreeItemByPrimaryTitle(fieldName).should('be.visible')
 
       cy.getCuiTreeItemByPrimaryTitle(fieldName).click()

--- a/apps/platform-e2e/src/support/nextjs-auth0/commands/login.ts
+++ b/apps/platform-e2e/src/support/nextjs-auth0/commands/login.ts
@@ -14,8 +14,8 @@ export const loginSession = () => {
       // so that there will be no forbidden errors when doing mutations
       // because the roles are needed
       cy.visit('/apps')
-      cy.getSpinner().should('not.exist')
       cy.intercept('GET', '/api/upsert-user').as('upsertUser')
+      cy.getSpinner().should('not.exist')
       cy.wait('@upsertUser', { timeout: 15000 })
     },
     {


### PR DESCRIPTION
<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(libs-ui-component): must begin with lowercase` -->

## Description

- There was an error `CypressError: Timed out retrying after 15000ms: `cy.wait()` timed out waiting `15000ms` for the 1st request to the route: `upsertUser`. No request ever occurred.`
Looks like the request already was completed by the time we try to intercept it and wait. So try to intercept it earlier.

- Fix CuiSidebar which rendered redundant toolbar when there are several tabs that exist

## Video or Image

<!-- Add video or image showing how the new feature works -->

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged -->

Fixes #2863
Fixes #2877 
