### PR TITLE
fix: allow to execute pre-/post- actions from _app

### DIFF
--- a/libs/frontend/domain/renderer/src/action-runner.model.ts
+++ b/libs/frontend/domain/renderer/src/action-runner.model.ts
@@ -65,19 +65,17 @@ const graphqlFetch = (
   return client.request(config.query, variables, headers)
 }
 
-const getRunner = (
+export const getRunner = (
   renderer?: IRenderer,
   actionId?: string,
   storeId?: string,
   providerStoreId?: string,
-): { runner?: IActionRunner['runner']; fromProvider?: boolean } => {
+): { runner?: IActionRunner; fromProvider?: boolean } => {
   if (!renderer || !actionId || !storeId) {
     return {}
   }
 
-  const runner = renderer.actionRunners.get(
-    getRunnerId(storeId, actionId),
-  )?.runner
+  const runner = renderer.actionRunners.get(getRunnerId(storeId, actionId))
 
   if (!isNil(runner)) {
     return { fromProvider: false, runner }
@@ -89,7 +87,7 @@ const getRunner = (
 
   const providerRunner = renderer.actionRunners.get(
     getRunnerId(providerStoreId, actionId),
-  )?.runner
+  )
 
   return {
     fromProvider: !isNil(providerRunner),
@@ -227,14 +225,14 @@ export class ActionRunner
           ? { ..._this, state: _this.rootState }
           : _this
 
-        return successRunner?.call(successRunnerThis, response)
+        return successRunner?.runner.call(successRunnerThis, response)
       } catch (error) {
         // actions in the provider should not have access to the state of regular pages
         const errorRunnerThis = isErrorRunnerFromProvider
           ? { ..._this, state: _this.rootState }
           : _this
 
-        return errorRunner?.call(errorRunnerThis, error)
+        return errorRunner?.runner.call(errorRunnerThis, error)
       }
     }
   }

--- a/libs/frontend/domain/renderer/src/element/element-wrapper.ts
+++ b/libs/frontend/domain/renderer/src/element/element-wrapper.ts
@@ -5,7 +5,6 @@ import type {
 } from '@codelab/frontend/abstract/core'
 import {
   getActionRunnerThisObject,
-  getRunnerId,
   isAtomInstance,
   RendererType,
 } from '@codelab/frontend/abstract/core'
@@ -15,6 +14,7 @@ import { mergeProps } from '@codelab/shared/utils'
 import { observer } from 'mobx-react-lite'
 import React, { useEffect } from 'react'
 import { ErrorBoundary } from 'react-error-boundary'
+import { getRunner } from '../action-runner.model'
 import { shouldRenderElement } from '../utils'
 import { mapOutput } from '../utils/render-output-utils'
 import { renderComponentWithStyles } from './get-styled-components'
@@ -37,14 +37,14 @@ export interface ElementWrapperProps {
 export const ElementWrapper = observer<ElementWrapperProps>(
   ({ element, renderer, ...rest }) => {
     useEffect(() => {
-      const { postRenderAction, store } = element
+      const { postRenderAction, providerStore, store } = element
 
-      if (!postRenderAction) {
-        return
-      }
-
-      const actionRunnerId = getRunnerId(store.id, postRenderAction.id)
-      const postRenderActionRunner = renderer.actionRunners.get(actionRunnerId)
+      const { runner: postRenderActionRunner } = getRunner(
+        renderer,
+        postRenderAction?.id,
+        store.id,
+        providerStore?.id,
+      )
 
       if (postRenderActionRunner) {
         const _this = getActionRunnerThisObject(

--- a/libs/frontend/domain/renderer/src/renderer.model.ts
+++ b/libs/frontend/domain/renderer/src/renderer.model.ts
@@ -40,7 +40,7 @@ import { createTransformer } from 'mobx-utils'
 import type { ReactElement, ReactNode } from 'react'
 import React from 'react'
 import type { ArrayOrSingle } from 'ts-essentials'
-import { ActionRunner } from './action-runner.model'
+import { ActionRunner, getRunner } from './action-runner.model'
 import { ComponentRuntimeProps } from './component-runtime-props.model'
 import type { ElementWrapperProps } from './element/element-wrapper'
 import { ElementWrapper } from './element/element-wrapper'
@@ -194,11 +194,15 @@ export class Renderer
       renderer: this,
     }
 
-    const { preRenderAction, store } = element
+    const { preRenderAction, providerStore, store } = element
 
     if (preRenderAction) {
-      const actionRunnerId = getRunnerId(store.id, preRenderAction.id)
-      const preRenderActionRunner = this.actionRunners.get(actionRunnerId)
+      const { runner: preRenderActionRunner } = getRunner(
+        this,
+        preRenderAction.id,
+        store.id,
+        providerStore?.id,
+      )
 
       if (preRenderActionRunner) {
         const _this = getActionRunnerThisObject(


### PR DESCRIPTION
<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(libs-ui-component): must begin with lowercase` -->

## Description

Need to lookup for preRender/postRender actions in rootStore if the action was not found in regular page store.

## Video or Image

https://github.com/codelab-app/platform/assets/74900868/d07b7ecf-abab-4d59-9afc-de68f182a7d5

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged -->

Fixes #2918 
