### PR TITLE
refactor: remove ArrayOrSingle from render pipe output type

### DIFF
--- a/libs/frontend/abstract/core/src/domain/render/render.interface.ts
+++ b/libs/frontend/abstract/core/src/domain/render/render.interface.ts
@@ -1,5 +1,4 @@
 import type { IAtomType } from '@codelab/shared/abstract/core'
-import type { ArrayOrSingle } from 'ts-essentials'
 import type { IComponentService } from '../component'
 import type { IElement, IElementService } from '../element'
 import type { IPropData, IPropDataByElementId } from '../prop'
@@ -31,5 +30,5 @@ export interface IBaseRenderPipe {
 
 export interface IRenderPipe extends IBaseRenderPipe {
   next?: IRenderPipe
-  render(element: IElement, props: IPropData): ArrayOrSingle<IRenderOutput>
+  render(element: IElement, props: IPropData): IRenderOutput
 }

--- a/libs/frontend/abstract/core/src/domain/render/renderer.model.interface.ts
+++ b/libs/frontend/abstract/core/src/domain/render/renderer.model.interface.ts
@@ -34,6 +34,6 @@ export interface IRenderer {
   logRendered(element: IElement, rendered: ArrayOrSingle<IRenderOutput>): void
   renderChildren(parentOutput: IRenderOutput): ArrayOrSingle<ReactNode>
   renderElement(element: IElement): ReactElement
-  renderIntermediateElement(element: IElement): ArrayOrSingle<IRenderOutput>
+  renderIntermediateElement(element: IElement): IRenderOutput
   renderRoot(): ReactElement | null
 }

--- a/libs/frontend/domain/renderer/src/renderPipes/atom-render-pipe.ts
+++ b/libs/frontend/domain/renderer/src/renderPipes/atom-render-pipe.ts
@@ -7,7 +7,6 @@ import {
 } from '@codelab/frontend/abstract/core'
 import type { IAtomType } from '@codelab/shared/abstract/core'
 import { ExtendedModel, model, prop } from 'mobx-keystone'
-import type { ArrayOrSingle } from 'ts-essentials'
 import { atomFactory } from '../atoms'
 import { jsonStringToCss } from '../element/get-styled-components'
 import { RenderOutput } from '../utils'
@@ -20,7 +19,7 @@ export class AtomRenderPipe
   })
   implements IRenderPipe
 {
-  render(element: IElement, props: IPropData): ArrayOrSingle<IRenderOutput> {
+  render(element: IElement, props: IPropData): IRenderOutput {
     if (!isAtomInstance(element.renderType)) {
       if (this.renderer.debugMode) {
         console.info(`AtomRenderPipe: No atom found`, { element: element.name })

--- a/libs/frontend/domain/renderer/src/renderPipes/component-render-pipe.ts
+++ b/libs/frontend/domain/renderer/src/renderPipes/component-render-pipe.ts
@@ -10,7 +10,6 @@ import {
   isComponentInstance,
 } from '@codelab/frontend/abstract/core'
 import { ExtendedModel, model, prop } from 'mobx-keystone'
-import type { ArrayOrSingle } from 'ts-essentials'
 import { BaseRenderPipe } from './render-pipe.base'
 
 @model('@codelab/ComponentRenderPipe')
@@ -20,7 +19,7 @@ export class ComponentRenderPipe
   })
   implements IRenderPipe
 {
-  render(element: IElement, props: IPropData): ArrayOrSingle<IRenderOutput> {
+  render(element: IElement, props: IPropData): IRenderOutput {
     if (!isComponentInstance(element.renderType)) {
       return this.next.render(element, props)
     }

--- a/libs/frontend/domain/renderer/src/renderPipes/conditional-render-pipe.ts
+++ b/libs/frontend/domain/renderer/src/renderPipes/conditional-render-pipe.ts
@@ -5,7 +5,6 @@ import type {
   IRenderPipe,
 } from '@codelab/frontend/abstract/core'
 import { ExtendedModel, model, prop } from 'mobx-keystone'
-import type { ArrayOrSingle } from 'ts-essentials'
 import { RenderOutput, shouldRenderElement } from '../utils'
 import { BaseRenderPipe } from './render-pipe.base'
 
@@ -16,7 +15,7 @@ export class ConditionalRenderPipe
   })
   implements IRenderPipe
 {
-  render(element: IElement, props: IPropData): ArrayOrSingle<IRenderOutput> {
+  render(element: IElement, props: IPropData): IRenderOutput {
     if (shouldRenderElement(element, props)) {
       return this.next.render(element, props)
     }

--- a/libs/frontend/domain/renderer/src/renderPipes/null-render-pipe.ts
+++ b/libs/frontend/domain/renderer/src/renderPipes/null-render-pipe.ts
@@ -5,7 +5,6 @@ import type {
   IRenderPipe,
 } from '@codelab/frontend/abstract/core'
 import { ExtendedModel, model } from 'mobx-keystone'
-import type { ArrayOrSingle } from 'ts-essentials'
 import { RenderOutput } from '../utils'
 import { BaseRenderPipe } from './render-pipe.base'
 
@@ -17,7 +16,7 @@ export class NullRenderPipe
   extends ExtendedModel(BaseRenderPipe, {})
   implements IRenderPipe
 {
-  render(element: IElement, props: IPropData): ArrayOrSingle<IRenderOutput> {
+  render(element: IElement, props: IPropData): IRenderOutput {
     if (this.renderer.debugMode) {
       console.info(`NullRenderPipe: rendering null`, { element: element.name })
     }

--- a/libs/frontend/domain/renderer/src/renderPipes/pass-through-render-pipe.ts
+++ b/libs/frontend/domain/renderer/src/renderPipes/pass-through-render-pipe.ts
@@ -7,7 +7,6 @@ import { isAtomInstance } from '@codelab/frontend/abstract/core'
 import type { Element } from '@codelab/frontend/domain/element'
 import { IAtomType } from '@codelab/shared/abstract/core'
 import { ExtendedModel, model } from 'mobx-keystone'
-import type { ArrayOrSingle } from 'ts-essentials'
 import { RenderOutput } from '../utils'
 import { BaseRenderPipe } from './render-pipe.base'
 
@@ -19,7 +18,7 @@ export class PassThroughRenderPipe
   extends ExtendedModel(BaseRenderPipe, {})
   implements IRenderPipe
 {
-  render(element: Element, props: IPropData): ArrayOrSingle<IRenderOutput> {
+  render(element: Element, props: IPropData): IRenderOutput {
     // TODO: element.renderType cannot be component, we should throw error here
     if (this.renderer.debugMode) {
       console.info(`PassThroughRenderPipe: rendering input`, {

--- a/libs/frontend/domain/renderer/src/renderer.model.ts
+++ b/libs/frontend/domain/renderer/src/renderer.model.ts
@@ -219,9 +219,7 @@ export class Renderer
    * Renders a single element (without its children) to an intermediate RenderOutput
    *
    */
-  renderIntermediateElement = (
-    element: IElement,
-  ): ArrayOrSingle<IRenderOutput> => {
+  renderIntermediateElement = (element: IElement): IRenderOutput => {
     this.addActionRunners(element)
 
     const runtimeProps = this.addRuntimeProps(elementRef(element.id))


### PR DESCRIPTION
## Description

This is an artifact from an older version of the render-pipe that is no longer needed.

