### PR TITLE
wip: clone actions when converting to component

### DIFF
--- a/libs/frontend/abstract/core/src/domain/action/action.service.interface.ts
+++ b/libs/frontend/abstract/core/src/domain/action/action.service.interface.ts
@@ -38,5 +38,6 @@ export interface IActionService
 
   action(id: string): Maybe<IAction>
   add<T extends IActionDTO>(action: T): IAction
+  cloneAction(action: IAction, storeId: string): Promise<IAction>
   load(actions: Array<ActionFragment>): Array<IAction>
 }

--- a/libs/frontend/abstract/core/src/domain/type/field/field.service.interface.ts
+++ b/libs/frontend/abstract/core/src/domain/type/field/field.service.interface.ts
@@ -41,6 +41,7 @@ export interface IFieldService
   fieldRepository: IFieldRepository
   fields: ObjectMap<IField>
   add(fieldDTO: IFieldDTO): IField
+  cloneField(field: IField, apiId: string): Promise<IField>
   delete(fields: Array<IField>): Promise<number>
   getField(id: string): Maybe<IField<IType>>
   load(fields: Array<FieldFragment>): void

--- a/libs/frontend/domain/element/src/store/element.service.ts
+++ b/libs/frontend/domain/element/src/store/element.service.ts
@@ -15,7 +15,10 @@ import {
 import { getAtomService } from '@codelab/frontend/domain/atom'
 import { Component } from '@codelab/frontend/domain/component'
 import { getPropService } from '@codelab/frontend/domain/prop'
-import { getActionService } from '@codelab/frontend/domain/store'
+import {
+  getActionService,
+  getStoreService,
+} from '@codelab/frontend/domain/store'
 import { getFieldService, getTypeService } from '@codelab/frontend/domain/type'
 import {
   RenderedComponentFragment,
@@ -119,6 +122,11 @@ export class ElementService
   @computed
   private get fieldService() {
     return getFieldService(this)
+  }
+
+  @computed
+  private get storeService() {
+    return getStoreService(this)
   }
 
   @modelAction
@@ -818,7 +826,7 @@ export class ElementService
       new Map<string, string>(),
     )
 
-    // Update element's and its descendants props values to use new action ids
+    // Update element and its descendants props values to use new action ids
     const elementAndDescendantsProps = [
       element.props.current,
       ...element.descendantElements.map(
@@ -854,6 +862,10 @@ export class ElementService
         })
       }),
     )
+
+    // This is required to load the added actions and fields into the component store
+    // otherwise the actions won't be available until the page is refreshed
+    await this.storeService.getOne(componentStore.id)
   }
 
   @modelFlow

--- a/libs/frontend/domain/element/src/store/element.service.ts
+++ b/libs/frontend/domain/element/src/store/element.service.ts
@@ -14,6 +14,7 @@ import {
 import { getAtomService } from '@codelab/frontend/domain/atom'
 import { Component } from '@codelab/frontend/domain/component'
 import { getPropService } from '@codelab/frontend/domain/prop'
+import { getActionService } from '@codelab/frontend/domain/store'
 import { getTypeService } from '@codelab/frontend/domain/type'
 import {
   RenderedComponentFragment,
@@ -106,6 +107,11 @@ export class ElementService
   @computed
   private get propService() {
     return getPropService(this)
+  }
+
+  @computed
+  private get actionService() {
+    return getActionService(this)
   }
 
   @modelAction
@@ -790,6 +796,19 @@ export class ElementService
     // this way in case if component creation fails, we avoid data loss
     const createdComponent = yield* _await(
       this.componentService.create({ id: v4(), name, owner }),
+    )
+
+    const elementActions = element.store.current.actions
+
+    const newActions = yield* _await(
+      Promise.all(
+        elementActions.map((action) =>
+          this.actionService.cloneAction(
+            action.current,
+            createdComponent.store.id,
+          ),
+        ),
+      ),
     )
 
     // 3. detach the element from the element tree

--- a/libs/frontend/domain/element/src/store/element.service.ts
+++ b/libs/frontend/domain/element/src/store/element.service.ts
@@ -15,7 +15,7 @@ import { getAtomService } from '@codelab/frontend/domain/atom'
 import { Component } from '@codelab/frontend/domain/component'
 import { getPropService } from '@codelab/frontend/domain/prop'
 import { getActionService } from '@codelab/frontend/domain/store'
-import { getTypeService } from '@codelab/frontend/domain/type'
+import { getFieldService, getTypeService } from '@codelab/frontend/domain/type'
 import {
   RenderedComponentFragment,
   RenderTypeKind,
@@ -112,6 +112,11 @@ export class ElementService
   @computed
   private get actionService() {
     return getActionService(this)
+  }
+
+  @computed
+  private get fieldService() {
+    return getFieldService(this)
   }
 
   @modelAction
@@ -781,6 +786,13 @@ export class ElementService
   ) {
     const elementStore = element.store.current
     const componentStore = component.store.current
+
+    // Duplicate state fields into the component store api
+    await Promise.all(
+      elementStore.api.current.fields.map((field) =>
+        this.fieldService.cloneField(field, componentStore.api.current.id),
+      ),
+    )
 
     // Duplicate actions into the component store
     const clonedActions = await Promise.all(

--- a/libs/frontend/domain/store/src/store/action.factory.ts
+++ b/libs/frontend/domain/store/src/store/action.factory.ts
@@ -109,4 +109,36 @@ export class ActionFactory extends Model({}) implements IActionFactory {
         }
     }
   }
+
+  static mapActionToDTO(action: IAction): IActionDTO {
+    switch (action.type) {
+      case IActionKind.CodeAction:
+        return {
+          __typename: IActionKind.CodeAction,
+
+          code: action.code,
+          id: action.id,
+          name: action.name,
+          store: { id: action.store.id },
+        }
+
+      case IActionKind.ApiAction:
+        return {
+          __typename: IActionKind.ApiAction,
+
+          config: { id: action.config.id },
+
+          errorAction: action.errorAction
+            ? { id: action.errorAction.id }
+            : undefined,
+          id: action.id,
+          name: action.name,
+          resource: { id: action.resource.id },
+          store: { id: action.store.id },
+          successAction: action.successAction
+            ? { id: action.successAction.id }
+            : undefined,
+        }
+    }
+  }
 }


### PR DESCRIPTION
<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(libs-ui-component): must begin with lowercase` -->

## Description
When converting an element to a component:

- [x] Create actions in the component store
- [x] Create state variables in the component store
- [x] Update element props to use new actions

To achieve this clones of all actions and state fields are created and added to the newly created component store.

<!-- This is a short description on the Pull Request -->

## Video or Image

<!-- Add video or image showing how the new feature works -->

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged -->

Fixes #2896
