### PR TITLE
fix: set hasSider flag to avoid flickering

### DIFF
--- a/libs/frontend/presentation/view/templates/Dashboard/DashboardTemplate.tsx
+++ b/libs/frontend/presentation/view/templates/Dashboard/DashboardTemplate.tsx
@@ -51,7 +51,11 @@ export const DashboardTemplateSSR = observer(
     return (
       <Layout className="max-h-full min-h-full">
         {Header && <Header />}
-        <Layout>
+        {/* 
+          Need explicitly set `hasSider` prop to avoid flickering
+          see AntD documentation or https://github.com/ant-design/ant-design/issues/8937 
+        */}
+        <Layout hasSider>
           <Sider collapsed collapsedWidth={sidebarWidth} theme="light">
             <CuiNavigationBar
               primaryItems={navigationBarItems.primaryItems}


### PR DESCRIPTION
<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(libs-ui-component): must begin with lowercase` -->

## Description

It appears to be a known issue - https://github.com/ant-design/ant-design/issues/8937. After it was fixed - AntDesign documentation recommends to use this approach when `Layout` is used on page with SSR:

<img width="1236" alt="Screenshot 2023-08-17 at 16 41 42" src="https://github.com/codelab-app/platform/assets/74900868/493df27a-de02-4ff1-8c5f-1fc1c47c1900">

## Video or Image

Behaviour before:

https://github.com/codelab-app/platform/assets/74900868/5399a681-ecac-4831-90fc-d4cc0b0947d8

After fix:

https://github.com/codelab-app/platform/assets/74900868/cc4ed12c-1f55-4f5e-9c83-8566456a79df

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged -->

Fixes #2899
