### PR TITLE
fix: converting element to a component

### DIFF
--- a/apps/platform-e2e/src/e2e/component/component.cy.ts
+++ b/apps/platform-e2e/src/e2e/component/component.cy.ts
@@ -1,8 +1,8 @@
 import type { IAppDTO } from '@codelab/shared/abstract/core'
 import { IAtomType, IPrimitiveTypeKind } from '@codelab/shared/abstract/core'
 import { slugify } from '@codelab/shared/utils'
-import { FIELD_TYPE } from '../support/antd/form'
-import { loginSession } from '../support/nextjs-auth0/commands/login'
+import { FIELD_TYPE } from '../../support/antd/form'
+import { loginSession } from '../../support/nextjs-auth0/commands/login'
 
 const COMPONENT_NAME = 'New Component'
 const COMPONENT_INSTANCE_NAME = 'Component Instance'

--- a/apps/platform-e2e/src/e2e/component/convert-element-to-component.cy.ts
+++ b/apps/platform-e2e/src/e2e/component/convert-element-to-component.cy.ts
@@ -1,0 +1,102 @@
+import { ROOT_ELEMENT_NAME } from '@codelab/frontend/abstract/core'
+import type { IAppDTO } from '@codelab/shared/abstract/core'
+import { IAtomType, IPageKindName } from '@codelab/shared/abstract/core'
+import { slugify } from '@codelab/shared/utils'
+import { loginSession } from '../../support/nextjs-auth0/commands/login'
+
+const CONVERT_TO_COMPONENT_TEXT = 'Convert To Component'
+const ELEMENT_CONTAINER = 'Element Abc'
+const ELEMENT_ROW = 'Row'
+const ELEMENT_COL_A = 'Col A'
+const ELEMENT_TEXT_1 = 'Text 1'
+
+const elements = [
+  {
+    name: ELEMENT_CONTAINER,
+    parentElement: ROOT_ELEMENT_NAME,
+  },
+  {
+    name: ELEMENT_ROW,
+    parentElement: ELEMENT_CONTAINER,
+  },
+  {
+    atom: IAtomType.AntDesignGridCol,
+    name: ELEMENT_COL_A,
+    parentElement: ELEMENT_ROW,
+  },
+  {
+    atom: IAtomType.AntDesignTypographyText,
+    name: ELEMENT_TEXT_1,
+    parentElement: ELEMENT_COL_A,
+  },
+]
+
+describe('Converting an element to a component', () => {
+  let app: IAppDTO
+  before(() => {
+    cy.resetDatabase()
+    loginSession()
+
+    cy.request('/api/cypress/atom')
+      .then(() => cy.request<IAppDTO>('/api/cypress/app'))
+      .then((apps) => {
+        app = apps.body
+        cy.visit(
+          `/apps/cypress/${slugify(app.name)}/pages/${slugify(
+            IPageKindName.Provider,
+          )}/builder`,
+        )
+        cy.getSpinner().should('not.exist')
+
+        // select root now so we can update its child later
+        // there is an issue with tree interaction
+        // Increased timeout since builder may take longer to load
+        cy.findByText(ROOT_ELEMENT_NAME, { timeout: 30000 })
+          .should('be.visible')
+          .click({ force: true })
+      })
+
+    cy.createElementTree(elements)
+  })
+
+  it('should convert the element into a component and create an instance of it', () => {
+    cy.getCuiTreeItemByPrimaryTitle(ELEMENT_CONTAINER).rightclick()
+
+    cy.findByText(CONVERT_TO_COMPONENT_TEXT).click()
+
+    cy.findByText(`instance of ${ELEMENT_CONTAINER}`).should('be.visible')
+
+    // the element descendants of a component instance is not shown
+    cy.getCuiTreeItemByPrimaryTitle(ELEMENT_ROW).should('not.exist')
+    cy.getCuiTreeItemByPrimaryTitle(ELEMENT_COL_A).should('not.exist')
+    cy.getCuiTreeItemByPrimaryTitle(ELEMENT_TEXT_1).should('not.exist')
+  })
+
+  it('should still have the descendant elements of the component', () => {
+    cy.visit(
+      `/apps/cypress/${slugify(app.name)}/pages/${slugify(
+        IPageKindName.Provider,
+      )}/builder?primarySidebarKey=components`,
+    )
+    // GetRenderedPageAndCommonAppData
+    cy.waitForApiCalls()
+    cy.getSpinner().should('not.exist')
+
+    // GetAtoms
+    // GetComponents
+    cy.waitForApiCalls()
+    cy.getSpinner().should('not.exist')
+
+    cy.getCuiSidebar('Components')
+      .getCuiSidebarViewContent('Custom')
+      .contains('.ant-card-head-title', ELEMENT_CONTAINER)
+      .next()
+      .getButton({ icon: 'edit' })
+      .click()
+
+    // the element descendants of a component should show on the custom component builder
+    cy.getCuiTreeItemByPrimaryTitle(ELEMENT_ROW).should('exist')
+    cy.getCuiTreeItemByPrimaryTitle(ELEMENT_COL_A).should('exist')
+    cy.getCuiTreeItemByPrimaryTitle(ELEMENT_TEXT_1).should('exist')
+  })
+})

--- a/libs/frontend/domain/element/src/store/element.service.ts
+++ b/libs/frontend/domain/element/src/store/element.service.ts
@@ -794,7 +794,6 @@ export class ElementService
 
     // 3. detach the element from the element tree
     const oldConnectedNodeIds = this.detachElementFromElementTree(element.id)
-    yield* _await(this.updateAffectedElements(oldConnectedNodeIds))
 
     // 4. attach current element to the component
     const affectedAttachedNodes = this.attachElementAsFirstChild({
@@ -802,7 +801,12 @@ export class ElementService
       parentElement: createdComponent.rootElement,
     })
 
-    yield* _await(this.updateAffectedElements(affectedAttachedNodes))
+    yield* _await(
+      this.updateAffectedElements([
+        ...oldConnectedNodeIds,
+        ...affectedAttachedNodes,
+      ]),
+    )
 
     // 5. create a new element as an instance of the component
     const componentId = createdComponent.id


### PR DESCRIPTION
<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(libs-ui-component): must begin with lowercase` -->

## Description

<!-- This is a short description on the Pull Request -->
This fixes converting an element to a component.

As mentioned in the issue, we were detaching an element to its parent then calling the mutation, which causes this [error](https://github.com/codelab-app/platform/blob/3397cb3cf545a6a89456a9ac8ee51789d2f161a4/libs/frontend/domain/element/src/store/element.model.ts#L210) to throw. This is fixed by calling the mutation later, once the element's parent/sibling connection is updated.

The mutation midway causes the tree to be re-rendered while the operation is being processed inside the mobx-keystone transaction, so we should do the mutation only once the element data locally is fully updated.

## Video or Image

<!-- Add video or image showing how the new feature works -->

https://github.com/codelab-app/platform/assets/27695022/fd04c7c2-9cc9-4b81-a486-27c1fbbe84eb



## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged -->

Fixes #2474 
