### PR TITLE
fix: build workspace error: duplicated project

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,14 +12,6 @@
 # compiled output
 # Ignore everything in 'dist'
 /dist/*
-# Don't ignore 'libs' within 'dist'
-!/dist/libs/
-# Ignore everything in 'dist/libs' except 'tools'
-/dist/libs/*
-!/dist/libs/tools/
-# Ignore everything in 'dist/libs/tools' except 'workspace'
-/dist/libs/tools/*
-!/dist/libs/tools/workspace/
 tmp/
 out-tsc/
 

--- a/libs/tools/workspace/package.json
+++ b/libs/tools/workspace/package.json
@@ -3,5 +3,18 @@
   "version": "0.0.1",
   "type": "commonjs",
   "generators": "./generators.json",
-  "executors": "./executors.json"
+  "executors": "./executors.json",
+  "dependencies": {
+    "@graphql-codegen/core": "4.0.0",
+    "@graphql-tools/graphql-file-loader": "8.0.0",
+    "@graphql-tools/load": "8.0.0",
+    "@graphql-tools/url-loader": "8.0.0",
+    "graphql": "16.6.0",
+    "lodash": "4.17.21"
+  },
+  "peerDependencies": {
+    "tslib": "2.3.1"
+  },
+  "main": "./src/index.js",
+  "types": "./src/index.d.ts"
 }

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   },
   "packageManager": "yarn@3.5.1",
   "workspaces": [
-    "dist/libs/tools/workspace"
+    "libs/tools/workspace"
   ],
   "version": "0.0.1",
   "license": "MIT",
@@ -196,7 +196,7 @@
     "@babel/plugin-transform-typescript": "^7.20.13",
     "@babel/preset-react": "^7.18.6",
     "@babel/types": "7.18.2",
-    "@codelab/tools-workspace": "file:./dist/libs/tools/workspace",
+    "@codelab/tools-workspace": "file:./libs/tools/workspace",
     "@commitlint/cli": "17.6.5",
     "@commitlint/config-conventional": "17.6.5",
     "@graphql-codegen/cli": "4.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5690,9 +5690,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@codelab/tools-workspace@file:./dist/libs/tools/workspace::locator=codelab%40workspace%3A.":
+"@codelab/tools-workspace@file:./libs/tools/workspace::locator=codelab%40workspace%3A.":
   version: 0.0.1
-  resolution: "@codelab/tools-workspace@file:./dist/libs/tools/workspace#./dist/libs/tools/workspace::hash=dce467&locator=codelab%40workspace%3A."
+  resolution: "@codelab/tools-workspace@file:./libs/tools/workspace#./libs/tools/workspace::hash=c347ee&locator=codelab%40workspace%3A."
   dependencies:
     "@graphql-codegen/core": 4.0.0
     "@graphql-tools/graphql-file-loader": 8.0.0
@@ -5702,13 +5702,13 @@ __metadata:
     lodash: 4.17.21
   peerDependencies:
     tslib: 2.3.1
-  checksum: 3bf8bdcd5b9161cab7b12afa98d1809f1893d03beffb973adf1488ff109f07785dcd3392ef2ce3307c70bab5f339240fc03460f4f5b2284d59dbf700db4e87d8
+  checksum: fed7449c50e351093b14a7b771c05e2fc504fe0a2e4e6c36ea06b8d11a879ccb90367fe4f3ade62cd877d9eef12a60a06cae065e2de78a935a6dc49bf8379202
   languageName: node
   linkType: hard
 
-"@codelab/tools-workspace@workspace:dist/libs/tools/workspace":
+"@codelab/tools-workspace@workspace:libs/tools/workspace":
   version: 0.0.0-use.local
-  resolution: "@codelab/tools-workspace@workspace:dist/libs/tools/workspace"
+  resolution: "@codelab/tools-workspace@workspace:libs/tools/workspace"
   dependencies:
     "@graphql-codegen/core": 4.0.0
     "@graphql-tools/graphql-file-loader": 8.0.0
@@ -21111,7 +21111,7 @@ __metadata:
     "@babel/preset-react": ^7.18.6
     "@babel/runtime": 7.18.3
     "@babel/types": 7.18.2
-    "@codelab/tools-workspace": "file:./dist/libs/tools/workspace"
+    "@codelab/tools-workspace": "file:./libs/tools/workspace"
     "@codemirror/autocomplete": 6.1.0
     "@codemirror/lang-css": 6.0.0
     "@codemirror/lang-html": 6.1.0


### PR DESCRIPTION
<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(libs-ui-component): must begin with lowercase` -->

## Description

Currently, build fails on stage `setup-workspace` with the error:
```
➤ YN0000: │ codelab@workspace:. STDERR Skipping project found at libs/tools/workspace since project @codelab/tools-workspace already exists at dist/libs/tools/workspace! Specify a unique name for the project to allow Nx to differentiate between the two projects.
➤ YN0000: │ codelab@workspace:. STDOUT 
➤ YN0000: │ codelab@workspace:. STDOUT  >  NX   Cannot find configuration for task @codelab/tools-workspace:build
➤ YN0000: │ codelab@workspace:. STDOUT 
➤ YN0000: │ codelab@workspace:. STDOUT    Pass --verbose to see the stacktrace.
➤ YN0000: │ codelab@workspace:. STDOUT 
➤ YN0009: │ codelab@workspace:. couldn't be built successfully (exit code 1, logs can be found here: /tmp/xfs-26c2938c/build.log)
➤ YN0000: └ Completed in 1m 17s
➤ YN0000: Failed with errors in 1m 22s
```

As a fix, try to ignore `@codelab/tools-workspace` project in `dist/libs/tools/workspace` folder, since it is just a build result of a project at `libs/tools/workspace`.
This should resolve the error about two projects with the same name

<!-- This is a short description on the Pull Request -->

## Video or Image

<!-- Add video or image showing how the new feature works -->

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged -->

Fixes #
