### PR TITLE
fix: UnionType issues

### DIFF
--- a/libs/frontend/abstract/core/src/domain/type/json-schema/typed-prop.interface.ts
+++ b/libs/frontend/abstract/core/src/domain/type/json-schema/typed-prop.interface.ts
@@ -1,4 +1,5 @@
 import { ITypeKind } from '@codelab/shared/abstract/core'
+import type { Maybe } from '@codelab/shared/abstract/types'
 import isPlainObject from 'lodash/isPlainObject'
 import isString from 'lodash/isString'
 import type { IPropData } from '../../prop'
@@ -15,7 +16,7 @@ export interface TypedProp {
   // sometimes we need to know the kind without having to load the type
   kind: ITypeKind
   type: string
-  value: string
+  value?: TypedProp | string
 }
 
 export const isTypedProp = (prop: IPropData): prop is TypedProp => {
@@ -33,4 +34,16 @@ export const isTypedProp = (prop: IPropData): prop is TypedProp => {
   // This condition reduces the chances of falsely identifying a prop from an atom component
   // that has an actual `type`, `kind`, or `value` field but is not a render prop.
   return hasTypeAndKindOnly || hasAllKeys
+}
+
+export const extractTypedPropValue = (prop: TypedProp): Maybe<string> => {
+  if (!prop.value) {
+    return undefined
+  }
+
+  if (isString(prop.value)) {
+    return prop.value
+  }
+
+  return extractTypedPropValue(prop.value)
 }

--- a/libs/frontend/abstract/core/src/domain/type/json-schema/typed-prop.interface.ts
+++ b/libs/frontend/abstract/core/src/domain/type/json-schema/typed-prop.interface.ts
@@ -16,6 +16,7 @@ export interface TypedProp {
   // sometimes we need to know the kind without having to load the type
   kind: ITypeKind
   type: string
+  // required for nested types
   value?: TypedProp | string
 }
 

--- a/libs/frontend/domain/renderer/src/typedPropTransformers/action-type-transformer.ts
+++ b/libs/frontend/domain/renderer/src/typedPropTransformers/action-type-transformer.ts
@@ -4,6 +4,7 @@ import type {
   TypedProp,
 } from '@codelab/frontend/abstract/core'
 import {
+  extractTypedPropValue,
   getActionRunnerThisObject,
   getRunnerId,
   isElementPageNode,
@@ -37,6 +38,12 @@ export class ActionTypeTransformer
       return prop.value
     }
 
+    const propValue = extractTypedPropValue(prop)
+
+    if (!propValue) {
+      return ''
+    }
+
     const providerStore = isElementPageNode(node)
       ? node.providerStore
       : undefined
@@ -44,12 +51,12 @@ export class ActionTypeTransformer
     const urlProps = isElementPageNode(node) ? node.urlProps : undefined
 
     const localActionRunner = this.renderer.actionRunners.get(
-      getRunnerId(node.store.id, prop.value),
+      getRunnerId(node.store.id, propValue),
     )
 
     const rootActionRunner = providerStore
       ? this.renderer.actionRunners.get(
-          getRunnerId(providerStore.id, prop.value),
+          getRunnerId(providerStore.id, propValue),
         )
       : undefined
 

--- a/libs/frontend/domain/renderer/src/typedPropTransformers/react-node-type-transformer.ts
+++ b/libs/frontend/domain/renderer/src/typedPropTransformers/react-node-type-transformer.ts
@@ -3,7 +3,10 @@ import type {
   ITypedPropTransformer,
   TypedProp,
 } from '@codelab/frontend/abstract/core'
-import { componentRef } from '@codelab/frontend/abstract/core'
+import {
+  componentRef,
+  extractTypedPropValue,
+} from '@codelab/frontend/abstract/core'
 import { hasStateExpression } from '@codelab/frontend/shared/utils'
 import { ExtendedModel, model } from 'mobx-keystone'
 import { BaseRenderPipe } from '../renderPipes/render-pipe.base'
@@ -30,19 +33,23 @@ export class ReactNodeTypeTransformer
 {
   public transform(prop: TypedProp, node: IPageNode) {
     const { expressionTransformer } = this.renderer
+    const value = extractTypedPropValue(prop)
+
+    if (!value) {
+      return ''
+    }
 
     // value is a custom JS component
     if (hasStateExpression(prop.value) && expressionTransformer.initialized) {
       const transpiledValue =
-        expressionTransformer.transpileAndEvaluateExpression(prop.value)
+        expressionTransformer.transpileAndEvaluateExpression(value)
 
       return typeof transpiledValue === 'function'
         ? transpiledValue.call(expressionTransformer.context)
         : transpiledValue
     }
 
-    const { value: componentId } = prop
-    const component = this.componentService.components.get(componentId)
+    const component = this.componentService.components.get(value)
     const fallback = ''
 
     if (!component) {

--- a/libs/frontend/domain/renderer/src/typedPropTransformers/react-node-type-transformer.ts
+++ b/libs/frontend/domain/renderer/src/typedPropTransformers/react-node-type-transformer.ts
@@ -33,23 +33,23 @@ export class ReactNodeTypeTransformer
 {
   public transform(prop: TypedProp, node: IPageNode) {
     const { expressionTransformer } = this.renderer
-    const value = extractTypedPropValue(prop)
+    const propValue = extractTypedPropValue(prop)
 
-    if (!value) {
+    if (!propValue) {
       return ''
     }
 
-    // value is a custom JS component
+    // propValue is a custom JS component
     if (hasStateExpression(prop.value) && expressionTransformer.initialized) {
       const transpiledValue =
-        expressionTransformer.transpileAndEvaluateExpression(value)
+        expressionTransformer.transpileAndEvaluateExpression(propValue)
 
       return typeof transpiledValue === 'function'
         ? transpiledValue.call(expressionTransformer.context)
         : transpiledValue
     }
 
-    const component = this.componentService.components.get(value)
+    const component = this.componentService.components.get(propValue)
     const fallback = ''
 
     if (!component) {

--- a/libs/frontend/domain/renderer/src/typedPropTransformers/render-prop-type-transformer.ts
+++ b/libs/frontend/domain/renderer/src/typedPropTransformers/render-prop-type-transformer.ts
@@ -4,7 +4,10 @@ import type {
   ITypedPropTransformer,
   TypedProp,
 } from '@codelab/frontend/abstract/core'
-import { componentRef } from '@codelab/frontend/abstract/core'
+import {
+  componentRef,
+  extractTypedPropValue,
+} from '@codelab/frontend/abstract/core'
 import { hasStateExpression } from '@codelab/frontend/shared/utils'
 import { ExtendedModel, model } from 'mobx-keystone'
 import { BaseRenderPipe } from '../renderPipes/render-pipe.base'
@@ -41,12 +44,17 @@ export class RenderPropTypeTransformer
 {
   public transform(prop: TypedProp, node: IPageNode) {
     const { expressionTransformer } = this.renderer
+    const propValue = extractTypedPropValue(prop)
 
-    if (hasStateExpression(prop.value) && expressionTransformer.initialized) {
-      return expressionTransformer.transpileAndEvaluateExpression(prop.value)
+    if (!propValue) {
+      return ''
     }
 
-    const component = this.componentService.components.get(prop.value)
+    if (hasStateExpression(propValue) && expressionTransformer.initialized) {
+      return expressionTransformer.transpileAndEvaluateExpression(propValue)
+    }
+
+    const component = this.componentService.components.get(propValue)
     const fields = component?.api.current.fields
     // can't return prop object because it will be passed as React Child, which will throw an error
     const fallback = ''

--- a/libs/frontend/domain/type/src/interface-form/fields/select-union-type-value/SelectUnionTypeValue.tsx
+++ b/libs/frontend/domain/type/src/interface-form/fields/select-union-type-value/SelectUnionTypeValue.tsx
@@ -77,11 +77,12 @@ export const SelectUnionTypeValue = (props: SelectUnionTypeValueProps) => {
 
   const { type: selectedTypeId } = fieldProps.value
   const selectOptions = makeSelectOptions(oneOf)
+  const typeFromOneOf = getTypeFromOneOf(oneOf, selectedTypeId)
 
   const valueSchema = {
     label: '',
     properties: {
-      value: getTypeFromOneOf(oneOf, selectedTypeId).properties.value,
+      value: typeFromOneOf.properties.value,
     },
     required: ['value'],
     type: 'object',
@@ -94,7 +95,7 @@ export const SelectUnionTypeValue = (props: SelectUnionTypeValueProps) => {
       previousSelectedTypeId !== selectedTypeId
     ) {
       context.onChange(concatenateName(name, context), {
-        kind: getTypeFromOneOf(oneOf, selectedTypeId).properties.kind.default,
+        kind: typeFromOneOf.properties.kind.default,
         type: selectedTypeId,
         value: undefined,
       })
@@ -106,7 +107,7 @@ export const SelectUnionTypeValue = (props: SelectUnionTypeValueProps) => {
     selectedTypeId,
     valueFieldName,
     name,
-    oneOf,
+    typeFromOneOf,
   ])
 
   // This is required to avoid using the value of previously

--- a/libs/frontend/domain/type/src/interface-form/fields/select-union-type-value/SelectUnionTypeValue.tsx
+++ b/libs/frontend/domain/type/src/interface-form/fields/select-union-type-value/SelectUnionTypeValue.tsx
@@ -5,7 +5,8 @@ import { usePrevious } from '@codelab/frontend/shared/utils'
 import { Form as AntdForm } from 'antd'
 import isNil from 'lodash/isNil'
 import React, { useEffect } from 'react'
-import { useField } from 'uniforms'
+import type { Context } from 'uniforms'
+import { joinName, useField } from 'uniforms'
 import { AutoField, SelectField } from 'uniforms-antd'
 
 export interface SelectUnionTypeValueProps {
@@ -35,17 +36,40 @@ const getTypeFromOneOf = (oneOf: Array<any>, typeId: string) => {
   return oneOf.find((of: any) => of.properties.type.default === typeId)
 }
 
+/*
+ * This is required for nested fields in a custom field (ToggleExpressionField).
+ * If we use a custom field the name should be joined with the parent name.
+ * https://uniforms.tools/docs/api-helpers/#joinname
+ */
+const concatenateName = (
+  name: string,
+  context: Context<Record<string, any>>,
+) => {
+  if (context.name.length) {
+    return joinName(context.name, name)
+  }
+
+  return name
+}
+
+/*
+ * In custom fields with subfields the name is passed down as an empty string
+ * because the connectField removes the name from the props. So we need to
+ * concatenate the name with the parent name.
+ * https://uniforms.tools/docs/api-helpers/#joinname
+ */
+const getTypeAndValueFieldNames = (name: string) => {
+  const typeFieldName = name ? `${name}.type` : 'type'
+  const valueFieldName = name ? `${name}.value` : 'value'
+
+  return { typeFieldName, valueFieldName }
+}
+
 export const SelectUnionTypeValue = (props: SelectUnionTypeValueProps) => {
   const { name } = props
   const [fieldProps, context] = useField(name, props)
   const oneOf = fieldProps.field.oneOf
-  // For the nested fields i.e. UnionType inside ArrayType, the name field is passed down as an empty string
-  // this causes the field not be validated correctly against the schema
-  // because "".type would not be valid
-  // TODO: this issue is most probably caused by the `connectField` wrapper in ToggleExpressionField
-  // must be fixed so that the name is correctly passed down to the nested fields
-  const typeFieldName = name ? `${name}.type` : 'type'
-  const valueFieldName = name ? `${name}.value` : 'value'
+  const { typeFieldName, valueFieldName } = getTypeAndValueFieldNames(name)
 
   if (!oneOf?.length) {
     throw new Error('SelectUnionTypeValue must be used with a oneOf field')
@@ -69,7 +93,7 @@ export const SelectUnionTypeValue = (props: SelectUnionTypeValueProps) => {
       !isNil(previousSelectedTypeId) &&
       previousSelectedTypeId !== selectedTypeId
     ) {
-      context.onChange(valueFieldName, undefined)
+      context.onChange(concatenateName(valueFieldName, context), undefined)
     }
   }, [
     context,
@@ -98,17 +122,10 @@ export const SelectUnionTypeValue = (props: SelectUnionTypeValueProps) => {
             const validate = createValidator(valueSchema)
             validate(formData)
 
-            // To use connectField ToggleExpressionField we need to
-            // remove the parent name from the field path {@link ToggleExpressionField#getBaseControl}
-            // Hence we need to reconstruct the field path here. This is only needed for nested fields
-            // TODO: fix the connectField in ToggleExpressionField so that correct props are passed
-            let valueFieldPath = valueFieldName
-
-            if (context.name.length) {
-              valueFieldPath = `${context.name.join('.')}.${valueFieldName}`
-            }
-
-            context.onChange(valueFieldPath, formData.value)
+            context.onChange(
+              concatenateName(valueFieldName, context),
+              formData.value,
+            )
           }}
           onSubmit={() => Promise.resolve()}
           schema={valueSchema as any}

--- a/libs/frontend/domain/type/src/interface-form/fields/select-union-type-value/SelectUnionTypeValue.tsx
+++ b/libs/frontend/domain/type/src/interface-form/fields/select-union-type-value/SelectUnionTypeValue.tsx
@@ -93,7 +93,11 @@ export const SelectUnionTypeValue = (props: SelectUnionTypeValueProps) => {
       !isNil(previousSelectedTypeId) &&
       previousSelectedTypeId !== selectedTypeId
     ) {
-      context.onChange(concatenateName(valueFieldName, context), undefined)
+      context.onChange(concatenateName(name, context), {
+        kind: getTypeFromOneOf(oneOf, selectedTypeId).properties.kind.default,
+        type: selectedTypeId,
+        value: undefined,
+      })
     }
   }, [
     context,
@@ -101,7 +105,18 @@ export const SelectUnionTypeValue = (props: SelectUnionTypeValueProps) => {
     previousSelectedTypeId,
     selectedTypeId,
     valueFieldName,
+    name,
+    oneOf,
   ])
+
+  // This is required to avoid using the value of previously
+  // selected type when switching between types.
+  const model = {
+    value:
+      isNil(previousSelectedTypeId) || selectedTypeId === previousSelectedTypeId
+        ? fieldProps.value.value
+        : undefined,
+  }
 
   return (
     <AntdForm.Item label={fieldProps.label}>
@@ -114,7 +129,7 @@ export const SelectUnionTypeValue = (props: SelectUnionTypeValueProps) => {
 
         <Form
           key={selectedTypeId}
-          model={{ value: fieldProps.value.value }}
+          model={model}
           onChangeModel={(formData) => {
             // This automatically sets the default values into the formData for the properties that has a default value
             // This is needed for ReactNodeType or similar types where the schema has a default `type` field value

--- a/libs/frontend/presentation/container/src/pageHooks/useRenderedPage.hook.ts
+++ b/libs/frontend/presentation/container/src/pageHooks/useRenderedPage.hook.ts
@@ -7,6 +7,7 @@ import type {
   TypedProp,
 } from '@codelab/frontend/abstract/core'
 import {
+  extractTypedPropValue,
   isComponentInstance,
   isTypedProp,
   rendererRef,
@@ -20,6 +21,7 @@ import type { Nullable } from '@codelab/shared/abstract/types'
 import { useAsync } from '@react-hookz/web'
 import flatMap from 'lodash/flatMap'
 import isObject from 'lodash/isObject'
+import isString from 'lodash/isString'
 import values from 'lodash/values'
 import { useRouter } from 'next/router'
 import { useStore } from '../providers'
@@ -146,8 +148,8 @@ const hasComponentId = (prop: TypedProp): boolean =>
   [ITypeKind.ReactNodeType, ITypeKind.RenderPropType].includes(prop.kind)
 
 const getComponentIdsFromProp = (prop: IPropData): Array<string> =>
-  isTypedProp(prop) && hasComponentId(prop)
-    ? [prop.value]
+  isTypedProp(prop) && hasComponentId(prop) && extractTypedPropValue(prop)
+    ? [extractTypedPropValue(prop)!]
     : isObject(prop)
     ? values(prop).flatMap((childProp) => getComponentIdsFromProp(childProp))
     : []
@@ -167,7 +169,9 @@ const getComponentIdsFromElements = (elements: Array<IElement>) =>
         acc.push(element.childMapperComponent.id)
       }
 
-      acc.push(...getComponentIdsFromProp(element.props.current))
+      acc.push(
+        ...getComponentIdsFromProp(element.props.current).filter(isString),
+      )
 
       return acc
     }, [])


### PR DESCRIPTION
<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(libs-ui-component): must begin with lowercase` -->

## Description
Fixes the following issues with `UnionType` in forms.

- [x] Cannot use `ReactNodeType` in `UnionType`
- [x] Default values are not changed when the type is changed


<!-- This is a short description on the Pull Request -->

## Video or Image

<!-- Add video or image showing how the new feature works -->

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged -->

Fixes #2847 
