### PR TITLE
fix: script error on adding renderType to Body

### DIFF
--- a/libs/frontend/domain/element/src/store/element.service.ts
+++ b/libs/frontend/domain/element/src/store/element.service.ts
@@ -130,7 +130,7 @@ export class ElementService
    */
   @modelFlow
   @transaction
-  loadRenderTypeInterface = _async(function* (
+  private loadRenderTypeInterface = _async(function* (
     this: ElementService,
     data: ICreateElementData,
   ) {

--- a/libs/frontend/domain/element/src/store/element.service.ts
+++ b/libs/frontend/domain/element/src/store/element.service.ts
@@ -124,11 +124,16 @@ export class ElementService
   }
 
   /**
-   * We need a separate create function for element trees
+   * If an element is created or updated with renderType atom or component
+   * that is not used yet anywhere in the current page,
+   * this will load its interface types and its fields
    */
   @modelFlow
   @transaction
-  create = _async(function* (this: ElementService, data: ICreateElementData) {
+  loadRenderTypeInterface = _async(function* (
+    this: ElementService,
+    data: ICreateElementData,
+  ) {
     const renderTypeApi =
       data.renderType &&
       (yield* _await(
@@ -144,6 +149,17 @@ export class ElementService
       // in the current page, this will load its interface types and its fields
       yield* _await(this.typeService.getOne(renderTypeApi.id))
     }
+
+    return renderTypeApi
+  })
+
+  /**
+   * We need a separate create function for element trees
+   */
+  @modelFlow
+  @transaction
+  create = _async(function* (this: ElementService, data: ICreateElementData) {
+    const renderTypeApi = yield* _await(this.loadRenderTypeInterface(data))
 
     const elementProps = this.propService.add({
       data: data.props?.data ?? makeDefaultProps(renderTypeApi?.current),
@@ -162,10 +178,10 @@ export class ElementService
 
   @modelFlow
   @transaction
-  update = _async(function* (
-    this: ElementService,
-    { id, ...elementData }: IUpdateElementData,
-  ) {
+  update = _async(function* (this: ElementService, data: IUpdateElementData) {
+    yield* _await(this.loadRenderTypeInterface(data))
+
+    const { id, ...elementData } = data
     const element = this.element(id)
     const { id: newRenderTypeId } = elementData.renderType ?? {}
     const { id: oldRenderTypeId } = element.renderType ?? {}

--- a/libs/frontend/domain/element/src/use-cases/element/update-element-props/UpdateElementPropsForm.tsx
+++ b/libs/frontend/domain/element/src/use-cases/element/update-element-props/UpdateElementPropsForm.tsx
@@ -53,12 +53,11 @@ export const UpdateElementPropsForm = observer<UpdateElementPropsFormProps>(
 
     const [{ result: interfaceType, status }, getInterface] = useAsync(
       async () => {
-        await loadAllTypesForElements(
-          componentService,
-          typeService,
-          builderService.activeElementTree?.rootElement.current
-            .descendantElements ?? [],
-        )
+        const roots = builderService.activeElementTree
+          ? [builderService.activeElementTree.rootElement.current]
+          : []
+
+        await loadAllTypesForElements(componentService, typeService, roots)
 
         return typeService.getInterface(apiId!)
       },

--- a/libs/frontend/presentation/container/src/pageHooks/useRenderedComponent.hook.ts
+++ b/libs/frontend/presentation/container/src/pageHooks/useRenderedComponent.hook.ts
@@ -34,14 +34,10 @@ export const useRenderedComponent = () => {
       return null
     }
 
-    const pageElements = [
-      component.rootElement.current,
-      ...component.rootElement.current.descendantElements,
-    ]
-
+    const roots = [component.rootElement.current]
     const rootElement = elementService.maybeElement(component.rootElement.id)
 
-    await loadAllTypesForElements(componentService, typeService, pageElements)
+    await loadAllTypesForElements(componentService, typeService, roots)
 
     if (rootElement) {
       builderService.selectElementNode(rootElement)

--- a/libs/frontend/presentation/container/src/pageHooks/useRenderedPage.hook.ts
+++ b/libs/frontend/presentation/container/src/pageHooks/useRenderedPage.hook.ts
@@ -88,16 +88,16 @@ export const useRenderedPage = ({
       return null
     }
 
-    const pageElements = [
+    const roots = [
       // This will load the custom components in the _app (provider page) for the regular pages since we also
       // render the elements of the provider page as part of the regular page
       ...(page.kind === PageKind.Regular
-        ? app.providerPage.rootElement.current.descendantElements
+        ? [app.providerPage.rootElement.current]
         : []),
-      ...page.rootElement.current.descendantElements,
+      page.rootElement.current,
     ]
 
-    await loadAllTypesForElements(componentService, typeService, pageElements)
+    await loadAllTypesForElements(componentService, typeService, roots)
 
     const pageRootElement = elementService.maybeElement(page.rootElement.id)
 
@@ -197,9 +197,14 @@ const getTypeIdsFromElements = (elements: Array<IElement>) => {
 export const loadAllTypesForElements = async (
   componentService: IComponentService,
   typeService: ITypeService,
-  elements: Array<IElement>,
+  roots: Array<IElement>,
 ) => {
   const loadedComponentElements: Array<IElement> = []
+
+  const elements = [
+    ...roots,
+    ...flatMap(roots.map((root) => root.descendantElements)),
+  ]
 
   // Loading custom components
   let componentsBatch = getComponentIdsFromElements(elements).filter(


### PR DESCRIPTION
<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(libs-ui-component): must begin with lowercase` -->

## Description
Fixed 2 issues in this PR:
1. The problem that the interface and corresponding fields were not loaded for Body at all (for renderType)
2. The problem when renderType interface and fields were not loaded on element *update*: when the user changes renderType to an atom that was not used on the current page before, this results in the same script error because could not resolve interface type for that atom

## Video or Image

https://github.com/codelab-app/platform/assets/74900868/c40fa740-4a39-4bd9-8e12-747a25a5eb08

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged -->

Fixes #2893
