### PR TITLE
feat: show assigned ReactNode props in the element tree view

### DIFF
--- a/libs/frontend/domain/builder/src/sections/explorer-pane/ElementContextMenu.tsx
+++ b/libs/frontend/domain/builder/src/sections/explorer-pane/ElementContextMenu.tsx
@@ -1,5 +1,9 @@
 import { useUser } from '@auth0/nextjs-auth0/client'
-import type { IElement, IElementService } from '@codelab/frontend/abstract/core'
+import type {
+  IElement,
+  IElementService,
+  IElementTreeViewDataNode,
+} from '@codelab/frontend/abstract/core'
 import {
   elementRef,
   elementTreeRef,
@@ -25,6 +29,7 @@ export type ElementContextMenuProps = ContextMenuProps &
     'cloneElement' | 'convertElementToComponent' | 'createForm' | 'deleteModal'
   > & {
     element: IElement
+    treeNode?: IElementTreeViewDataNode
   }
 
 /**
@@ -40,6 +45,7 @@ export const ElementContextMenu = observer<
     createForm,
     deleteModal,
     element,
+    treeNode,
   }) => {
     const { builderService, componentService } = useStore()
     const { user } = useUser()
@@ -94,6 +100,7 @@ export const ElementContextMenu = observer<
 
     const menuItems = [
       {
+        hide: treeNode?.selectable === false,
         key: 'add-child',
         label: 'Add child',
         onClick: onAddChild,

--- a/libs/frontend/domain/builder/src/sections/explorer-pane/builder-tree/ElementTreeItemElementTitle.tsx
+++ b/libs/frontend/domain/builder/src/sections/explorer-pane/builder-tree/ElementTreeItemElementTitle.tsx
@@ -49,6 +49,7 @@ export const ElementTreeItemElementTitle = observer(
 
     const atomMeta = atomName ? `${atomName}` : undefined
     const meta = componentMeta ?? atomMeta ?? ''
+    const { selectable: treeNodeIsSelectable = true } = treeNode
 
     const errorMessage = element.renderingMetadata?.error
       ? `Error: ${element.renderingMetadata.error.message}`
@@ -69,7 +70,7 @@ export const ElementTreeItemElementTitle = observer(
             <BorderOuterOutlined style={{ color: 'gray' }} />
           )
         }
-        primaryTitle={element.label}
+        primaryTitle={treeNode.primaryTitle}
         secondaryTitle={meta}
         tag={
           errorMessage ? (
@@ -79,29 +80,31 @@ export const ElementTreeItemElementTitle = observer(
           ) : null
         }
         toolbar={
-          <CuiTreeItemToolbar
-            items={[
-              {
-                icon: <PlusOutlined />,
-                key: `add-child-${element.id}`,
-                onClick: () => {
-                  popover.open(FormNames.CreateElement)
-                  elementService.createForm.open({
-                    elementOptions:
-                      element.closestContainerNode.elements.map(
-                        mapElementOption,
+          treeNodeIsSelectable && (
+            <CuiTreeItemToolbar
+              items={[
+                {
+                  icon: <PlusOutlined />,
+                  key: `add-child-${element.id}`,
+                  onClick: () => {
+                    popover.open(FormNames.CreateElement)
+                    elementService.createForm.open({
+                      elementOptions:
+                        element.closestContainerNode.elements.map(
+                          mapElementOption,
+                        ),
+                      elementTree: elementTreeRef(
+                        element.closestContainerNode.id,
                       ),
-                    elementTree: elementTreeRef(
-                      element.closestContainerNode.id,
-                    ),
-                    selectedElement: elementRef(element.id),
-                  })
+                      selectedElement: elementRef(element.id),
+                    })
+                  },
+                  title: 'Add Child',
                 },
-                title: 'Add Child',
-              },
-            ]}
-            title="ElementTreeItemToolbar"
-          />
+              ]}
+              title="ElementTreeItemToolbar"
+            />
+          )
         }
         variant={errorMessage ? 'danger' : 'primary'}
       />

--- a/libs/frontend/domain/builder/src/sections/explorer-pane/builder-tree/ElementTreeItemTitle.tsx
+++ b/libs/frontend/domain/builder/src/sections/explorer-pane/builder-tree/ElementTreeItemTitle.tsx
@@ -30,6 +30,7 @@ export const ElementTreeItemTitle = observer<ElementTreeItemTitleProps>(
             // eslint-disable-next-line react/jsx-props-no-spreading
             {...elementContextMenuProps}
             element={node}
+            treeNode={data}
           >
             <ElementTreeItemElementTitle element={node} treeNode={data} />
           </ElementContextMenu>

--- a/libs/frontend/domain/element/src/store/element.model.ts
+++ b/libs/frontend/domain/element/src/store/element.model.ts
@@ -37,7 +37,11 @@ import {
   ElementCreateInput,
   ElementUpdateInput,
 } from '@codelab/shared/abstract/codegen'
-import type { IAuth0Owner, IElementDTO } from '@codelab/shared/abstract/core'
+import {
+  type IAuth0Owner,
+  type IElementDTO,
+  ITypeKind,
+} from '@codelab/shared/abstract/core'
 import type { IEntity } from '@codelab/shared/abstract/types'
 import { Maybe, Nullable, Nullish } from '@codelab/shared/abstract/types'
 import {
@@ -50,6 +54,7 @@ import {
   createUniqueName,
   mergeProps,
 } from '@codelab/shared/utils'
+import { forEach } from 'lodash'
 import attempt from 'lodash/attempt'
 import isError from 'lodash/isError'
 import { computed } from 'mobx'
@@ -472,6 +477,26 @@ export class Element
       })
     }
 
+    // Add assigned ReactNodes props as children
+    const reactNodesChildren: Array<IElementTreeViewDataNode> = []
+    Object.keys(this.props.current.values).forEach((key, index) => {
+      const propData = this.props.current.values[key]
+
+      const component = this.componentService.components.get(propData.value)
+        ?.rootElement.current
+
+      if (propData.kind === ITypeKind.ReactNodeType && component) {
+        reactNodesChildren.push({
+          ...component.treeViewNode,
+          children: [],
+          isChildMapperComponentInstance: true,
+          key: `${propData.value}${index}`,
+          primaryTitle: `${key}:`,
+          selectable: false,
+        })
+      }
+    })
+
     const childMapperRenderIndex =
       this.children.findIndex(
         (child) => child.id === this.childMapperPreviousSibling?.id,
@@ -486,6 +511,7 @@ export class Element
         children: [],
         isChildMapperComponentInstance: true,
       })),
+      ...reactNodesChildren,
     )
 
     return {

--- a/libs/frontend/domain/element/src/store/element.model.ts
+++ b/libs/frontend/domain/element/src/store/element.model.ts
@@ -54,7 +54,6 @@ import {
   createUniqueName,
   mergeProps,
 } from '@codelab/shared/utils'
-import { forEach } from 'lodash'
 import attempt from 'lodash/attempt'
 import isError from 'lodash/isError'
 import { computed } from 'mobx'

--- a/libs/frontend/domain/element/src/store/element.model.ts
+++ b/libs/frontend/domain/element/src/store/element.model.ts
@@ -476,7 +476,7 @@ export class Element
       })
     }
 
-    // Add assigned ReactNodes props as children
+    // Add assigned ReactNode props as children
     const reactNodesChildren: Array<IElementTreeViewDataNode> = []
     Object.keys(this.props.current.values).forEach((key, index) => {
       const propData = this.props.current.values[key]


### PR DESCRIPTION
<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(libs-ui-component): must begin with lowercase` -->

## Description

Currently, the element tree view doesn't display any assigned ReactNode props, making it challenging for users to determine which component is in use. To improve clarity, the ReactNodes should be made visible within the element tree, enabling users to easily identify the specific  components being used.

![Screen Shot 2023-08-24 at 17 23 12](https://github.com/codelab-app/platform/assets/32300655/d1acce11-bf97-4eba-9e49-a688076a8cbb)

## Video or Image

[![LOOM DEMO](http://cdn.loom.com/sessions/thumbnails/798a64a189764836b3f5f7a04a9ceab4-00001.gif)](https://www.loom.com/share/798a64a189764836b3f5f7a04a9ceab4)

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged -->

Fixes [#2933](https://github.com/codelab-app/platform/issues/2933)
