### PR TITLE
feat: introduce css breakpoints

### DIFF
--- a/libs/backend/abstract/codegen/src/ogm-types.gen.ts
+++ b/libs/backend/abstract/codegen/src/ogm-types.gen.ts
@@ -2289,8 +2289,7 @@ export type ApiActionElementElementNodeAggregateSelection = {
   __typename?: 'ApiActionElementElementNodeAggregateSelection'
   id: IdAggregateSelectionNonNullable
   _compoundName: StringAggregateSelectionNonNullable
-  customCss: StringAggregateSelectionNullable
-  guiCss: StringAggregateSelectionNullable
+  style: StringAggregateSelectionNullable
   childMapperPropKey: StringAggregateSelectionNullable
   renderForEachPropKey: StringAggregateSelectionNullable
   renderIfExpression: StringAggregateSelectionNullable
@@ -3218,8 +3217,7 @@ export type CodeActionElementElementNodeAggregateSelection = {
   __typename?: 'CodeActionElementElementNodeAggregateSelection'
   id: IdAggregateSelectionNonNullable
   _compoundName: StringAggregateSelectionNonNullable
-  customCss: StringAggregateSelectionNullable
-  guiCss: StringAggregateSelectionNullable
+  style: StringAggregateSelectionNullable
   childMapperPropKey: StringAggregateSelectionNullable
   renderForEachPropKey: StringAggregateSelectionNullable
   renderIfExpression: StringAggregateSelectionNullable
@@ -3501,8 +3499,7 @@ export type ComponentElementChildrenContainerElementNodeAggregateSelection = {
   __typename?: 'ComponentElementChildrenContainerElementNodeAggregateSelection'
   id: IdAggregateSelectionNonNullable
   _compoundName: StringAggregateSelectionNonNullable
-  customCss: StringAggregateSelectionNullable
-  guiCss: StringAggregateSelectionNullable
+  style: StringAggregateSelectionNullable
   childMapperPropKey: StringAggregateSelectionNullable
   renderForEachPropKey: StringAggregateSelectionNullable
   renderIfExpression: StringAggregateSelectionNullable
@@ -3518,8 +3515,7 @@ export type ComponentElementRootElementNodeAggregateSelection = {
   __typename?: 'ComponentElementRootElementNodeAggregateSelection'
   id: IdAggregateSelectionNonNullable
   _compoundName: StringAggregateSelectionNonNullable
-  customCss: StringAggregateSelectionNullable
-  guiCss: StringAggregateSelectionNullable
+  style: StringAggregateSelectionNullable
   childMapperPropKey: StringAggregateSelectionNullable
   renderForEachPropKey: StringAggregateSelectionNullable
   renderIfExpression: StringAggregateSelectionNullable
@@ -3957,8 +3953,7 @@ export type Element = {
   __typename?: 'Element'
   id: Scalars['ID']
   _compoundName: Scalars['String']
-  customCss?: Maybe<Scalars['String']>
-  guiCss?: Maybe<Scalars['String']>
+  style?: Maybe<Scalars['String']>
   childMapperPropKey?: Maybe<Scalars['String']>
   renderForEachPropKey?: Maybe<Scalars['String']>
   renderIfExpression?: Maybe<Scalars['String']>
@@ -4247,8 +4242,7 @@ export type ElementAggregateSelection = {
   count: Scalars['Int']
   id: IdAggregateSelectionNonNullable
   _compoundName: StringAggregateSelectionNonNullable
-  customCss: StringAggregateSelectionNullable
-  guiCss: StringAggregateSelectionNullable
+  style: StringAggregateSelectionNullable
   childMapperPropKey: StringAggregateSelectionNullable
   renderForEachPropKey: StringAggregateSelectionNullable
   renderIfExpression: StringAggregateSelectionNullable
@@ -4351,8 +4345,7 @@ export type ElementElementChildMapperPreviousSiblingNodeAggregateSelection = {
   __typename?: 'ElementElementChildMapperPreviousSiblingNodeAggregateSelection'
   id: IdAggregateSelectionNonNullable
   _compoundName: StringAggregateSelectionNonNullable
-  customCss: StringAggregateSelectionNullable
-  guiCss: StringAggregateSelectionNullable
+  style: StringAggregateSelectionNullable
   childMapperPropKey: StringAggregateSelectionNullable
   renderForEachPropKey: StringAggregateSelectionNullable
   renderIfExpression: StringAggregateSelectionNullable
@@ -4368,8 +4361,7 @@ export type ElementElementFirstChildNodeAggregateSelection = {
   __typename?: 'ElementElementFirstChildNodeAggregateSelection'
   id: IdAggregateSelectionNonNullable
   _compoundName: StringAggregateSelectionNonNullable
-  customCss: StringAggregateSelectionNullable
-  guiCss: StringAggregateSelectionNullable
+  style: StringAggregateSelectionNullable
   childMapperPropKey: StringAggregateSelectionNullable
   renderForEachPropKey: StringAggregateSelectionNullable
   renderIfExpression: StringAggregateSelectionNullable
@@ -4385,8 +4377,7 @@ export type ElementElementNextSiblingNodeAggregateSelection = {
   __typename?: 'ElementElementNextSiblingNodeAggregateSelection'
   id: IdAggregateSelectionNonNullable
   _compoundName: StringAggregateSelectionNonNullable
-  customCss: StringAggregateSelectionNullable
-  guiCss: StringAggregateSelectionNullable
+  style: StringAggregateSelectionNullable
   childMapperPropKey: StringAggregateSelectionNullable
   renderForEachPropKey: StringAggregateSelectionNullable
   renderIfExpression: StringAggregateSelectionNullable
@@ -4402,8 +4393,7 @@ export type ElementElementParentNodeAggregateSelection = {
   __typename?: 'ElementElementParentNodeAggregateSelection'
   id: IdAggregateSelectionNonNullable
   _compoundName: StringAggregateSelectionNonNullable
-  customCss: StringAggregateSelectionNullable
-  guiCss: StringAggregateSelectionNullable
+  style: StringAggregateSelectionNullable
   childMapperPropKey: StringAggregateSelectionNullable
   renderForEachPropKey: StringAggregateSelectionNullable
   renderIfExpression: StringAggregateSelectionNullable
@@ -4419,8 +4409,7 @@ export type ElementElementPrevSiblingNodeAggregateSelection = {
   __typename?: 'ElementElementPrevSiblingNodeAggregateSelection'
   id: IdAggregateSelectionNonNullable
   _compoundName: StringAggregateSelectionNonNullable
-  customCss: StringAggregateSelectionNullable
-  guiCss: StringAggregateSelectionNullable
+  style: StringAggregateSelectionNullable
   childMapperPropKey: StringAggregateSelectionNullable
   renderForEachPropKey: StringAggregateSelectionNullable
   renderIfExpression: StringAggregateSelectionNullable
@@ -5322,8 +5311,7 @@ export type HookElementElementNodeAggregateSelection = {
   __typename?: 'HookElementElementNodeAggregateSelection'
   id: IdAggregateSelectionNonNullable
   _compoundName: StringAggregateSelectionNonNullable
-  customCss: StringAggregateSelectionNullable
-  guiCss: StringAggregateSelectionNullable
+  style: StringAggregateSelectionNullable
   childMapperPropKey: StringAggregateSelectionNullable
   renderForEachPropKey: StringAggregateSelectionNullable
   renderIfExpression: StringAggregateSelectionNullable
@@ -5826,8 +5814,7 @@ export type PageElementPageContentContainerNodeAggregateSelection = {
   __typename?: 'PageElementPageContentContainerNodeAggregateSelection'
   id: IdAggregateSelectionNonNullable
   _compoundName: StringAggregateSelectionNonNullable
-  customCss: StringAggregateSelectionNullable
-  guiCss: StringAggregateSelectionNullable
+  style: StringAggregateSelectionNullable
   childMapperPropKey: StringAggregateSelectionNullable
   renderForEachPropKey: StringAggregateSelectionNullable
   renderIfExpression: StringAggregateSelectionNullable
@@ -5843,8 +5830,7 @@ export type PageElementRootElementNodeAggregateSelection = {
   __typename?: 'PageElementRootElementNodeAggregateSelection'
   id: IdAggregateSelectionNonNullable
   _compoundName: StringAggregateSelectionNonNullable
-  customCss: StringAggregateSelectionNullable
-  guiCss: StringAggregateSelectionNullable
+  style: StringAggregateSelectionNullable
   childMapperPropKey: StringAggregateSelectionNullable
   renderForEachPropKey: StringAggregateSelectionNullable
   renderIfExpression: StringAggregateSelectionNullable
@@ -7493,8 +7479,7 @@ export type UserElementElementsNodeAggregateSelection = {
   __typename?: 'UserElementElementsNodeAggregateSelection'
   id: IdAggregateSelectionNonNullable
   _compoundName: StringAggregateSelectionNonNullable
-  customCss: StringAggregateSelectionNullable
-  guiCss: StringAggregateSelectionNullable
+  style: StringAggregateSelectionNullable
   childMapperPropKey: StringAggregateSelectionNullable
   renderForEachPropKey: StringAggregateSelectionNullable
   renderIfExpression: StringAggregateSelectionNullable
@@ -16443,8 +16428,7 @@ export type ElementConnectWhere = {
 export type ElementCreateInput = {
   id: Scalars['ID']
   _compoundName: Scalars['String']
-  customCss?: InputMaybe<Scalars['String']>
-  guiCss?: InputMaybe<Scalars['String']>
+  style?: InputMaybe<Scalars['String']>
   childMapperPropKey?: InputMaybe<Scalars['String']>
   renderForEachPropKey?: InputMaybe<Scalars['String']>
   renderIfExpression?: InputMaybe<Scalars['String']>
@@ -17214,8 +17198,7 @@ export type ElementNextSiblingUpdateFieldInput = {
 export type ElementOnCreateInput = {
   id: Scalars['ID']
   _compoundName: Scalars['String']
-  customCss?: InputMaybe<Scalars['String']>
-  guiCss?: InputMaybe<Scalars['String']>
+  style?: InputMaybe<Scalars['String']>
   childMapperPropKey?: InputMaybe<Scalars['String']>
   renderForEachPropKey?: InputMaybe<Scalars['String']>
   renderIfExpression?: InputMaybe<Scalars['String']>
@@ -19136,8 +19119,7 @@ export type ElementRenderComponentTypeUpdateFieldInput = {
 export type ElementSort = {
   id?: InputMaybe<SortDirection>
   _compoundName?: InputMaybe<SortDirection>
-  customCss?: InputMaybe<SortDirection>
-  guiCss?: InputMaybe<SortDirection>
+  style?: InputMaybe<SortDirection>
   childMapperPropKey?: InputMaybe<SortDirection>
   renderForEachPropKey?: InputMaybe<SortDirection>
   renderIfExpression?: InputMaybe<SortDirection>
@@ -19461,8 +19443,7 @@ export type ElementUniqueWhere = {
 export type ElementUpdateInput = {
   id?: InputMaybe<Scalars['ID']>
   _compoundName?: InputMaybe<Scalars['String']>
-  customCss?: InputMaybe<Scalars['String']>
-  guiCss?: InputMaybe<Scalars['String']>
+  style?: InputMaybe<Scalars['String']>
   childMapperPropKey?: InputMaybe<Scalars['String']>
   renderForEachPropKey?: InputMaybe<Scalars['String']>
   renderIfExpression?: InputMaybe<Scalars['String']>
@@ -19517,7 +19498,7 @@ export type ElementWhere = {
   _compoundName_NOT_STARTS_WITH?: InputMaybe<Scalars['String']>
   /** @deprecated Negation filters will be deprecated, use the NOT operator to achieve the same behavior */
   _compoundName_NOT_ENDS_WITH?: InputMaybe<Scalars['String']>
-  customCss?: InputMaybe<Scalars['String']>
+  style?: InputMaybe<Scalars['String']>
   /** @deprecated Negation filters will be deprecated, use the NOT operator to achieve the same behavior */
   style_NOT?: InputMaybe<Scalars['String']>
   style_IN?: InputMaybe<Array<InputMaybe<Scalars['String']>>>
@@ -34585,8 +34566,7 @@ export interface ElementAggregateSelectionInput {
   count?: boolean
   id?: IdAggregateInputNonNullable
   _compoundName?: StringAggregateInputNonNullable
-  customCss?: StringAggregateInputNullable
-  guiCss?: StringAggregateInputNullable
+  style?: StringAggregateInputNullable
   childMapperPropKey?: StringAggregateInputNullable
   renderForEachPropKey?: StringAggregateInputNullable
   renderIfExpression?: StringAggregateInputNullable

--- a/libs/backend/abstract/codegen/src/ogm-types.gen.ts
+++ b/libs/backend/abstract/codegen/src/ogm-types.gen.ts
@@ -8204,115 +8204,60 @@ export type ApiActionElementNodeAggregationWhereInput = {
   _compoundName_LONGEST_LENGTH_LTE?: InputMaybe<Scalars['Int']>
   _compoundName_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars['Int']>
   /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
-  customCss_EQUAL?: InputMaybe<Scalars['String']>
+  style_EQUAL?: InputMaybe<Scalars['String']>
   /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  customCss_AVERAGE_EQUAL?: InputMaybe<Scalars['Float']>
+  style_AVERAGE_EQUAL?: InputMaybe<Scalars['Float']>
   /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  customCss_LONGEST_EQUAL?: InputMaybe<Scalars['Int']>
+  style_LONGEST_EQUAL?: InputMaybe<Scalars['Int']>
   /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  customCss_SHORTEST_EQUAL?: InputMaybe<Scalars['Int']>
-  customCss_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars['Float']>
-  customCss_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars['Int']>
-  customCss_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars['Int']>
+  style_SHORTEST_EQUAL?: InputMaybe<Scalars['Int']>
+  style_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars['Float']>
+  style_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars['Int']>
+  style_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars['Int']>
   /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
-  customCss_GT?: InputMaybe<Scalars['Int']>
+  style_GT?: InputMaybe<Scalars['Int']>
   /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  customCss_AVERAGE_GT?: InputMaybe<Scalars['Float']>
+  style_AVERAGE_GT?: InputMaybe<Scalars['Float']>
   /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  customCss_LONGEST_GT?: InputMaybe<Scalars['Int']>
+  style_LONGEST_GT?: InputMaybe<Scalars['Int']>
   /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  customCss_SHORTEST_GT?: InputMaybe<Scalars['Int']>
-  customCss_AVERAGE_LENGTH_GT?: InputMaybe<Scalars['Float']>
-  customCss_LONGEST_LENGTH_GT?: InputMaybe<Scalars['Int']>
-  customCss_SHORTEST_LENGTH_GT?: InputMaybe<Scalars['Int']>
+  style_SHORTEST_GT?: InputMaybe<Scalars['Int']>
+  style_AVERAGE_LENGTH_GT?: InputMaybe<Scalars['Float']>
+  style_LONGEST_LENGTH_GT?: InputMaybe<Scalars['Int']>
+  style_SHORTEST_LENGTH_GT?: InputMaybe<Scalars['Int']>
   /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
-  customCss_GTE?: InputMaybe<Scalars['Int']>
+  style_GTE?: InputMaybe<Scalars['Int']>
   /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  customCss_AVERAGE_GTE?: InputMaybe<Scalars['Float']>
+  style_AVERAGE_GTE?: InputMaybe<Scalars['Float']>
   /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  customCss_LONGEST_GTE?: InputMaybe<Scalars['Int']>
+  style_LONGEST_GTE?: InputMaybe<Scalars['Int']>
   /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  customCss_SHORTEST_GTE?: InputMaybe<Scalars['Int']>
-  customCss_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars['Float']>
-  customCss_LONGEST_LENGTH_GTE?: InputMaybe<Scalars['Int']>
-  customCss_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars['Int']>
+  style_SHORTEST_GTE?: InputMaybe<Scalars['Int']>
+  style_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars['Float']>
+  style_LONGEST_LENGTH_GTE?: InputMaybe<Scalars['Int']>
+  style_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars['Int']>
   /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
-  customCss_LT?: InputMaybe<Scalars['Int']>
+  style_LT?: InputMaybe<Scalars['Int']>
   /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  customCss_AVERAGE_LT?: InputMaybe<Scalars['Float']>
+  style_AVERAGE_LT?: InputMaybe<Scalars['Float']>
   /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  customCss_LONGEST_LT?: InputMaybe<Scalars['Int']>
+  style_LONGEST_LT?: InputMaybe<Scalars['Int']>
   /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  customCss_SHORTEST_LT?: InputMaybe<Scalars['Int']>
-  customCss_AVERAGE_LENGTH_LT?: InputMaybe<Scalars['Float']>
-  customCss_LONGEST_LENGTH_LT?: InputMaybe<Scalars['Int']>
-  customCss_SHORTEST_LENGTH_LT?: InputMaybe<Scalars['Int']>
+  style_SHORTEST_LT?: InputMaybe<Scalars['Int']>
+  style_AVERAGE_LENGTH_LT?: InputMaybe<Scalars['Float']>
+  style_LONGEST_LENGTH_LT?: InputMaybe<Scalars['Int']>
+  style_SHORTEST_LENGTH_LT?: InputMaybe<Scalars['Int']>
   /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
-  customCss_LTE?: InputMaybe<Scalars['Int']>
+  style_LTE?: InputMaybe<Scalars['Int']>
   /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  customCss_AVERAGE_LTE?: InputMaybe<Scalars['Float']>
+  style_AVERAGE_LTE?: InputMaybe<Scalars['Float']>
   /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  customCss_LONGEST_LTE?: InputMaybe<Scalars['Int']>
+  style_LONGEST_LTE?: InputMaybe<Scalars['Int']>
   /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  customCss_SHORTEST_LTE?: InputMaybe<Scalars['Int']>
-  customCss_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars['Float']>
-  customCss_LONGEST_LENGTH_LTE?: InputMaybe<Scalars['Int']>
-  customCss_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars['Int']>
-  /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
-  guiCss_EQUAL?: InputMaybe<Scalars['String']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  guiCss_AVERAGE_EQUAL?: InputMaybe<Scalars['Float']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  guiCss_LONGEST_EQUAL?: InputMaybe<Scalars['Int']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  guiCss_SHORTEST_EQUAL?: InputMaybe<Scalars['Int']>
-  guiCss_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars['Float']>
-  guiCss_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars['Int']>
-  guiCss_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars['Int']>
-  /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
-  guiCss_GT?: InputMaybe<Scalars['Int']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  guiCss_AVERAGE_GT?: InputMaybe<Scalars['Float']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  guiCss_LONGEST_GT?: InputMaybe<Scalars['Int']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  guiCss_SHORTEST_GT?: InputMaybe<Scalars['Int']>
-  guiCss_AVERAGE_LENGTH_GT?: InputMaybe<Scalars['Float']>
-  guiCss_LONGEST_LENGTH_GT?: InputMaybe<Scalars['Int']>
-  guiCss_SHORTEST_LENGTH_GT?: InputMaybe<Scalars['Int']>
-  /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
-  guiCss_GTE?: InputMaybe<Scalars['Int']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  guiCss_AVERAGE_GTE?: InputMaybe<Scalars['Float']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  guiCss_LONGEST_GTE?: InputMaybe<Scalars['Int']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  guiCss_SHORTEST_GTE?: InputMaybe<Scalars['Int']>
-  guiCss_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars['Float']>
-  guiCss_LONGEST_LENGTH_GTE?: InputMaybe<Scalars['Int']>
-  guiCss_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars['Int']>
-  /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
-  guiCss_LT?: InputMaybe<Scalars['Int']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  guiCss_AVERAGE_LT?: InputMaybe<Scalars['Float']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  guiCss_LONGEST_LT?: InputMaybe<Scalars['Int']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  guiCss_SHORTEST_LT?: InputMaybe<Scalars['Int']>
-  guiCss_AVERAGE_LENGTH_LT?: InputMaybe<Scalars['Float']>
-  guiCss_LONGEST_LENGTH_LT?: InputMaybe<Scalars['Int']>
-  guiCss_SHORTEST_LENGTH_LT?: InputMaybe<Scalars['Int']>
-  /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
-  guiCss_LTE?: InputMaybe<Scalars['Int']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  guiCss_AVERAGE_LTE?: InputMaybe<Scalars['Float']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  guiCss_LONGEST_LTE?: InputMaybe<Scalars['Int']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  guiCss_SHORTEST_LTE?: InputMaybe<Scalars['Int']>
-  guiCss_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars['Float']>
-  guiCss_LONGEST_LENGTH_LTE?: InputMaybe<Scalars['Int']>
-  guiCss_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars['Int']>
+  style_SHORTEST_LTE?: InputMaybe<Scalars['Int']>
+  style_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars['Float']>
+  style_LONGEST_LENGTH_LTE?: InputMaybe<Scalars['Int']>
+  style_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars['Int']>
   /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
   childMapperPropKey_EQUAL?: InputMaybe<Scalars['String']>
   /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
@@ -12483,115 +12428,60 @@ export type BaseActionElementNodeAggregationWhereInput = {
   _compoundName_LONGEST_LENGTH_LTE?: InputMaybe<Scalars['Int']>
   _compoundName_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars['Int']>
   /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
-  customCss_EQUAL?: InputMaybe<Scalars['String']>
+  style_EQUAL?: InputMaybe<Scalars['String']>
   /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  customCss_AVERAGE_EQUAL?: InputMaybe<Scalars['Float']>
+  style_AVERAGE_EQUAL?: InputMaybe<Scalars['Float']>
   /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  customCss_LONGEST_EQUAL?: InputMaybe<Scalars['Int']>
+  style_LONGEST_EQUAL?: InputMaybe<Scalars['Int']>
   /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  customCss_SHORTEST_EQUAL?: InputMaybe<Scalars['Int']>
-  customCss_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars['Float']>
-  customCss_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars['Int']>
-  customCss_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars['Int']>
+  style_SHORTEST_EQUAL?: InputMaybe<Scalars['Int']>
+  style_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars['Float']>
+  style_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars['Int']>
+  style_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars['Int']>
   /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
-  customCss_GT?: InputMaybe<Scalars['Int']>
+  style_GT?: InputMaybe<Scalars['Int']>
   /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  customCss_AVERAGE_GT?: InputMaybe<Scalars['Float']>
+  style_AVERAGE_GT?: InputMaybe<Scalars['Float']>
   /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  customCss_LONGEST_GT?: InputMaybe<Scalars['Int']>
+  style_LONGEST_GT?: InputMaybe<Scalars['Int']>
   /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  customCss_SHORTEST_GT?: InputMaybe<Scalars['Int']>
-  customCss_AVERAGE_LENGTH_GT?: InputMaybe<Scalars['Float']>
-  customCss_LONGEST_LENGTH_GT?: InputMaybe<Scalars['Int']>
-  customCss_SHORTEST_LENGTH_GT?: InputMaybe<Scalars['Int']>
+  style_SHORTEST_GT?: InputMaybe<Scalars['Int']>
+  style_AVERAGE_LENGTH_GT?: InputMaybe<Scalars['Float']>
+  style_LONGEST_LENGTH_GT?: InputMaybe<Scalars['Int']>
+  style_SHORTEST_LENGTH_GT?: InputMaybe<Scalars['Int']>
   /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
-  customCss_GTE?: InputMaybe<Scalars['Int']>
+  style_GTE?: InputMaybe<Scalars['Int']>
   /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  customCss_AVERAGE_GTE?: InputMaybe<Scalars['Float']>
+  style_AVERAGE_GTE?: InputMaybe<Scalars['Float']>
   /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  customCss_LONGEST_GTE?: InputMaybe<Scalars['Int']>
+  style_LONGEST_GTE?: InputMaybe<Scalars['Int']>
   /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  customCss_SHORTEST_GTE?: InputMaybe<Scalars['Int']>
-  customCss_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars['Float']>
-  customCss_LONGEST_LENGTH_GTE?: InputMaybe<Scalars['Int']>
-  customCss_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars['Int']>
+  style_SHORTEST_GTE?: InputMaybe<Scalars['Int']>
+  style_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars['Float']>
+  style_LONGEST_LENGTH_GTE?: InputMaybe<Scalars['Int']>
+  style_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars['Int']>
   /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
-  customCss_LT?: InputMaybe<Scalars['Int']>
+  style_LT?: InputMaybe<Scalars['Int']>
   /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  customCss_AVERAGE_LT?: InputMaybe<Scalars['Float']>
+  style_AVERAGE_LT?: InputMaybe<Scalars['Float']>
   /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  customCss_LONGEST_LT?: InputMaybe<Scalars['Int']>
+  style_LONGEST_LT?: InputMaybe<Scalars['Int']>
   /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  customCss_SHORTEST_LT?: InputMaybe<Scalars['Int']>
-  customCss_AVERAGE_LENGTH_LT?: InputMaybe<Scalars['Float']>
-  customCss_LONGEST_LENGTH_LT?: InputMaybe<Scalars['Int']>
-  customCss_SHORTEST_LENGTH_LT?: InputMaybe<Scalars['Int']>
+  style_SHORTEST_LT?: InputMaybe<Scalars['Int']>
+  style_AVERAGE_LENGTH_LT?: InputMaybe<Scalars['Float']>
+  style_LONGEST_LENGTH_LT?: InputMaybe<Scalars['Int']>
+  style_SHORTEST_LENGTH_LT?: InputMaybe<Scalars['Int']>
   /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
-  customCss_LTE?: InputMaybe<Scalars['Int']>
+  style_LTE?: InputMaybe<Scalars['Int']>
   /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  customCss_AVERAGE_LTE?: InputMaybe<Scalars['Float']>
+  style_AVERAGE_LTE?: InputMaybe<Scalars['Float']>
   /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  customCss_LONGEST_LTE?: InputMaybe<Scalars['Int']>
+  style_LONGEST_LTE?: InputMaybe<Scalars['Int']>
   /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  customCss_SHORTEST_LTE?: InputMaybe<Scalars['Int']>
-  customCss_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars['Float']>
-  customCss_LONGEST_LENGTH_LTE?: InputMaybe<Scalars['Int']>
-  customCss_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars['Int']>
-  /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
-  guiCss_EQUAL?: InputMaybe<Scalars['String']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  guiCss_AVERAGE_EQUAL?: InputMaybe<Scalars['Float']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  guiCss_LONGEST_EQUAL?: InputMaybe<Scalars['Int']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  guiCss_SHORTEST_EQUAL?: InputMaybe<Scalars['Int']>
-  guiCss_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars['Float']>
-  guiCss_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars['Int']>
-  guiCss_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars['Int']>
-  /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
-  guiCss_GT?: InputMaybe<Scalars['Int']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  guiCss_AVERAGE_GT?: InputMaybe<Scalars['Float']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  guiCss_LONGEST_GT?: InputMaybe<Scalars['Int']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  guiCss_SHORTEST_GT?: InputMaybe<Scalars['Int']>
-  guiCss_AVERAGE_LENGTH_GT?: InputMaybe<Scalars['Float']>
-  guiCss_LONGEST_LENGTH_GT?: InputMaybe<Scalars['Int']>
-  guiCss_SHORTEST_LENGTH_GT?: InputMaybe<Scalars['Int']>
-  /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
-  guiCss_GTE?: InputMaybe<Scalars['Int']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  guiCss_AVERAGE_GTE?: InputMaybe<Scalars['Float']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  guiCss_LONGEST_GTE?: InputMaybe<Scalars['Int']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  guiCss_SHORTEST_GTE?: InputMaybe<Scalars['Int']>
-  guiCss_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars['Float']>
-  guiCss_LONGEST_LENGTH_GTE?: InputMaybe<Scalars['Int']>
-  guiCss_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars['Int']>
-  /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
-  guiCss_LT?: InputMaybe<Scalars['Int']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  guiCss_AVERAGE_LT?: InputMaybe<Scalars['Float']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  guiCss_LONGEST_LT?: InputMaybe<Scalars['Int']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  guiCss_SHORTEST_LT?: InputMaybe<Scalars['Int']>
-  guiCss_AVERAGE_LENGTH_LT?: InputMaybe<Scalars['Float']>
-  guiCss_LONGEST_LENGTH_LT?: InputMaybe<Scalars['Int']>
-  guiCss_SHORTEST_LENGTH_LT?: InputMaybe<Scalars['Int']>
-  /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
-  guiCss_LTE?: InputMaybe<Scalars['Int']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  guiCss_AVERAGE_LTE?: InputMaybe<Scalars['Float']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  guiCss_LONGEST_LTE?: InputMaybe<Scalars['Int']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  guiCss_SHORTEST_LTE?: InputMaybe<Scalars['Int']>
-  guiCss_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars['Float']>
-  guiCss_LONGEST_LENGTH_LTE?: InputMaybe<Scalars['Int']>
-  guiCss_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars['Int']>
+  style_SHORTEST_LTE?: InputMaybe<Scalars['Int']>
+  style_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars['Float']>
+  style_LONGEST_LENGTH_LTE?: InputMaybe<Scalars['Int']>
+  style_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars['Int']>
   /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
   childMapperPropKey_EQUAL?: InputMaybe<Scalars['String']>
   /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
@@ -13423,115 +13313,60 @@ export type CodeActionElementNodeAggregationWhereInput = {
   _compoundName_LONGEST_LENGTH_LTE?: InputMaybe<Scalars['Int']>
   _compoundName_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars['Int']>
   /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
-  customCss_EQUAL?: InputMaybe<Scalars['String']>
+  style_EQUAL?: InputMaybe<Scalars['String']>
   /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  customCss_AVERAGE_EQUAL?: InputMaybe<Scalars['Float']>
+  style_AVERAGE_EQUAL?: InputMaybe<Scalars['Float']>
   /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  customCss_LONGEST_EQUAL?: InputMaybe<Scalars['Int']>
+  style_LONGEST_EQUAL?: InputMaybe<Scalars['Int']>
   /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  customCss_SHORTEST_EQUAL?: InputMaybe<Scalars['Int']>
-  customCss_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars['Float']>
-  customCss_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars['Int']>
-  customCss_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars['Int']>
+  style_SHORTEST_EQUAL?: InputMaybe<Scalars['Int']>
+  style_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars['Float']>
+  style_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars['Int']>
+  style_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars['Int']>
   /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
-  customCss_GT?: InputMaybe<Scalars['Int']>
+  style_GT?: InputMaybe<Scalars['Int']>
   /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  customCss_AVERAGE_GT?: InputMaybe<Scalars['Float']>
+  style_AVERAGE_GT?: InputMaybe<Scalars['Float']>
   /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  customCss_LONGEST_GT?: InputMaybe<Scalars['Int']>
+  style_LONGEST_GT?: InputMaybe<Scalars['Int']>
   /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  customCss_SHORTEST_GT?: InputMaybe<Scalars['Int']>
-  customCss_AVERAGE_LENGTH_GT?: InputMaybe<Scalars['Float']>
-  customCss_LONGEST_LENGTH_GT?: InputMaybe<Scalars['Int']>
-  customCss_SHORTEST_LENGTH_GT?: InputMaybe<Scalars['Int']>
+  style_SHORTEST_GT?: InputMaybe<Scalars['Int']>
+  style_AVERAGE_LENGTH_GT?: InputMaybe<Scalars['Float']>
+  style_LONGEST_LENGTH_GT?: InputMaybe<Scalars['Int']>
+  style_SHORTEST_LENGTH_GT?: InputMaybe<Scalars['Int']>
   /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
-  customCss_GTE?: InputMaybe<Scalars['Int']>
+  style_GTE?: InputMaybe<Scalars['Int']>
   /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  customCss_AVERAGE_GTE?: InputMaybe<Scalars['Float']>
+  style_AVERAGE_GTE?: InputMaybe<Scalars['Float']>
   /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  customCss_LONGEST_GTE?: InputMaybe<Scalars['Int']>
+  style_LONGEST_GTE?: InputMaybe<Scalars['Int']>
   /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  customCss_SHORTEST_GTE?: InputMaybe<Scalars['Int']>
-  customCss_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars['Float']>
-  customCss_LONGEST_LENGTH_GTE?: InputMaybe<Scalars['Int']>
-  customCss_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars['Int']>
+  style_SHORTEST_GTE?: InputMaybe<Scalars['Int']>
+  style_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars['Float']>
+  style_LONGEST_LENGTH_GTE?: InputMaybe<Scalars['Int']>
+  style_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars['Int']>
   /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
-  customCss_LT?: InputMaybe<Scalars['Int']>
+  style_LT?: InputMaybe<Scalars['Int']>
   /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  customCss_AVERAGE_LT?: InputMaybe<Scalars['Float']>
+  style_AVERAGE_LT?: InputMaybe<Scalars['Float']>
   /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  customCss_LONGEST_LT?: InputMaybe<Scalars['Int']>
+  style_LONGEST_LT?: InputMaybe<Scalars['Int']>
   /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  customCss_SHORTEST_LT?: InputMaybe<Scalars['Int']>
-  customCss_AVERAGE_LENGTH_LT?: InputMaybe<Scalars['Float']>
-  customCss_LONGEST_LENGTH_LT?: InputMaybe<Scalars['Int']>
-  customCss_SHORTEST_LENGTH_LT?: InputMaybe<Scalars['Int']>
+  style_SHORTEST_LT?: InputMaybe<Scalars['Int']>
+  style_AVERAGE_LENGTH_LT?: InputMaybe<Scalars['Float']>
+  style_LONGEST_LENGTH_LT?: InputMaybe<Scalars['Int']>
+  style_SHORTEST_LENGTH_LT?: InputMaybe<Scalars['Int']>
   /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
-  customCss_LTE?: InputMaybe<Scalars['Int']>
+  style_LTE?: InputMaybe<Scalars['Int']>
   /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  customCss_AVERAGE_LTE?: InputMaybe<Scalars['Float']>
+  style_AVERAGE_LTE?: InputMaybe<Scalars['Float']>
   /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  customCss_LONGEST_LTE?: InputMaybe<Scalars['Int']>
+  style_LONGEST_LTE?: InputMaybe<Scalars['Int']>
   /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  customCss_SHORTEST_LTE?: InputMaybe<Scalars['Int']>
-  customCss_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars['Float']>
-  customCss_LONGEST_LENGTH_LTE?: InputMaybe<Scalars['Int']>
-  customCss_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars['Int']>
-  /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
-  guiCss_EQUAL?: InputMaybe<Scalars['String']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  guiCss_AVERAGE_EQUAL?: InputMaybe<Scalars['Float']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  guiCss_LONGEST_EQUAL?: InputMaybe<Scalars['Int']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  guiCss_SHORTEST_EQUAL?: InputMaybe<Scalars['Int']>
-  guiCss_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars['Float']>
-  guiCss_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars['Int']>
-  guiCss_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars['Int']>
-  /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
-  guiCss_GT?: InputMaybe<Scalars['Int']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  guiCss_AVERAGE_GT?: InputMaybe<Scalars['Float']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  guiCss_LONGEST_GT?: InputMaybe<Scalars['Int']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  guiCss_SHORTEST_GT?: InputMaybe<Scalars['Int']>
-  guiCss_AVERAGE_LENGTH_GT?: InputMaybe<Scalars['Float']>
-  guiCss_LONGEST_LENGTH_GT?: InputMaybe<Scalars['Int']>
-  guiCss_SHORTEST_LENGTH_GT?: InputMaybe<Scalars['Int']>
-  /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
-  guiCss_GTE?: InputMaybe<Scalars['Int']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  guiCss_AVERAGE_GTE?: InputMaybe<Scalars['Float']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  guiCss_LONGEST_GTE?: InputMaybe<Scalars['Int']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  guiCss_SHORTEST_GTE?: InputMaybe<Scalars['Int']>
-  guiCss_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars['Float']>
-  guiCss_LONGEST_LENGTH_GTE?: InputMaybe<Scalars['Int']>
-  guiCss_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars['Int']>
-  /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
-  guiCss_LT?: InputMaybe<Scalars['Int']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  guiCss_AVERAGE_LT?: InputMaybe<Scalars['Float']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  guiCss_LONGEST_LT?: InputMaybe<Scalars['Int']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  guiCss_SHORTEST_LT?: InputMaybe<Scalars['Int']>
-  guiCss_AVERAGE_LENGTH_LT?: InputMaybe<Scalars['Float']>
-  guiCss_LONGEST_LENGTH_LT?: InputMaybe<Scalars['Int']>
-  guiCss_SHORTEST_LENGTH_LT?: InputMaybe<Scalars['Int']>
-  /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
-  guiCss_LTE?: InputMaybe<Scalars['Int']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  guiCss_AVERAGE_LTE?: InputMaybe<Scalars['Float']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  guiCss_LONGEST_LTE?: InputMaybe<Scalars['Int']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  guiCss_SHORTEST_LTE?: InputMaybe<Scalars['Int']>
-  guiCss_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars['Float']>
-  guiCss_LONGEST_LENGTH_LTE?: InputMaybe<Scalars['Int']>
-  guiCss_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars['Int']>
+  style_SHORTEST_LTE?: InputMaybe<Scalars['Int']>
+  style_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars['Float']>
+  style_LONGEST_LENGTH_LTE?: InputMaybe<Scalars['Int']>
+  style_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars['Int']>
   /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
   childMapperPropKey_EQUAL?: InputMaybe<Scalars['String']>
   /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
@@ -14460,115 +14295,60 @@ export type ComponentChildrenContainerElementNodeAggregationWhereInput = {
   _compoundName_LONGEST_LENGTH_LTE?: InputMaybe<Scalars['Int']>
   _compoundName_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars['Int']>
   /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
-  customCss_EQUAL?: InputMaybe<Scalars['String']>
+  style_EQUAL?: InputMaybe<Scalars['String']>
   /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  customCss_AVERAGE_EQUAL?: InputMaybe<Scalars['Float']>
+  style_AVERAGE_EQUAL?: InputMaybe<Scalars['Float']>
   /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  customCss_LONGEST_EQUAL?: InputMaybe<Scalars['Int']>
+  style_LONGEST_EQUAL?: InputMaybe<Scalars['Int']>
   /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  customCss_SHORTEST_EQUAL?: InputMaybe<Scalars['Int']>
-  customCss_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars['Float']>
-  customCss_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars['Int']>
-  customCss_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars['Int']>
+  style_SHORTEST_EQUAL?: InputMaybe<Scalars['Int']>
+  style_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars['Float']>
+  style_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars['Int']>
+  style_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars['Int']>
   /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
-  customCss_GT?: InputMaybe<Scalars['Int']>
+  style_GT?: InputMaybe<Scalars['Int']>
   /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  customCss_AVERAGE_GT?: InputMaybe<Scalars['Float']>
+  style_AVERAGE_GT?: InputMaybe<Scalars['Float']>
   /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  customCss_LONGEST_GT?: InputMaybe<Scalars['Int']>
+  style_LONGEST_GT?: InputMaybe<Scalars['Int']>
   /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  customCss_SHORTEST_GT?: InputMaybe<Scalars['Int']>
-  customCss_AVERAGE_LENGTH_GT?: InputMaybe<Scalars['Float']>
-  customCss_LONGEST_LENGTH_GT?: InputMaybe<Scalars['Int']>
-  customCss_SHORTEST_LENGTH_GT?: InputMaybe<Scalars['Int']>
+  style_SHORTEST_GT?: InputMaybe<Scalars['Int']>
+  style_AVERAGE_LENGTH_GT?: InputMaybe<Scalars['Float']>
+  style_LONGEST_LENGTH_GT?: InputMaybe<Scalars['Int']>
+  style_SHORTEST_LENGTH_GT?: InputMaybe<Scalars['Int']>
   /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
-  customCss_GTE?: InputMaybe<Scalars['Int']>
+  style_GTE?: InputMaybe<Scalars['Int']>
   /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  customCss_AVERAGE_GTE?: InputMaybe<Scalars['Float']>
+  style_AVERAGE_GTE?: InputMaybe<Scalars['Float']>
   /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  customCss_LONGEST_GTE?: InputMaybe<Scalars['Int']>
+  style_LONGEST_GTE?: InputMaybe<Scalars['Int']>
   /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  customCss_SHORTEST_GTE?: InputMaybe<Scalars['Int']>
-  customCss_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars['Float']>
-  customCss_LONGEST_LENGTH_GTE?: InputMaybe<Scalars['Int']>
-  customCss_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars['Int']>
+  style_SHORTEST_GTE?: InputMaybe<Scalars['Int']>
+  style_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars['Float']>
+  style_LONGEST_LENGTH_GTE?: InputMaybe<Scalars['Int']>
+  style_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars['Int']>
   /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
-  customCss_LT?: InputMaybe<Scalars['Int']>
+  style_LT?: InputMaybe<Scalars['Int']>
   /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  customCss_AVERAGE_LT?: InputMaybe<Scalars['Float']>
+  style_AVERAGE_LT?: InputMaybe<Scalars['Float']>
   /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  customCss_LONGEST_LT?: InputMaybe<Scalars['Int']>
+  style_LONGEST_LT?: InputMaybe<Scalars['Int']>
   /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  customCss_SHORTEST_LT?: InputMaybe<Scalars['Int']>
-  customCss_AVERAGE_LENGTH_LT?: InputMaybe<Scalars['Float']>
-  customCss_LONGEST_LENGTH_LT?: InputMaybe<Scalars['Int']>
-  customCss_SHORTEST_LENGTH_LT?: InputMaybe<Scalars['Int']>
+  style_SHORTEST_LT?: InputMaybe<Scalars['Int']>
+  style_AVERAGE_LENGTH_LT?: InputMaybe<Scalars['Float']>
+  style_LONGEST_LENGTH_LT?: InputMaybe<Scalars['Int']>
+  style_SHORTEST_LENGTH_LT?: InputMaybe<Scalars['Int']>
   /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
-  customCss_LTE?: InputMaybe<Scalars['Int']>
+  style_LTE?: InputMaybe<Scalars['Int']>
   /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  customCss_AVERAGE_LTE?: InputMaybe<Scalars['Float']>
+  style_AVERAGE_LTE?: InputMaybe<Scalars['Float']>
   /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  customCss_LONGEST_LTE?: InputMaybe<Scalars['Int']>
+  style_LONGEST_LTE?: InputMaybe<Scalars['Int']>
   /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  customCss_SHORTEST_LTE?: InputMaybe<Scalars['Int']>
-  customCss_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars['Float']>
-  customCss_LONGEST_LENGTH_LTE?: InputMaybe<Scalars['Int']>
-  customCss_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars['Int']>
-  /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
-  guiCss_EQUAL?: InputMaybe<Scalars['String']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  guiCss_AVERAGE_EQUAL?: InputMaybe<Scalars['Float']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  guiCss_LONGEST_EQUAL?: InputMaybe<Scalars['Int']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  guiCss_SHORTEST_EQUAL?: InputMaybe<Scalars['Int']>
-  guiCss_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars['Float']>
-  guiCss_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars['Int']>
-  guiCss_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars['Int']>
-  /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
-  guiCss_GT?: InputMaybe<Scalars['Int']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  guiCss_AVERAGE_GT?: InputMaybe<Scalars['Float']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  guiCss_LONGEST_GT?: InputMaybe<Scalars['Int']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  guiCss_SHORTEST_GT?: InputMaybe<Scalars['Int']>
-  guiCss_AVERAGE_LENGTH_GT?: InputMaybe<Scalars['Float']>
-  guiCss_LONGEST_LENGTH_GT?: InputMaybe<Scalars['Int']>
-  guiCss_SHORTEST_LENGTH_GT?: InputMaybe<Scalars['Int']>
-  /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
-  guiCss_GTE?: InputMaybe<Scalars['Int']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  guiCss_AVERAGE_GTE?: InputMaybe<Scalars['Float']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  guiCss_LONGEST_GTE?: InputMaybe<Scalars['Int']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  guiCss_SHORTEST_GTE?: InputMaybe<Scalars['Int']>
-  guiCss_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars['Float']>
-  guiCss_LONGEST_LENGTH_GTE?: InputMaybe<Scalars['Int']>
-  guiCss_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars['Int']>
-  /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
-  guiCss_LT?: InputMaybe<Scalars['Int']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  guiCss_AVERAGE_LT?: InputMaybe<Scalars['Float']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  guiCss_LONGEST_LT?: InputMaybe<Scalars['Int']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  guiCss_SHORTEST_LT?: InputMaybe<Scalars['Int']>
-  guiCss_AVERAGE_LENGTH_LT?: InputMaybe<Scalars['Float']>
-  guiCss_LONGEST_LENGTH_LT?: InputMaybe<Scalars['Int']>
-  guiCss_SHORTEST_LENGTH_LT?: InputMaybe<Scalars['Int']>
-  /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
-  guiCss_LTE?: InputMaybe<Scalars['Int']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  guiCss_AVERAGE_LTE?: InputMaybe<Scalars['Float']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  guiCss_LONGEST_LTE?: InputMaybe<Scalars['Int']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  guiCss_SHORTEST_LTE?: InputMaybe<Scalars['Int']>
-  guiCss_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars['Float']>
-  guiCss_LONGEST_LENGTH_LTE?: InputMaybe<Scalars['Int']>
-  guiCss_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars['Int']>
+  style_SHORTEST_LTE?: InputMaybe<Scalars['Int']>
+  style_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars['Float']>
+  style_LONGEST_LENGTH_LTE?: InputMaybe<Scalars['Int']>
+  style_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars['Int']>
   /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
   childMapperPropKey_EQUAL?: InputMaybe<Scalars['String']>
   /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
@@ -15271,115 +15051,60 @@ export type ComponentRootElementNodeAggregationWhereInput = {
   _compoundName_LONGEST_LENGTH_LTE?: InputMaybe<Scalars['Int']>
   _compoundName_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars['Int']>
   /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
-  customCss_EQUAL?: InputMaybe<Scalars['String']>
+  style_EQUAL?: InputMaybe<Scalars['String']>
   /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  customCss_AVERAGE_EQUAL?: InputMaybe<Scalars['Float']>
+  style_AVERAGE_EQUAL?: InputMaybe<Scalars['Float']>
   /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  customCss_LONGEST_EQUAL?: InputMaybe<Scalars['Int']>
+  style_LONGEST_EQUAL?: InputMaybe<Scalars['Int']>
   /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  customCss_SHORTEST_EQUAL?: InputMaybe<Scalars['Int']>
-  customCss_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars['Float']>
-  customCss_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars['Int']>
-  customCss_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars['Int']>
+  style_SHORTEST_EQUAL?: InputMaybe<Scalars['Int']>
+  style_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars['Float']>
+  style_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars['Int']>
+  style_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars['Int']>
   /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
-  customCss_GT?: InputMaybe<Scalars['Int']>
+  style_GT?: InputMaybe<Scalars['Int']>
   /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  customCss_AVERAGE_GT?: InputMaybe<Scalars['Float']>
+  style_AVERAGE_GT?: InputMaybe<Scalars['Float']>
   /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  customCss_LONGEST_GT?: InputMaybe<Scalars['Int']>
+  style_LONGEST_GT?: InputMaybe<Scalars['Int']>
   /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  customCss_SHORTEST_GT?: InputMaybe<Scalars['Int']>
-  customCss_AVERAGE_LENGTH_GT?: InputMaybe<Scalars['Float']>
-  customCss_LONGEST_LENGTH_GT?: InputMaybe<Scalars['Int']>
-  customCss_SHORTEST_LENGTH_GT?: InputMaybe<Scalars['Int']>
+  style_SHORTEST_GT?: InputMaybe<Scalars['Int']>
+  style_AVERAGE_LENGTH_GT?: InputMaybe<Scalars['Float']>
+  style_LONGEST_LENGTH_GT?: InputMaybe<Scalars['Int']>
+  style_SHORTEST_LENGTH_GT?: InputMaybe<Scalars['Int']>
   /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
-  customCss_GTE?: InputMaybe<Scalars['Int']>
+  style_GTE?: InputMaybe<Scalars['Int']>
   /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  customCss_AVERAGE_GTE?: InputMaybe<Scalars['Float']>
+  style_AVERAGE_GTE?: InputMaybe<Scalars['Float']>
   /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  customCss_LONGEST_GTE?: InputMaybe<Scalars['Int']>
+  style_LONGEST_GTE?: InputMaybe<Scalars['Int']>
   /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  customCss_SHORTEST_GTE?: InputMaybe<Scalars['Int']>
-  customCss_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars['Float']>
-  customCss_LONGEST_LENGTH_GTE?: InputMaybe<Scalars['Int']>
-  customCss_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars['Int']>
+  style_SHORTEST_GTE?: InputMaybe<Scalars['Int']>
+  style_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars['Float']>
+  style_LONGEST_LENGTH_GTE?: InputMaybe<Scalars['Int']>
+  style_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars['Int']>
   /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
-  customCss_LT?: InputMaybe<Scalars['Int']>
+  style_LT?: InputMaybe<Scalars['Int']>
   /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  customCss_AVERAGE_LT?: InputMaybe<Scalars['Float']>
+  style_AVERAGE_LT?: InputMaybe<Scalars['Float']>
   /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  customCss_LONGEST_LT?: InputMaybe<Scalars['Int']>
+  style_LONGEST_LT?: InputMaybe<Scalars['Int']>
   /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  customCss_SHORTEST_LT?: InputMaybe<Scalars['Int']>
-  customCss_AVERAGE_LENGTH_LT?: InputMaybe<Scalars['Float']>
-  customCss_LONGEST_LENGTH_LT?: InputMaybe<Scalars['Int']>
-  customCss_SHORTEST_LENGTH_LT?: InputMaybe<Scalars['Int']>
+  style_SHORTEST_LT?: InputMaybe<Scalars['Int']>
+  style_AVERAGE_LENGTH_LT?: InputMaybe<Scalars['Float']>
+  style_LONGEST_LENGTH_LT?: InputMaybe<Scalars['Int']>
+  style_SHORTEST_LENGTH_LT?: InputMaybe<Scalars['Int']>
   /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
-  customCss_LTE?: InputMaybe<Scalars['Int']>
+  style_LTE?: InputMaybe<Scalars['Int']>
   /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  customCss_AVERAGE_LTE?: InputMaybe<Scalars['Float']>
+  style_AVERAGE_LTE?: InputMaybe<Scalars['Float']>
   /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  customCss_LONGEST_LTE?: InputMaybe<Scalars['Int']>
+  style_LONGEST_LTE?: InputMaybe<Scalars['Int']>
   /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  customCss_SHORTEST_LTE?: InputMaybe<Scalars['Int']>
-  customCss_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars['Float']>
-  customCss_LONGEST_LENGTH_LTE?: InputMaybe<Scalars['Int']>
-  customCss_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars['Int']>
-  /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
-  guiCss_EQUAL?: InputMaybe<Scalars['String']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  guiCss_AVERAGE_EQUAL?: InputMaybe<Scalars['Float']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  guiCss_LONGEST_EQUAL?: InputMaybe<Scalars['Int']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  guiCss_SHORTEST_EQUAL?: InputMaybe<Scalars['Int']>
-  guiCss_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars['Float']>
-  guiCss_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars['Int']>
-  guiCss_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars['Int']>
-  /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
-  guiCss_GT?: InputMaybe<Scalars['Int']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  guiCss_AVERAGE_GT?: InputMaybe<Scalars['Float']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  guiCss_LONGEST_GT?: InputMaybe<Scalars['Int']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  guiCss_SHORTEST_GT?: InputMaybe<Scalars['Int']>
-  guiCss_AVERAGE_LENGTH_GT?: InputMaybe<Scalars['Float']>
-  guiCss_LONGEST_LENGTH_GT?: InputMaybe<Scalars['Int']>
-  guiCss_SHORTEST_LENGTH_GT?: InputMaybe<Scalars['Int']>
-  /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
-  guiCss_GTE?: InputMaybe<Scalars['Int']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  guiCss_AVERAGE_GTE?: InputMaybe<Scalars['Float']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  guiCss_LONGEST_GTE?: InputMaybe<Scalars['Int']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  guiCss_SHORTEST_GTE?: InputMaybe<Scalars['Int']>
-  guiCss_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars['Float']>
-  guiCss_LONGEST_LENGTH_GTE?: InputMaybe<Scalars['Int']>
-  guiCss_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars['Int']>
-  /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
-  guiCss_LT?: InputMaybe<Scalars['Int']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  guiCss_AVERAGE_LT?: InputMaybe<Scalars['Float']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  guiCss_LONGEST_LT?: InputMaybe<Scalars['Int']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  guiCss_SHORTEST_LT?: InputMaybe<Scalars['Int']>
-  guiCss_AVERAGE_LENGTH_LT?: InputMaybe<Scalars['Float']>
-  guiCss_LONGEST_LENGTH_LT?: InputMaybe<Scalars['Int']>
-  guiCss_SHORTEST_LENGTH_LT?: InputMaybe<Scalars['Int']>
-  /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
-  guiCss_LTE?: InputMaybe<Scalars['Int']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  guiCss_AVERAGE_LTE?: InputMaybe<Scalars['Float']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  guiCss_LONGEST_LTE?: InputMaybe<Scalars['Int']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  guiCss_SHORTEST_LTE?: InputMaybe<Scalars['Int']>
-  guiCss_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars['Float']>
-  guiCss_LONGEST_LENGTH_LTE?: InputMaybe<Scalars['Int']>
-  guiCss_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars['Int']>
+  style_SHORTEST_LTE?: InputMaybe<Scalars['Int']>
+  style_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars['Float']>
+  style_LONGEST_LENGTH_LTE?: InputMaybe<Scalars['Int']>
+  style_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars['Int']>
   /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
   childMapperPropKey_EQUAL?: InputMaybe<Scalars['String']>
   /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
@@ -16442,115 +16167,60 @@ export type ElementChildMapperPreviousSiblingNodeAggregationWhereInput = {
   _compoundName_LONGEST_LENGTH_LTE?: InputMaybe<Scalars['Int']>
   _compoundName_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars['Int']>
   /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
-  customCss_EQUAL?: InputMaybe<Scalars['String']>
+  style_EQUAL?: InputMaybe<Scalars['String']>
   /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  customCss_AVERAGE_EQUAL?: InputMaybe<Scalars['Float']>
+  style_AVERAGE_EQUAL?: InputMaybe<Scalars['Float']>
   /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  customCss_LONGEST_EQUAL?: InputMaybe<Scalars['Int']>
+  style_LONGEST_EQUAL?: InputMaybe<Scalars['Int']>
   /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  customCss_SHORTEST_EQUAL?: InputMaybe<Scalars['Int']>
-  customCss_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars['Float']>
-  customCss_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars['Int']>
-  customCss_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars['Int']>
+  style_SHORTEST_EQUAL?: InputMaybe<Scalars['Int']>
+  style_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars['Float']>
+  style_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars['Int']>
+  style_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars['Int']>
   /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
-  customCss_GT?: InputMaybe<Scalars['Int']>
+  style_GT?: InputMaybe<Scalars['Int']>
   /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  customCss_AVERAGE_GT?: InputMaybe<Scalars['Float']>
+  style_AVERAGE_GT?: InputMaybe<Scalars['Float']>
   /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  customCss_LONGEST_GT?: InputMaybe<Scalars['Int']>
+  style_LONGEST_GT?: InputMaybe<Scalars['Int']>
   /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  customCss_SHORTEST_GT?: InputMaybe<Scalars['Int']>
-  customCss_AVERAGE_LENGTH_GT?: InputMaybe<Scalars['Float']>
-  customCss_LONGEST_LENGTH_GT?: InputMaybe<Scalars['Int']>
-  customCss_SHORTEST_LENGTH_GT?: InputMaybe<Scalars['Int']>
+  style_SHORTEST_GT?: InputMaybe<Scalars['Int']>
+  style_AVERAGE_LENGTH_GT?: InputMaybe<Scalars['Float']>
+  style_LONGEST_LENGTH_GT?: InputMaybe<Scalars['Int']>
+  style_SHORTEST_LENGTH_GT?: InputMaybe<Scalars['Int']>
   /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
-  customCss_GTE?: InputMaybe<Scalars['Int']>
+  style_GTE?: InputMaybe<Scalars['Int']>
   /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  customCss_AVERAGE_GTE?: InputMaybe<Scalars['Float']>
+  style_AVERAGE_GTE?: InputMaybe<Scalars['Float']>
   /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  customCss_LONGEST_GTE?: InputMaybe<Scalars['Int']>
+  style_LONGEST_GTE?: InputMaybe<Scalars['Int']>
   /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  customCss_SHORTEST_GTE?: InputMaybe<Scalars['Int']>
-  customCss_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars['Float']>
-  customCss_LONGEST_LENGTH_GTE?: InputMaybe<Scalars['Int']>
-  customCss_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars['Int']>
+  style_SHORTEST_GTE?: InputMaybe<Scalars['Int']>
+  style_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars['Float']>
+  style_LONGEST_LENGTH_GTE?: InputMaybe<Scalars['Int']>
+  style_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars['Int']>
   /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
-  customCss_LT?: InputMaybe<Scalars['Int']>
+  style_LT?: InputMaybe<Scalars['Int']>
   /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  customCss_AVERAGE_LT?: InputMaybe<Scalars['Float']>
+  style_AVERAGE_LT?: InputMaybe<Scalars['Float']>
   /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  customCss_LONGEST_LT?: InputMaybe<Scalars['Int']>
+  style_LONGEST_LT?: InputMaybe<Scalars['Int']>
   /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  customCss_SHORTEST_LT?: InputMaybe<Scalars['Int']>
-  customCss_AVERAGE_LENGTH_LT?: InputMaybe<Scalars['Float']>
-  customCss_LONGEST_LENGTH_LT?: InputMaybe<Scalars['Int']>
-  customCss_SHORTEST_LENGTH_LT?: InputMaybe<Scalars['Int']>
+  style_SHORTEST_LT?: InputMaybe<Scalars['Int']>
+  style_AVERAGE_LENGTH_LT?: InputMaybe<Scalars['Float']>
+  style_LONGEST_LENGTH_LT?: InputMaybe<Scalars['Int']>
+  style_SHORTEST_LENGTH_LT?: InputMaybe<Scalars['Int']>
   /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
-  customCss_LTE?: InputMaybe<Scalars['Int']>
+  style_LTE?: InputMaybe<Scalars['Int']>
   /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  customCss_AVERAGE_LTE?: InputMaybe<Scalars['Float']>
+  style_AVERAGE_LTE?: InputMaybe<Scalars['Float']>
   /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  customCss_LONGEST_LTE?: InputMaybe<Scalars['Int']>
+  style_LONGEST_LTE?: InputMaybe<Scalars['Int']>
   /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  customCss_SHORTEST_LTE?: InputMaybe<Scalars['Int']>
-  customCss_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars['Float']>
-  customCss_LONGEST_LENGTH_LTE?: InputMaybe<Scalars['Int']>
-  customCss_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars['Int']>
-  /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
-  guiCss_EQUAL?: InputMaybe<Scalars['String']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  guiCss_AVERAGE_EQUAL?: InputMaybe<Scalars['Float']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  guiCss_LONGEST_EQUAL?: InputMaybe<Scalars['Int']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  guiCss_SHORTEST_EQUAL?: InputMaybe<Scalars['Int']>
-  guiCss_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars['Float']>
-  guiCss_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars['Int']>
-  guiCss_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars['Int']>
-  /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
-  guiCss_GT?: InputMaybe<Scalars['Int']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  guiCss_AVERAGE_GT?: InputMaybe<Scalars['Float']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  guiCss_LONGEST_GT?: InputMaybe<Scalars['Int']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  guiCss_SHORTEST_GT?: InputMaybe<Scalars['Int']>
-  guiCss_AVERAGE_LENGTH_GT?: InputMaybe<Scalars['Float']>
-  guiCss_LONGEST_LENGTH_GT?: InputMaybe<Scalars['Int']>
-  guiCss_SHORTEST_LENGTH_GT?: InputMaybe<Scalars['Int']>
-  /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
-  guiCss_GTE?: InputMaybe<Scalars['Int']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  guiCss_AVERAGE_GTE?: InputMaybe<Scalars['Float']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  guiCss_LONGEST_GTE?: InputMaybe<Scalars['Int']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  guiCss_SHORTEST_GTE?: InputMaybe<Scalars['Int']>
-  guiCss_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars['Float']>
-  guiCss_LONGEST_LENGTH_GTE?: InputMaybe<Scalars['Int']>
-  guiCss_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars['Int']>
-  /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
-  guiCss_LT?: InputMaybe<Scalars['Int']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  guiCss_AVERAGE_LT?: InputMaybe<Scalars['Float']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  guiCss_LONGEST_LT?: InputMaybe<Scalars['Int']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  guiCss_SHORTEST_LT?: InputMaybe<Scalars['Int']>
-  guiCss_AVERAGE_LENGTH_LT?: InputMaybe<Scalars['Float']>
-  guiCss_LONGEST_LENGTH_LT?: InputMaybe<Scalars['Int']>
-  guiCss_SHORTEST_LENGTH_LT?: InputMaybe<Scalars['Int']>
-  /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
-  guiCss_LTE?: InputMaybe<Scalars['Int']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  guiCss_AVERAGE_LTE?: InputMaybe<Scalars['Float']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  guiCss_LONGEST_LTE?: InputMaybe<Scalars['Int']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  guiCss_SHORTEST_LTE?: InputMaybe<Scalars['Int']>
-  guiCss_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars['Float']>
-  guiCss_LONGEST_LENGTH_LTE?: InputMaybe<Scalars['Int']>
-  guiCss_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars['Int']>
+  style_SHORTEST_LTE?: InputMaybe<Scalars['Int']>
+  style_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars['Float']>
+  style_LONGEST_LENGTH_LTE?: InputMaybe<Scalars['Int']>
+  style_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars['Int']>
   /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
   childMapperPropKey_EQUAL?: InputMaybe<Scalars['String']>
   /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
@@ -16948,115 +16618,60 @@ export type ElementFirstChildNodeAggregationWhereInput = {
   _compoundName_LONGEST_LENGTH_LTE?: InputMaybe<Scalars['Int']>
   _compoundName_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars['Int']>
   /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
-  customCss_EQUAL?: InputMaybe<Scalars['String']>
+  style_EQUAL?: InputMaybe<Scalars['String']>
   /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  customCss_AVERAGE_EQUAL?: InputMaybe<Scalars['Float']>
+  style_AVERAGE_EQUAL?: InputMaybe<Scalars['Float']>
   /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  customCss_LONGEST_EQUAL?: InputMaybe<Scalars['Int']>
+  style_LONGEST_EQUAL?: InputMaybe<Scalars['Int']>
   /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  customCss_SHORTEST_EQUAL?: InputMaybe<Scalars['Int']>
-  customCss_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars['Float']>
-  customCss_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars['Int']>
-  customCss_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars['Int']>
+  style_SHORTEST_EQUAL?: InputMaybe<Scalars['Int']>
+  style_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars['Float']>
+  style_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars['Int']>
+  style_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars['Int']>
   /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
-  customCss_GT?: InputMaybe<Scalars['Int']>
+  style_GT?: InputMaybe<Scalars['Int']>
   /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  customCss_AVERAGE_GT?: InputMaybe<Scalars['Float']>
+  style_AVERAGE_GT?: InputMaybe<Scalars['Float']>
   /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  customCss_LONGEST_GT?: InputMaybe<Scalars['Int']>
+  style_LONGEST_GT?: InputMaybe<Scalars['Int']>
   /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  customCss_SHORTEST_GT?: InputMaybe<Scalars['Int']>
-  customCss_AVERAGE_LENGTH_GT?: InputMaybe<Scalars['Float']>
-  customCss_LONGEST_LENGTH_GT?: InputMaybe<Scalars['Int']>
-  customCss_SHORTEST_LENGTH_GT?: InputMaybe<Scalars['Int']>
+  style_SHORTEST_GT?: InputMaybe<Scalars['Int']>
+  style_AVERAGE_LENGTH_GT?: InputMaybe<Scalars['Float']>
+  style_LONGEST_LENGTH_GT?: InputMaybe<Scalars['Int']>
+  style_SHORTEST_LENGTH_GT?: InputMaybe<Scalars['Int']>
   /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
-  customCss_GTE?: InputMaybe<Scalars['Int']>
+  style_GTE?: InputMaybe<Scalars['Int']>
   /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  customCss_AVERAGE_GTE?: InputMaybe<Scalars['Float']>
+  style_AVERAGE_GTE?: InputMaybe<Scalars['Float']>
   /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  customCss_LONGEST_GTE?: InputMaybe<Scalars['Int']>
+  style_LONGEST_GTE?: InputMaybe<Scalars['Int']>
   /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  customCss_SHORTEST_GTE?: InputMaybe<Scalars['Int']>
-  customCss_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars['Float']>
-  customCss_LONGEST_LENGTH_GTE?: InputMaybe<Scalars['Int']>
-  customCss_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars['Int']>
+  style_SHORTEST_GTE?: InputMaybe<Scalars['Int']>
+  style_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars['Float']>
+  style_LONGEST_LENGTH_GTE?: InputMaybe<Scalars['Int']>
+  style_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars['Int']>
   /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
-  customCss_LT?: InputMaybe<Scalars['Int']>
+  style_LT?: InputMaybe<Scalars['Int']>
   /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  customCss_AVERAGE_LT?: InputMaybe<Scalars['Float']>
+  style_AVERAGE_LT?: InputMaybe<Scalars['Float']>
   /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  customCss_LONGEST_LT?: InputMaybe<Scalars['Int']>
+  style_LONGEST_LT?: InputMaybe<Scalars['Int']>
   /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  customCss_SHORTEST_LT?: InputMaybe<Scalars['Int']>
-  customCss_AVERAGE_LENGTH_LT?: InputMaybe<Scalars['Float']>
-  customCss_LONGEST_LENGTH_LT?: InputMaybe<Scalars['Int']>
-  customCss_SHORTEST_LENGTH_LT?: InputMaybe<Scalars['Int']>
+  style_SHORTEST_LT?: InputMaybe<Scalars['Int']>
+  style_AVERAGE_LENGTH_LT?: InputMaybe<Scalars['Float']>
+  style_LONGEST_LENGTH_LT?: InputMaybe<Scalars['Int']>
+  style_SHORTEST_LENGTH_LT?: InputMaybe<Scalars['Int']>
   /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
-  customCss_LTE?: InputMaybe<Scalars['Int']>
+  style_LTE?: InputMaybe<Scalars['Int']>
   /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  customCss_AVERAGE_LTE?: InputMaybe<Scalars['Float']>
+  style_AVERAGE_LTE?: InputMaybe<Scalars['Float']>
   /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  customCss_LONGEST_LTE?: InputMaybe<Scalars['Int']>
+  style_LONGEST_LTE?: InputMaybe<Scalars['Int']>
   /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  customCss_SHORTEST_LTE?: InputMaybe<Scalars['Int']>
-  customCss_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars['Float']>
-  customCss_LONGEST_LENGTH_LTE?: InputMaybe<Scalars['Int']>
-  customCss_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars['Int']>
-  /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
-  guiCss_EQUAL?: InputMaybe<Scalars['String']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  guiCss_AVERAGE_EQUAL?: InputMaybe<Scalars['Float']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  guiCss_LONGEST_EQUAL?: InputMaybe<Scalars['Int']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  guiCss_SHORTEST_EQUAL?: InputMaybe<Scalars['Int']>
-  guiCss_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars['Float']>
-  guiCss_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars['Int']>
-  guiCss_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars['Int']>
-  /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
-  guiCss_GT?: InputMaybe<Scalars['Int']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  guiCss_AVERAGE_GT?: InputMaybe<Scalars['Float']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  guiCss_LONGEST_GT?: InputMaybe<Scalars['Int']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  guiCss_SHORTEST_GT?: InputMaybe<Scalars['Int']>
-  guiCss_AVERAGE_LENGTH_GT?: InputMaybe<Scalars['Float']>
-  guiCss_LONGEST_LENGTH_GT?: InputMaybe<Scalars['Int']>
-  guiCss_SHORTEST_LENGTH_GT?: InputMaybe<Scalars['Int']>
-  /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
-  guiCss_GTE?: InputMaybe<Scalars['Int']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  guiCss_AVERAGE_GTE?: InputMaybe<Scalars['Float']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  guiCss_LONGEST_GTE?: InputMaybe<Scalars['Int']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  guiCss_SHORTEST_GTE?: InputMaybe<Scalars['Int']>
-  guiCss_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars['Float']>
-  guiCss_LONGEST_LENGTH_GTE?: InputMaybe<Scalars['Int']>
-  guiCss_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars['Int']>
-  /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
-  guiCss_LT?: InputMaybe<Scalars['Int']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  guiCss_AVERAGE_LT?: InputMaybe<Scalars['Float']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  guiCss_LONGEST_LT?: InputMaybe<Scalars['Int']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  guiCss_SHORTEST_LT?: InputMaybe<Scalars['Int']>
-  guiCss_AVERAGE_LENGTH_LT?: InputMaybe<Scalars['Float']>
-  guiCss_LONGEST_LENGTH_LT?: InputMaybe<Scalars['Int']>
-  guiCss_SHORTEST_LENGTH_LT?: InputMaybe<Scalars['Int']>
-  /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
-  guiCss_LTE?: InputMaybe<Scalars['Int']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  guiCss_AVERAGE_LTE?: InputMaybe<Scalars['Float']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  guiCss_LONGEST_LTE?: InputMaybe<Scalars['Int']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  guiCss_SHORTEST_LTE?: InputMaybe<Scalars['Int']>
-  guiCss_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars['Float']>
-  guiCss_LONGEST_LENGTH_LTE?: InputMaybe<Scalars['Int']>
-  guiCss_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars['Int']>
+  style_SHORTEST_LTE?: InputMaybe<Scalars['Int']>
+  style_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars['Float']>
+  style_LONGEST_LENGTH_LTE?: InputMaybe<Scalars['Int']>
+  style_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars['Int']>
   /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
   childMapperPropKey_EQUAL?: InputMaybe<Scalars['String']>
   /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
@@ -17361,115 +16976,60 @@ export type ElementNextSiblingNodeAggregationWhereInput = {
   _compoundName_LONGEST_LENGTH_LTE?: InputMaybe<Scalars['Int']>
   _compoundName_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars['Int']>
   /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
-  customCss_EQUAL?: InputMaybe<Scalars['String']>
+  style_EQUAL?: InputMaybe<Scalars['String']>
   /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  customCss_AVERAGE_EQUAL?: InputMaybe<Scalars['Float']>
+  style_AVERAGE_EQUAL?: InputMaybe<Scalars['Float']>
   /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  customCss_LONGEST_EQUAL?: InputMaybe<Scalars['Int']>
+  style_LONGEST_EQUAL?: InputMaybe<Scalars['Int']>
   /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  customCss_SHORTEST_EQUAL?: InputMaybe<Scalars['Int']>
-  customCss_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars['Float']>
-  customCss_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars['Int']>
-  customCss_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars['Int']>
+  style_SHORTEST_EQUAL?: InputMaybe<Scalars['Int']>
+  style_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars['Float']>
+  style_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars['Int']>
+  style_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars['Int']>
   /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
-  customCss_GT?: InputMaybe<Scalars['Int']>
+  style_GT?: InputMaybe<Scalars['Int']>
   /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  customCss_AVERAGE_GT?: InputMaybe<Scalars['Float']>
+  style_AVERAGE_GT?: InputMaybe<Scalars['Float']>
   /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  customCss_LONGEST_GT?: InputMaybe<Scalars['Int']>
+  style_LONGEST_GT?: InputMaybe<Scalars['Int']>
   /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  customCss_SHORTEST_GT?: InputMaybe<Scalars['Int']>
-  customCss_AVERAGE_LENGTH_GT?: InputMaybe<Scalars['Float']>
-  customCss_LONGEST_LENGTH_GT?: InputMaybe<Scalars['Int']>
-  customCss_SHORTEST_LENGTH_GT?: InputMaybe<Scalars['Int']>
+  style_SHORTEST_GT?: InputMaybe<Scalars['Int']>
+  style_AVERAGE_LENGTH_GT?: InputMaybe<Scalars['Float']>
+  style_LONGEST_LENGTH_GT?: InputMaybe<Scalars['Int']>
+  style_SHORTEST_LENGTH_GT?: InputMaybe<Scalars['Int']>
   /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
-  customCss_GTE?: InputMaybe<Scalars['Int']>
+  style_GTE?: InputMaybe<Scalars['Int']>
   /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  customCss_AVERAGE_GTE?: InputMaybe<Scalars['Float']>
+  style_AVERAGE_GTE?: InputMaybe<Scalars['Float']>
   /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  customCss_LONGEST_GTE?: InputMaybe<Scalars['Int']>
+  style_LONGEST_GTE?: InputMaybe<Scalars['Int']>
   /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  customCss_SHORTEST_GTE?: InputMaybe<Scalars['Int']>
-  customCss_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars['Float']>
-  customCss_LONGEST_LENGTH_GTE?: InputMaybe<Scalars['Int']>
-  customCss_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars['Int']>
+  style_SHORTEST_GTE?: InputMaybe<Scalars['Int']>
+  style_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars['Float']>
+  style_LONGEST_LENGTH_GTE?: InputMaybe<Scalars['Int']>
+  style_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars['Int']>
   /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
-  customCss_LT?: InputMaybe<Scalars['Int']>
+  style_LT?: InputMaybe<Scalars['Int']>
   /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  customCss_AVERAGE_LT?: InputMaybe<Scalars['Float']>
+  style_AVERAGE_LT?: InputMaybe<Scalars['Float']>
   /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  customCss_LONGEST_LT?: InputMaybe<Scalars['Int']>
+  style_LONGEST_LT?: InputMaybe<Scalars['Int']>
   /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  customCss_SHORTEST_LT?: InputMaybe<Scalars['Int']>
-  customCss_AVERAGE_LENGTH_LT?: InputMaybe<Scalars['Float']>
-  customCss_LONGEST_LENGTH_LT?: InputMaybe<Scalars['Int']>
-  customCss_SHORTEST_LENGTH_LT?: InputMaybe<Scalars['Int']>
+  style_SHORTEST_LT?: InputMaybe<Scalars['Int']>
+  style_AVERAGE_LENGTH_LT?: InputMaybe<Scalars['Float']>
+  style_LONGEST_LENGTH_LT?: InputMaybe<Scalars['Int']>
+  style_SHORTEST_LENGTH_LT?: InputMaybe<Scalars['Int']>
   /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
-  customCss_LTE?: InputMaybe<Scalars['Int']>
+  style_LTE?: InputMaybe<Scalars['Int']>
   /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  customCss_AVERAGE_LTE?: InputMaybe<Scalars['Float']>
+  style_AVERAGE_LTE?: InputMaybe<Scalars['Float']>
   /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  customCss_LONGEST_LTE?: InputMaybe<Scalars['Int']>
+  style_LONGEST_LTE?: InputMaybe<Scalars['Int']>
   /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  customCss_SHORTEST_LTE?: InputMaybe<Scalars['Int']>
-  customCss_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars['Float']>
-  customCss_LONGEST_LENGTH_LTE?: InputMaybe<Scalars['Int']>
-  customCss_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars['Int']>
-  /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
-  guiCss_EQUAL?: InputMaybe<Scalars['String']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  guiCss_AVERAGE_EQUAL?: InputMaybe<Scalars['Float']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  guiCss_LONGEST_EQUAL?: InputMaybe<Scalars['Int']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  guiCss_SHORTEST_EQUAL?: InputMaybe<Scalars['Int']>
-  guiCss_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars['Float']>
-  guiCss_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars['Int']>
-  guiCss_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars['Int']>
-  /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
-  guiCss_GT?: InputMaybe<Scalars['Int']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  guiCss_AVERAGE_GT?: InputMaybe<Scalars['Float']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  guiCss_LONGEST_GT?: InputMaybe<Scalars['Int']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  guiCss_SHORTEST_GT?: InputMaybe<Scalars['Int']>
-  guiCss_AVERAGE_LENGTH_GT?: InputMaybe<Scalars['Float']>
-  guiCss_LONGEST_LENGTH_GT?: InputMaybe<Scalars['Int']>
-  guiCss_SHORTEST_LENGTH_GT?: InputMaybe<Scalars['Int']>
-  /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
-  guiCss_GTE?: InputMaybe<Scalars['Int']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  guiCss_AVERAGE_GTE?: InputMaybe<Scalars['Float']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  guiCss_LONGEST_GTE?: InputMaybe<Scalars['Int']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  guiCss_SHORTEST_GTE?: InputMaybe<Scalars['Int']>
-  guiCss_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars['Float']>
-  guiCss_LONGEST_LENGTH_GTE?: InputMaybe<Scalars['Int']>
-  guiCss_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars['Int']>
-  /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
-  guiCss_LT?: InputMaybe<Scalars['Int']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  guiCss_AVERAGE_LT?: InputMaybe<Scalars['Float']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  guiCss_LONGEST_LT?: InputMaybe<Scalars['Int']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  guiCss_SHORTEST_LT?: InputMaybe<Scalars['Int']>
-  guiCss_AVERAGE_LENGTH_LT?: InputMaybe<Scalars['Float']>
-  guiCss_LONGEST_LENGTH_LT?: InputMaybe<Scalars['Int']>
-  guiCss_SHORTEST_LENGTH_LT?: InputMaybe<Scalars['Int']>
-  /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
-  guiCss_LTE?: InputMaybe<Scalars['Int']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  guiCss_AVERAGE_LTE?: InputMaybe<Scalars['Float']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  guiCss_LONGEST_LTE?: InputMaybe<Scalars['Int']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  guiCss_SHORTEST_LTE?: InputMaybe<Scalars['Int']>
-  guiCss_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars['Float']>
-  guiCss_LONGEST_LENGTH_LTE?: InputMaybe<Scalars['Int']>
-  guiCss_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars['Int']>
+  style_SHORTEST_LTE?: InputMaybe<Scalars['Int']>
+  style_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars['Float']>
+  style_LONGEST_LENGTH_LTE?: InputMaybe<Scalars['Int']>
+  style_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars['Int']>
   /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
   childMapperPropKey_EQUAL?: InputMaybe<Scalars['String']>
   /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
@@ -18177,115 +17737,60 @@ export type ElementParentNodeAggregationWhereInput = {
   _compoundName_LONGEST_LENGTH_LTE?: InputMaybe<Scalars['Int']>
   _compoundName_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars['Int']>
   /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
-  customCss_EQUAL?: InputMaybe<Scalars['String']>
+  style_EQUAL?: InputMaybe<Scalars['String']>
   /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  customCss_AVERAGE_EQUAL?: InputMaybe<Scalars['Float']>
+  style_AVERAGE_EQUAL?: InputMaybe<Scalars['Float']>
   /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  customCss_LONGEST_EQUAL?: InputMaybe<Scalars['Int']>
+  style_LONGEST_EQUAL?: InputMaybe<Scalars['Int']>
   /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  customCss_SHORTEST_EQUAL?: InputMaybe<Scalars['Int']>
-  customCss_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars['Float']>
-  customCss_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars['Int']>
-  customCss_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars['Int']>
+  style_SHORTEST_EQUAL?: InputMaybe<Scalars['Int']>
+  style_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars['Float']>
+  style_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars['Int']>
+  style_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars['Int']>
   /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
-  customCss_GT?: InputMaybe<Scalars['Int']>
+  style_GT?: InputMaybe<Scalars['Int']>
   /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  customCss_AVERAGE_GT?: InputMaybe<Scalars['Float']>
+  style_AVERAGE_GT?: InputMaybe<Scalars['Float']>
   /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  customCss_LONGEST_GT?: InputMaybe<Scalars['Int']>
+  style_LONGEST_GT?: InputMaybe<Scalars['Int']>
   /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  customCss_SHORTEST_GT?: InputMaybe<Scalars['Int']>
-  customCss_AVERAGE_LENGTH_GT?: InputMaybe<Scalars['Float']>
-  customCss_LONGEST_LENGTH_GT?: InputMaybe<Scalars['Int']>
-  customCss_SHORTEST_LENGTH_GT?: InputMaybe<Scalars['Int']>
+  style_SHORTEST_GT?: InputMaybe<Scalars['Int']>
+  style_AVERAGE_LENGTH_GT?: InputMaybe<Scalars['Float']>
+  style_LONGEST_LENGTH_GT?: InputMaybe<Scalars['Int']>
+  style_SHORTEST_LENGTH_GT?: InputMaybe<Scalars['Int']>
   /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
-  customCss_GTE?: InputMaybe<Scalars['Int']>
+  style_GTE?: InputMaybe<Scalars['Int']>
   /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  customCss_AVERAGE_GTE?: InputMaybe<Scalars['Float']>
+  style_AVERAGE_GTE?: InputMaybe<Scalars['Float']>
   /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  customCss_LONGEST_GTE?: InputMaybe<Scalars['Int']>
+  style_LONGEST_GTE?: InputMaybe<Scalars['Int']>
   /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  customCss_SHORTEST_GTE?: InputMaybe<Scalars['Int']>
-  customCss_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars['Float']>
-  customCss_LONGEST_LENGTH_GTE?: InputMaybe<Scalars['Int']>
-  customCss_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars['Int']>
+  style_SHORTEST_GTE?: InputMaybe<Scalars['Int']>
+  style_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars['Float']>
+  style_LONGEST_LENGTH_GTE?: InputMaybe<Scalars['Int']>
+  style_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars['Int']>
   /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
-  customCss_LT?: InputMaybe<Scalars['Int']>
+  style_LT?: InputMaybe<Scalars['Int']>
   /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  customCss_AVERAGE_LT?: InputMaybe<Scalars['Float']>
+  style_AVERAGE_LT?: InputMaybe<Scalars['Float']>
   /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  customCss_LONGEST_LT?: InputMaybe<Scalars['Int']>
+  style_LONGEST_LT?: InputMaybe<Scalars['Int']>
   /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  customCss_SHORTEST_LT?: InputMaybe<Scalars['Int']>
-  customCss_AVERAGE_LENGTH_LT?: InputMaybe<Scalars['Float']>
-  customCss_LONGEST_LENGTH_LT?: InputMaybe<Scalars['Int']>
-  customCss_SHORTEST_LENGTH_LT?: InputMaybe<Scalars['Int']>
+  style_SHORTEST_LT?: InputMaybe<Scalars['Int']>
+  style_AVERAGE_LENGTH_LT?: InputMaybe<Scalars['Float']>
+  style_LONGEST_LENGTH_LT?: InputMaybe<Scalars['Int']>
+  style_SHORTEST_LENGTH_LT?: InputMaybe<Scalars['Int']>
   /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
-  customCss_LTE?: InputMaybe<Scalars['Int']>
+  style_LTE?: InputMaybe<Scalars['Int']>
   /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  customCss_AVERAGE_LTE?: InputMaybe<Scalars['Float']>
+  style_AVERAGE_LTE?: InputMaybe<Scalars['Float']>
   /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  customCss_LONGEST_LTE?: InputMaybe<Scalars['Int']>
+  style_LONGEST_LTE?: InputMaybe<Scalars['Int']>
   /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  customCss_SHORTEST_LTE?: InputMaybe<Scalars['Int']>
-  customCss_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars['Float']>
-  customCss_LONGEST_LENGTH_LTE?: InputMaybe<Scalars['Int']>
-  customCss_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars['Int']>
-  /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
-  guiCss_EQUAL?: InputMaybe<Scalars['String']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  guiCss_AVERAGE_EQUAL?: InputMaybe<Scalars['Float']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  guiCss_LONGEST_EQUAL?: InputMaybe<Scalars['Int']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  guiCss_SHORTEST_EQUAL?: InputMaybe<Scalars['Int']>
-  guiCss_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars['Float']>
-  guiCss_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars['Int']>
-  guiCss_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars['Int']>
-  /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
-  guiCss_GT?: InputMaybe<Scalars['Int']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  guiCss_AVERAGE_GT?: InputMaybe<Scalars['Float']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  guiCss_LONGEST_GT?: InputMaybe<Scalars['Int']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  guiCss_SHORTEST_GT?: InputMaybe<Scalars['Int']>
-  guiCss_AVERAGE_LENGTH_GT?: InputMaybe<Scalars['Float']>
-  guiCss_LONGEST_LENGTH_GT?: InputMaybe<Scalars['Int']>
-  guiCss_SHORTEST_LENGTH_GT?: InputMaybe<Scalars['Int']>
-  /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
-  guiCss_GTE?: InputMaybe<Scalars['Int']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  guiCss_AVERAGE_GTE?: InputMaybe<Scalars['Float']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  guiCss_LONGEST_GTE?: InputMaybe<Scalars['Int']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  guiCss_SHORTEST_GTE?: InputMaybe<Scalars['Int']>
-  guiCss_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars['Float']>
-  guiCss_LONGEST_LENGTH_GTE?: InputMaybe<Scalars['Int']>
-  guiCss_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars['Int']>
-  /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
-  guiCss_LT?: InputMaybe<Scalars['Int']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  guiCss_AVERAGE_LT?: InputMaybe<Scalars['Float']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  guiCss_LONGEST_LT?: InputMaybe<Scalars['Int']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  guiCss_SHORTEST_LT?: InputMaybe<Scalars['Int']>
-  guiCss_AVERAGE_LENGTH_LT?: InputMaybe<Scalars['Float']>
-  guiCss_LONGEST_LENGTH_LT?: InputMaybe<Scalars['Int']>
-  guiCss_SHORTEST_LENGTH_LT?: InputMaybe<Scalars['Int']>
-  /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
-  guiCss_LTE?: InputMaybe<Scalars['Int']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  guiCss_AVERAGE_LTE?: InputMaybe<Scalars['Float']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  guiCss_LONGEST_LTE?: InputMaybe<Scalars['Int']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  guiCss_SHORTEST_LTE?: InputMaybe<Scalars['Int']>
-  guiCss_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars['Float']>
-  guiCss_LONGEST_LENGTH_LTE?: InputMaybe<Scalars['Int']>
-  guiCss_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars['Int']>
+  style_SHORTEST_LTE?: InputMaybe<Scalars['Int']>
+  style_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars['Float']>
+  style_LONGEST_LENGTH_LTE?: InputMaybe<Scalars['Int']>
+  style_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars['Int']>
   /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
   childMapperPropKey_EQUAL?: InputMaybe<Scalars['String']>
   /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
@@ -18690,115 +18195,60 @@ export type ElementPrevSiblingNodeAggregationWhereInput = {
   _compoundName_LONGEST_LENGTH_LTE?: InputMaybe<Scalars['Int']>
   _compoundName_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars['Int']>
   /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
-  customCss_EQUAL?: InputMaybe<Scalars['String']>
+  style_EQUAL?: InputMaybe<Scalars['String']>
   /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  customCss_AVERAGE_EQUAL?: InputMaybe<Scalars['Float']>
+  style_AVERAGE_EQUAL?: InputMaybe<Scalars['Float']>
   /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  customCss_LONGEST_EQUAL?: InputMaybe<Scalars['Int']>
+  style_LONGEST_EQUAL?: InputMaybe<Scalars['Int']>
   /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  customCss_SHORTEST_EQUAL?: InputMaybe<Scalars['Int']>
-  customCss_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars['Float']>
-  customCss_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars['Int']>
-  customCss_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars['Int']>
+  style_SHORTEST_EQUAL?: InputMaybe<Scalars['Int']>
+  style_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars['Float']>
+  style_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars['Int']>
+  style_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars['Int']>
   /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
-  customCss_GT?: InputMaybe<Scalars['Int']>
+  style_GT?: InputMaybe<Scalars['Int']>
   /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  customCss_AVERAGE_GT?: InputMaybe<Scalars['Float']>
+  style_AVERAGE_GT?: InputMaybe<Scalars['Float']>
   /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  customCss_LONGEST_GT?: InputMaybe<Scalars['Int']>
+  style_LONGEST_GT?: InputMaybe<Scalars['Int']>
   /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  customCss_SHORTEST_GT?: InputMaybe<Scalars['Int']>
-  customCss_AVERAGE_LENGTH_GT?: InputMaybe<Scalars['Float']>
-  customCss_LONGEST_LENGTH_GT?: InputMaybe<Scalars['Int']>
-  customCss_SHORTEST_LENGTH_GT?: InputMaybe<Scalars['Int']>
+  style_SHORTEST_GT?: InputMaybe<Scalars['Int']>
+  style_AVERAGE_LENGTH_GT?: InputMaybe<Scalars['Float']>
+  style_LONGEST_LENGTH_GT?: InputMaybe<Scalars['Int']>
+  style_SHORTEST_LENGTH_GT?: InputMaybe<Scalars['Int']>
   /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
-  customCss_GTE?: InputMaybe<Scalars['Int']>
+  style_GTE?: InputMaybe<Scalars['Int']>
   /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  customCss_AVERAGE_GTE?: InputMaybe<Scalars['Float']>
+  style_AVERAGE_GTE?: InputMaybe<Scalars['Float']>
   /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  customCss_LONGEST_GTE?: InputMaybe<Scalars['Int']>
+  style_LONGEST_GTE?: InputMaybe<Scalars['Int']>
   /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  customCss_SHORTEST_GTE?: InputMaybe<Scalars['Int']>
-  customCss_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars['Float']>
-  customCss_LONGEST_LENGTH_GTE?: InputMaybe<Scalars['Int']>
-  customCss_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars['Int']>
+  style_SHORTEST_GTE?: InputMaybe<Scalars['Int']>
+  style_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars['Float']>
+  style_LONGEST_LENGTH_GTE?: InputMaybe<Scalars['Int']>
+  style_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars['Int']>
   /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
-  customCss_LT?: InputMaybe<Scalars['Int']>
+  style_LT?: InputMaybe<Scalars['Int']>
   /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  customCss_AVERAGE_LT?: InputMaybe<Scalars['Float']>
+  style_AVERAGE_LT?: InputMaybe<Scalars['Float']>
   /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  customCss_LONGEST_LT?: InputMaybe<Scalars['Int']>
+  style_LONGEST_LT?: InputMaybe<Scalars['Int']>
   /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  customCss_SHORTEST_LT?: InputMaybe<Scalars['Int']>
-  customCss_AVERAGE_LENGTH_LT?: InputMaybe<Scalars['Float']>
-  customCss_LONGEST_LENGTH_LT?: InputMaybe<Scalars['Int']>
-  customCss_SHORTEST_LENGTH_LT?: InputMaybe<Scalars['Int']>
+  style_SHORTEST_LT?: InputMaybe<Scalars['Int']>
+  style_AVERAGE_LENGTH_LT?: InputMaybe<Scalars['Float']>
+  style_LONGEST_LENGTH_LT?: InputMaybe<Scalars['Int']>
+  style_SHORTEST_LENGTH_LT?: InputMaybe<Scalars['Int']>
   /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
-  customCss_LTE?: InputMaybe<Scalars['Int']>
+  style_LTE?: InputMaybe<Scalars['Int']>
   /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  customCss_AVERAGE_LTE?: InputMaybe<Scalars['Float']>
+  style_AVERAGE_LTE?: InputMaybe<Scalars['Float']>
   /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  customCss_LONGEST_LTE?: InputMaybe<Scalars['Int']>
+  style_LONGEST_LTE?: InputMaybe<Scalars['Int']>
   /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  customCss_SHORTEST_LTE?: InputMaybe<Scalars['Int']>
-  customCss_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars['Float']>
-  customCss_LONGEST_LENGTH_LTE?: InputMaybe<Scalars['Int']>
-  customCss_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars['Int']>
-  /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
-  guiCss_EQUAL?: InputMaybe<Scalars['String']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  guiCss_AVERAGE_EQUAL?: InputMaybe<Scalars['Float']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  guiCss_LONGEST_EQUAL?: InputMaybe<Scalars['Int']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  guiCss_SHORTEST_EQUAL?: InputMaybe<Scalars['Int']>
-  guiCss_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars['Float']>
-  guiCss_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars['Int']>
-  guiCss_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars['Int']>
-  /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
-  guiCss_GT?: InputMaybe<Scalars['Int']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  guiCss_AVERAGE_GT?: InputMaybe<Scalars['Float']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  guiCss_LONGEST_GT?: InputMaybe<Scalars['Int']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  guiCss_SHORTEST_GT?: InputMaybe<Scalars['Int']>
-  guiCss_AVERAGE_LENGTH_GT?: InputMaybe<Scalars['Float']>
-  guiCss_LONGEST_LENGTH_GT?: InputMaybe<Scalars['Int']>
-  guiCss_SHORTEST_LENGTH_GT?: InputMaybe<Scalars['Int']>
-  /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
-  guiCss_GTE?: InputMaybe<Scalars['Int']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  guiCss_AVERAGE_GTE?: InputMaybe<Scalars['Float']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  guiCss_LONGEST_GTE?: InputMaybe<Scalars['Int']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  guiCss_SHORTEST_GTE?: InputMaybe<Scalars['Int']>
-  guiCss_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars['Float']>
-  guiCss_LONGEST_LENGTH_GTE?: InputMaybe<Scalars['Int']>
-  guiCss_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars['Int']>
-  /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
-  guiCss_LT?: InputMaybe<Scalars['Int']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  guiCss_AVERAGE_LT?: InputMaybe<Scalars['Float']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  guiCss_LONGEST_LT?: InputMaybe<Scalars['Int']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  guiCss_SHORTEST_LT?: InputMaybe<Scalars['Int']>
-  guiCss_AVERAGE_LENGTH_LT?: InputMaybe<Scalars['Float']>
-  guiCss_LONGEST_LENGTH_LT?: InputMaybe<Scalars['Int']>
-  guiCss_SHORTEST_LENGTH_LT?: InputMaybe<Scalars['Int']>
-  /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
-  guiCss_LTE?: InputMaybe<Scalars['Int']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  guiCss_AVERAGE_LTE?: InputMaybe<Scalars['Float']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  guiCss_LONGEST_LTE?: InputMaybe<Scalars['Int']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  guiCss_SHORTEST_LTE?: InputMaybe<Scalars['Int']>
-  guiCss_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars['Float']>
-  guiCss_LONGEST_LENGTH_LTE?: InputMaybe<Scalars['Int']>
-  guiCss_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars['Int']>
+  style_SHORTEST_LTE?: InputMaybe<Scalars['Int']>
+  style_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars['Float']>
+  style_LONGEST_LENGTH_LTE?: InputMaybe<Scalars['Int']>
+  style_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars['Int']>
   /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
   childMapperPropKey_EQUAL?: InputMaybe<Scalars['String']>
   /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
@@ -20069,36 +19519,20 @@ export type ElementWhere = {
   _compoundName_NOT_ENDS_WITH?: InputMaybe<Scalars['String']>
   customCss?: InputMaybe<Scalars['String']>
   /** @deprecated Negation filters will be deprecated, use the NOT operator to achieve the same behavior */
-  customCss_NOT?: InputMaybe<Scalars['String']>
-  customCss_IN?: InputMaybe<Array<InputMaybe<Scalars['String']>>>
+  style_NOT?: InputMaybe<Scalars['String']>
+  style_IN?: InputMaybe<Array<InputMaybe<Scalars['String']>>>
   /** @deprecated Negation filters will be deprecated, use the NOT operator to achieve the same behavior */
-  customCss_NOT_IN?: InputMaybe<Array<InputMaybe<Scalars['String']>>>
-  customCss_MATCHES?: InputMaybe<Scalars['String']>
-  customCss_CONTAINS?: InputMaybe<Scalars['String']>
-  customCss_STARTS_WITH?: InputMaybe<Scalars['String']>
-  customCss_ENDS_WITH?: InputMaybe<Scalars['String']>
+  style_NOT_IN?: InputMaybe<Array<InputMaybe<Scalars['String']>>>
+  style_MATCHES?: InputMaybe<Scalars['String']>
+  style_CONTAINS?: InputMaybe<Scalars['String']>
+  style_STARTS_WITH?: InputMaybe<Scalars['String']>
+  style_ENDS_WITH?: InputMaybe<Scalars['String']>
   /** @deprecated Negation filters will be deprecated, use the NOT operator to achieve the same behavior */
-  customCss_NOT_CONTAINS?: InputMaybe<Scalars['String']>
+  style_NOT_CONTAINS?: InputMaybe<Scalars['String']>
   /** @deprecated Negation filters will be deprecated, use the NOT operator to achieve the same behavior */
-  customCss_NOT_STARTS_WITH?: InputMaybe<Scalars['String']>
+  style_NOT_STARTS_WITH?: InputMaybe<Scalars['String']>
   /** @deprecated Negation filters will be deprecated, use the NOT operator to achieve the same behavior */
-  customCss_NOT_ENDS_WITH?: InputMaybe<Scalars['String']>
-  guiCss?: InputMaybe<Scalars['String']>
-  /** @deprecated Negation filters will be deprecated, use the NOT operator to achieve the same behavior */
-  guiCss_NOT?: InputMaybe<Scalars['String']>
-  guiCss_IN?: InputMaybe<Array<InputMaybe<Scalars['String']>>>
-  /** @deprecated Negation filters will be deprecated, use the NOT operator to achieve the same behavior */
-  guiCss_NOT_IN?: InputMaybe<Array<InputMaybe<Scalars['String']>>>
-  guiCss_MATCHES?: InputMaybe<Scalars['String']>
-  guiCss_CONTAINS?: InputMaybe<Scalars['String']>
-  guiCss_STARTS_WITH?: InputMaybe<Scalars['String']>
-  guiCss_ENDS_WITH?: InputMaybe<Scalars['String']>
-  /** @deprecated Negation filters will be deprecated, use the NOT operator to achieve the same behavior */
-  guiCss_NOT_CONTAINS?: InputMaybe<Scalars['String']>
-  /** @deprecated Negation filters will be deprecated, use the NOT operator to achieve the same behavior */
-  guiCss_NOT_STARTS_WITH?: InputMaybe<Scalars['String']>
-  /** @deprecated Negation filters will be deprecated, use the NOT operator to achieve the same behavior */
-  guiCss_NOT_ENDS_WITH?: InputMaybe<Scalars['String']>
+  style_NOT_ENDS_WITH?: InputMaybe<Scalars['String']>
   childMapperPropKey?: InputMaybe<Scalars['String']>
   /** @deprecated Negation filters will be deprecated, use the NOT operator to achieve the same behavior */
   childMapperPropKey_NOT?: InputMaybe<Scalars['String']>
@@ -22750,115 +22184,60 @@ export type HookElementNodeAggregationWhereInput = {
   _compoundName_LONGEST_LENGTH_LTE?: InputMaybe<Scalars['Int']>
   _compoundName_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars['Int']>
   /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
-  customCss_EQUAL?: InputMaybe<Scalars['String']>
+  style_EQUAL?: InputMaybe<Scalars['String']>
   /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  customCss_AVERAGE_EQUAL?: InputMaybe<Scalars['Float']>
+  style_AVERAGE_EQUAL?: InputMaybe<Scalars['Float']>
   /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  customCss_LONGEST_EQUAL?: InputMaybe<Scalars['Int']>
+  style_LONGEST_EQUAL?: InputMaybe<Scalars['Int']>
   /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  customCss_SHORTEST_EQUAL?: InputMaybe<Scalars['Int']>
-  customCss_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars['Float']>
-  customCss_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars['Int']>
-  customCss_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars['Int']>
+  style_SHORTEST_EQUAL?: InputMaybe<Scalars['Int']>
+  style_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars['Float']>
+  style_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars['Int']>
+  style_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars['Int']>
   /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
-  customCss_GT?: InputMaybe<Scalars['Int']>
+  style_GT?: InputMaybe<Scalars['Int']>
   /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  customCss_AVERAGE_GT?: InputMaybe<Scalars['Float']>
+  style_AVERAGE_GT?: InputMaybe<Scalars['Float']>
   /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  customCss_LONGEST_GT?: InputMaybe<Scalars['Int']>
+  style_LONGEST_GT?: InputMaybe<Scalars['Int']>
   /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  customCss_SHORTEST_GT?: InputMaybe<Scalars['Int']>
-  customCss_AVERAGE_LENGTH_GT?: InputMaybe<Scalars['Float']>
-  customCss_LONGEST_LENGTH_GT?: InputMaybe<Scalars['Int']>
-  customCss_SHORTEST_LENGTH_GT?: InputMaybe<Scalars['Int']>
+  style_SHORTEST_GT?: InputMaybe<Scalars['Int']>
+  style_AVERAGE_LENGTH_GT?: InputMaybe<Scalars['Float']>
+  style_LONGEST_LENGTH_GT?: InputMaybe<Scalars['Int']>
+  style_SHORTEST_LENGTH_GT?: InputMaybe<Scalars['Int']>
   /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
-  customCss_GTE?: InputMaybe<Scalars['Int']>
+  style_GTE?: InputMaybe<Scalars['Int']>
   /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  customCss_AVERAGE_GTE?: InputMaybe<Scalars['Float']>
+  style_AVERAGE_GTE?: InputMaybe<Scalars['Float']>
   /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  customCss_LONGEST_GTE?: InputMaybe<Scalars['Int']>
+  style_LONGEST_GTE?: InputMaybe<Scalars['Int']>
   /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  customCss_SHORTEST_GTE?: InputMaybe<Scalars['Int']>
-  customCss_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars['Float']>
-  customCss_LONGEST_LENGTH_GTE?: InputMaybe<Scalars['Int']>
-  customCss_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars['Int']>
+  style_SHORTEST_GTE?: InputMaybe<Scalars['Int']>
+  style_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars['Float']>
+  style_LONGEST_LENGTH_GTE?: InputMaybe<Scalars['Int']>
+  style_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars['Int']>
   /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
-  customCss_LT?: InputMaybe<Scalars['Int']>
+  style_LT?: InputMaybe<Scalars['Int']>
   /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  customCss_AVERAGE_LT?: InputMaybe<Scalars['Float']>
+  style_AVERAGE_LT?: InputMaybe<Scalars['Float']>
   /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  customCss_LONGEST_LT?: InputMaybe<Scalars['Int']>
+  style_LONGEST_LT?: InputMaybe<Scalars['Int']>
   /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  customCss_SHORTEST_LT?: InputMaybe<Scalars['Int']>
-  customCss_AVERAGE_LENGTH_LT?: InputMaybe<Scalars['Float']>
-  customCss_LONGEST_LENGTH_LT?: InputMaybe<Scalars['Int']>
-  customCss_SHORTEST_LENGTH_LT?: InputMaybe<Scalars['Int']>
+  style_SHORTEST_LT?: InputMaybe<Scalars['Int']>
+  style_AVERAGE_LENGTH_LT?: InputMaybe<Scalars['Float']>
+  style_LONGEST_LENGTH_LT?: InputMaybe<Scalars['Int']>
+  style_SHORTEST_LENGTH_LT?: InputMaybe<Scalars['Int']>
   /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
-  customCss_LTE?: InputMaybe<Scalars['Int']>
+  style_LTE?: InputMaybe<Scalars['Int']>
   /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  customCss_AVERAGE_LTE?: InputMaybe<Scalars['Float']>
+  style_AVERAGE_LTE?: InputMaybe<Scalars['Float']>
   /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  customCss_LONGEST_LTE?: InputMaybe<Scalars['Int']>
+  style_LONGEST_LTE?: InputMaybe<Scalars['Int']>
   /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  customCss_SHORTEST_LTE?: InputMaybe<Scalars['Int']>
-  customCss_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars['Float']>
-  customCss_LONGEST_LENGTH_LTE?: InputMaybe<Scalars['Int']>
-  customCss_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars['Int']>
-  /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
-  guiCss_EQUAL?: InputMaybe<Scalars['String']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  guiCss_AVERAGE_EQUAL?: InputMaybe<Scalars['Float']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  guiCss_LONGEST_EQUAL?: InputMaybe<Scalars['Int']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  guiCss_SHORTEST_EQUAL?: InputMaybe<Scalars['Int']>
-  guiCss_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars['Float']>
-  guiCss_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars['Int']>
-  guiCss_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars['Int']>
-  /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
-  guiCss_GT?: InputMaybe<Scalars['Int']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  guiCss_AVERAGE_GT?: InputMaybe<Scalars['Float']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  guiCss_LONGEST_GT?: InputMaybe<Scalars['Int']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  guiCss_SHORTEST_GT?: InputMaybe<Scalars['Int']>
-  guiCss_AVERAGE_LENGTH_GT?: InputMaybe<Scalars['Float']>
-  guiCss_LONGEST_LENGTH_GT?: InputMaybe<Scalars['Int']>
-  guiCss_SHORTEST_LENGTH_GT?: InputMaybe<Scalars['Int']>
-  /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
-  guiCss_GTE?: InputMaybe<Scalars['Int']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  guiCss_AVERAGE_GTE?: InputMaybe<Scalars['Float']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  guiCss_LONGEST_GTE?: InputMaybe<Scalars['Int']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  guiCss_SHORTEST_GTE?: InputMaybe<Scalars['Int']>
-  guiCss_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars['Float']>
-  guiCss_LONGEST_LENGTH_GTE?: InputMaybe<Scalars['Int']>
-  guiCss_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars['Int']>
-  /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
-  guiCss_LT?: InputMaybe<Scalars['Int']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  guiCss_AVERAGE_LT?: InputMaybe<Scalars['Float']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  guiCss_LONGEST_LT?: InputMaybe<Scalars['Int']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  guiCss_SHORTEST_LT?: InputMaybe<Scalars['Int']>
-  guiCss_AVERAGE_LENGTH_LT?: InputMaybe<Scalars['Float']>
-  guiCss_LONGEST_LENGTH_LT?: InputMaybe<Scalars['Int']>
-  guiCss_SHORTEST_LENGTH_LT?: InputMaybe<Scalars['Int']>
-  /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
-  guiCss_LTE?: InputMaybe<Scalars['Int']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  guiCss_AVERAGE_LTE?: InputMaybe<Scalars['Float']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  guiCss_LONGEST_LTE?: InputMaybe<Scalars['Int']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  guiCss_SHORTEST_LTE?: InputMaybe<Scalars['Int']>
-  guiCss_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars['Float']>
-  guiCss_LONGEST_LENGTH_LTE?: InputMaybe<Scalars['Int']>
-  guiCss_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars['Int']>
+  style_SHORTEST_LTE?: InputMaybe<Scalars['Int']>
+  style_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars['Float']>
+  style_LONGEST_LENGTH_LTE?: InputMaybe<Scalars['Int']>
+  style_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars['Int']>
   /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
   childMapperPropKey_EQUAL?: InputMaybe<Scalars['String']>
   /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
@@ -25614,115 +24993,60 @@ export type PagePageContentContainerNodeAggregationWhereInput = {
   _compoundName_LONGEST_LENGTH_LTE?: InputMaybe<Scalars['Int']>
   _compoundName_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars['Int']>
   /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
-  customCss_EQUAL?: InputMaybe<Scalars['String']>
+  style_EQUAL?: InputMaybe<Scalars['String']>
   /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  customCss_AVERAGE_EQUAL?: InputMaybe<Scalars['Float']>
+  style_AVERAGE_EQUAL?: InputMaybe<Scalars['Float']>
   /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  customCss_LONGEST_EQUAL?: InputMaybe<Scalars['Int']>
+  style_LONGEST_EQUAL?: InputMaybe<Scalars['Int']>
   /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  customCss_SHORTEST_EQUAL?: InputMaybe<Scalars['Int']>
-  customCss_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars['Float']>
-  customCss_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars['Int']>
-  customCss_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars['Int']>
+  style_SHORTEST_EQUAL?: InputMaybe<Scalars['Int']>
+  style_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars['Float']>
+  style_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars['Int']>
+  style_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars['Int']>
   /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
-  customCss_GT?: InputMaybe<Scalars['Int']>
+  style_GT?: InputMaybe<Scalars['Int']>
   /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  customCss_AVERAGE_GT?: InputMaybe<Scalars['Float']>
+  style_AVERAGE_GT?: InputMaybe<Scalars['Float']>
   /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  customCss_LONGEST_GT?: InputMaybe<Scalars['Int']>
+  style_LONGEST_GT?: InputMaybe<Scalars['Int']>
   /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  customCss_SHORTEST_GT?: InputMaybe<Scalars['Int']>
-  customCss_AVERAGE_LENGTH_GT?: InputMaybe<Scalars['Float']>
-  customCss_LONGEST_LENGTH_GT?: InputMaybe<Scalars['Int']>
-  customCss_SHORTEST_LENGTH_GT?: InputMaybe<Scalars['Int']>
+  style_SHORTEST_GT?: InputMaybe<Scalars['Int']>
+  style_AVERAGE_LENGTH_GT?: InputMaybe<Scalars['Float']>
+  style_LONGEST_LENGTH_GT?: InputMaybe<Scalars['Int']>
+  style_SHORTEST_LENGTH_GT?: InputMaybe<Scalars['Int']>
   /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
-  customCss_GTE?: InputMaybe<Scalars['Int']>
+  style_GTE?: InputMaybe<Scalars['Int']>
   /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  customCss_AVERAGE_GTE?: InputMaybe<Scalars['Float']>
+  style_AVERAGE_GTE?: InputMaybe<Scalars['Float']>
   /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  customCss_LONGEST_GTE?: InputMaybe<Scalars['Int']>
+  style_LONGEST_GTE?: InputMaybe<Scalars['Int']>
   /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  customCss_SHORTEST_GTE?: InputMaybe<Scalars['Int']>
-  customCss_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars['Float']>
-  customCss_LONGEST_LENGTH_GTE?: InputMaybe<Scalars['Int']>
-  customCss_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars['Int']>
+  style_SHORTEST_GTE?: InputMaybe<Scalars['Int']>
+  style_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars['Float']>
+  style_LONGEST_LENGTH_GTE?: InputMaybe<Scalars['Int']>
+  style_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars['Int']>
   /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
-  customCss_LT?: InputMaybe<Scalars['Int']>
+  style_LT?: InputMaybe<Scalars['Int']>
   /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  customCss_AVERAGE_LT?: InputMaybe<Scalars['Float']>
+  style_AVERAGE_LT?: InputMaybe<Scalars['Float']>
   /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  customCss_LONGEST_LT?: InputMaybe<Scalars['Int']>
+  style_LONGEST_LT?: InputMaybe<Scalars['Int']>
   /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  customCss_SHORTEST_LT?: InputMaybe<Scalars['Int']>
-  customCss_AVERAGE_LENGTH_LT?: InputMaybe<Scalars['Float']>
-  customCss_LONGEST_LENGTH_LT?: InputMaybe<Scalars['Int']>
-  customCss_SHORTEST_LENGTH_LT?: InputMaybe<Scalars['Int']>
+  style_SHORTEST_LT?: InputMaybe<Scalars['Int']>
+  style_AVERAGE_LENGTH_LT?: InputMaybe<Scalars['Float']>
+  style_LONGEST_LENGTH_LT?: InputMaybe<Scalars['Int']>
+  style_SHORTEST_LENGTH_LT?: InputMaybe<Scalars['Int']>
   /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
-  customCss_LTE?: InputMaybe<Scalars['Int']>
+  style_LTE?: InputMaybe<Scalars['Int']>
   /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  customCss_AVERAGE_LTE?: InputMaybe<Scalars['Float']>
+  style_AVERAGE_LTE?: InputMaybe<Scalars['Float']>
   /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  customCss_LONGEST_LTE?: InputMaybe<Scalars['Int']>
+  style_LONGEST_LTE?: InputMaybe<Scalars['Int']>
   /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  customCss_SHORTEST_LTE?: InputMaybe<Scalars['Int']>
-  customCss_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars['Float']>
-  customCss_LONGEST_LENGTH_LTE?: InputMaybe<Scalars['Int']>
-  customCss_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars['Int']>
-  /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
-  guiCss_EQUAL?: InputMaybe<Scalars['String']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  guiCss_AVERAGE_EQUAL?: InputMaybe<Scalars['Float']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  guiCss_LONGEST_EQUAL?: InputMaybe<Scalars['Int']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  guiCss_SHORTEST_EQUAL?: InputMaybe<Scalars['Int']>
-  guiCss_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars['Float']>
-  guiCss_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars['Int']>
-  guiCss_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars['Int']>
-  /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
-  guiCss_GT?: InputMaybe<Scalars['Int']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  guiCss_AVERAGE_GT?: InputMaybe<Scalars['Float']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  guiCss_LONGEST_GT?: InputMaybe<Scalars['Int']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  guiCss_SHORTEST_GT?: InputMaybe<Scalars['Int']>
-  guiCss_AVERAGE_LENGTH_GT?: InputMaybe<Scalars['Float']>
-  guiCss_LONGEST_LENGTH_GT?: InputMaybe<Scalars['Int']>
-  guiCss_SHORTEST_LENGTH_GT?: InputMaybe<Scalars['Int']>
-  /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
-  guiCss_GTE?: InputMaybe<Scalars['Int']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  guiCss_AVERAGE_GTE?: InputMaybe<Scalars['Float']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  guiCss_LONGEST_GTE?: InputMaybe<Scalars['Int']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  guiCss_SHORTEST_GTE?: InputMaybe<Scalars['Int']>
-  guiCss_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars['Float']>
-  guiCss_LONGEST_LENGTH_GTE?: InputMaybe<Scalars['Int']>
-  guiCss_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars['Int']>
-  /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
-  guiCss_LT?: InputMaybe<Scalars['Int']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  guiCss_AVERAGE_LT?: InputMaybe<Scalars['Float']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  guiCss_LONGEST_LT?: InputMaybe<Scalars['Int']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  guiCss_SHORTEST_LT?: InputMaybe<Scalars['Int']>
-  guiCss_AVERAGE_LENGTH_LT?: InputMaybe<Scalars['Float']>
-  guiCss_LONGEST_LENGTH_LT?: InputMaybe<Scalars['Int']>
-  guiCss_SHORTEST_LENGTH_LT?: InputMaybe<Scalars['Int']>
-  /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
-  guiCss_LTE?: InputMaybe<Scalars['Int']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  guiCss_AVERAGE_LTE?: InputMaybe<Scalars['Float']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  guiCss_LONGEST_LTE?: InputMaybe<Scalars['Int']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  guiCss_SHORTEST_LTE?: InputMaybe<Scalars['Int']>
-  guiCss_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars['Float']>
-  guiCss_LONGEST_LENGTH_LTE?: InputMaybe<Scalars['Int']>
-  guiCss_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars['Int']>
+  style_SHORTEST_LTE?: InputMaybe<Scalars['Int']>
+  style_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars['Float']>
+  style_LONGEST_LENGTH_LTE?: InputMaybe<Scalars['Int']>
+  style_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars['Int']>
   /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
   childMapperPropKey_EQUAL?: InputMaybe<Scalars['String']>
   /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
@@ -26034,115 +25358,60 @@ export type PageRootElementNodeAggregationWhereInput = {
   _compoundName_LONGEST_LENGTH_LTE?: InputMaybe<Scalars['Int']>
   _compoundName_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars['Int']>
   /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
-  customCss_EQUAL?: InputMaybe<Scalars['String']>
+  style_EQUAL?: InputMaybe<Scalars['String']>
   /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  customCss_AVERAGE_EQUAL?: InputMaybe<Scalars['Float']>
+  style_AVERAGE_EQUAL?: InputMaybe<Scalars['Float']>
   /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  customCss_LONGEST_EQUAL?: InputMaybe<Scalars['Int']>
+  style_LONGEST_EQUAL?: InputMaybe<Scalars['Int']>
   /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  customCss_SHORTEST_EQUAL?: InputMaybe<Scalars['Int']>
-  customCss_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars['Float']>
-  customCss_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars['Int']>
-  customCss_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars['Int']>
+  style_SHORTEST_EQUAL?: InputMaybe<Scalars['Int']>
+  style_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars['Float']>
+  style_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars['Int']>
+  style_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars['Int']>
   /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
-  customCss_GT?: InputMaybe<Scalars['Int']>
+  style_GT?: InputMaybe<Scalars['Int']>
   /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  customCss_AVERAGE_GT?: InputMaybe<Scalars['Float']>
+  style_AVERAGE_GT?: InputMaybe<Scalars['Float']>
   /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  customCss_LONGEST_GT?: InputMaybe<Scalars['Int']>
+  style_LONGEST_GT?: InputMaybe<Scalars['Int']>
   /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  customCss_SHORTEST_GT?: InputMaybe<Scalars['Int']>
-  customCss_AVERAGE_LENGTH_GT?: InputMaybe<Scalars['Float']>
-  customCss_LONGEST_LENGTH_GT?: InputMaybe<Scalars['Int']>
-  customCss_SHORTEST_LENGTH_GT?: InputMaybe<Scalars['Int']>
+  style_SHORTEST_GT?: InputMaybe<Scalars['Int']>
+  style_AVERAGE_LENGTH_GT?: InputMaybe<Scalars['Float']>
+  style_LONGEST_LENGTH_GT?: InputMaybe<Scalars['Int']>
+  style_SHORTEST_LENGTH_GT?: InputMaybe<Scalars['Int']>
   /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
-  customCss_GTE?: InputMaybe<Scalars['Int']>
+  style_GTE?: InputMaybe<Scalars['Int']>
   /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  customCss_AVERAGE_GTE?: InputMaybe<Scalars['Float']>
+  style_AVERAGE_GTE?: InputMaybe<Scalars['Float']>
   /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  customCss_LONGEST_GTE?: InputMaybe<Scalars['Int']>
+  style_LONGEST_GTE?: InputMaybe<Scalars['Int']>
   /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  customCss_SHORTEST_GTE?: InputMaybe<Scalars['Int']>
-  customCss_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars['Float']>
-  customCss_LONGEST_LENGTH_GTE?: InputMaybe<Scalars['Int']>
-  customCss_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars['Int']>
+  style_SHORTEST_GTE?: InputMaybe<Scalars['Int']>
+  style_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars['Float']>
+  style_LONGEST_LENGTH_GTE?: InputMaybe<Scalars['Int']>
+  style_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars['Int']>
   /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
-  customCss_LT?: InputMaybe<Scalars['Int']>
+  style_LT?: InputMaybe<Scalars['Int']>
   /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  customCss_AVERAGE_LT?: InputMaybe<Scalars['Float']>
+  style_AVERAGE_LT?: InputMaybe<Scalars['Float']>
   /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  customCss_LONGEST_LT?: InputMaybe<Scalars['Int']>
+  style_LONGEST_LT?: InputMaybe<Scalars['Int']>
   /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  customCss_SHORTEST_LT?: InputMaybe<Scalars['Int']>
-  customCss_AVERAGE_LENGTH_LT?: InputMaybe<Scalars['Float']>
-  customCss_LONGEST_LENGTH_LT?: InputMaybe<Scalars['Int']>
-  customCss_SHORTEST_LENGTH_LT?: InputMaybe<Scalars['Int']>
+  style_SHORTEST_LT?: InputMaybe<Scalars['Int']>
+  style_AVERAGE_LENGTH_LT?: InputMaybe<Scalars['Float']>
+  style_LONGEST_LENGTH_LT?: InputMaybe<Scalars['Int']>
+  style_SHORTEST_LENGTH_LT?: InputMaybe<Scalars['Int']>
   /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
-  customCss_LTE?: InputMaybe<Scalars['Int']>
+  style_LTE?: InputMaybe<Scalars['Int']>
   /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  customCss_AVERAGE_LTE?: InputMaybe<Scalars['Float']>
+  style_AVERAGE_LTE?: InputMaybe<Scalars['Float']>
   /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  customCss_LONGEST_LTE?: InputMaybe<Scalars['Int']>
+  style_LONGEST_LTE?: InputMaybe<Scalars['Int']>
   /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  customCss_SHORTEST_LTE?: InputMaybe<Scalars['Int']>
-  customCss_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars['Float']>
-  customCss_LONGEST_LENGTH_LTE?: InputMaybe<Scalars['Int']>
-  customCss_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars['Int']>
-  /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
-  guiCss_EQUAL?: InputMaybe<Scalars['String']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  guiCss_AVERAGE_EQUAL?: InputMaybe<Scalars['Float']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  guiCss_LONGEST_EQUAL?: InputMaybe<Scalars['Int']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  guiCss_SHORTEST_EQUAL?: InputMaybe<Scalars['Int']>
-  guiCss_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars['Float']>
-  guiCss_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars['Int']>
-  guiCss_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars['Int']>
-  /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
-  guiCss_GT?: InputMaybe<Scalars['Int']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  guiCss_AVERAGE_GT?: InputMaybe<Scalars['Float']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  guiCss_LONGEST_GT?: InputMaybe<Scalars['Int']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  guiCss_SHORTEST_GT?: InputMaybe<Scalars['Int']>
-  guiCss_AVERAGE_LENGTH_GT?: InputMaybe<Scalars['Float']>
-  guiCss_LONGEST_LENGTH_GT?: InputMaybe<Scalars['Int']>
-  guiCss_SHORTEST_LENGTH_GT?: InputMaybe<Scalars['Int']>
-  /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
-  guiCss_GTE?: InputMaybe<Scalars['Int']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  guiCss_AVERAGE_GTE?: InputMaybe<Scalars['Float']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  guiCss_LONGEST_GTE?: InputMaybe<Scalars['Int']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  guiCss_SHORTEST_GTE?: InputMaybe<Scalars['Int']>
-  guiCss_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars['Float']>
-  guiCss_LONGEST_LENGTH_GTE?: InputMaybe<Scalars['Int']>
-  guiCss_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars['Int']>
-  /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
-  guiCss_LT?: InputMaybe<Scalars['Int']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  guiCss_AVERAGE_LT?: InputMaybe<Scalars['Float']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  guiCss_LONGEST_LT?: InputMaybe<Scalars['Int']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  guiCss_SHORTEST_LT?: InputMaybe<Scalars['Int']>
-  guiCss_AVERAGE_LENGTH_LT?: InputMaybe<Scalars['Float']>
-  guiCss_LONGEST_LENGTH_LT?: InputMaybe<Scalars['Int']>
-  guiCss_SHORTEST_LENGTH_LT?: InputMaybe<Scalars['Int']>
-  /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
-  guiCss_LTE?: InputMaybe<Scalars['Int']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  guiCss_AVERAGE_LTE?: InputMaybe<Scalars['Float']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  guiCss_LONGEST_LTE?: InputMaybe<Scalars['Int']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  guiCss_SHORTEST_LTE?: InputMaybe<Scalars['Int']>
-  guiCss_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars['Float']>
-  guiCss_LONGEST_LENGTH_LTE?: InputMaybe<Scalars['Int']>
-  guiCss_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars['Int']>
+  style_SHORTEST_LTE?: InputMaybe<Scalars['Int']>
+  style_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars['Float']>
+  style_LONGEST_LENGTH_LTE?: InputMaybe<Scalars['Int']>
+  style_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars['Int']>
   /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
   childMapperPropKey_EQUAL?: InputMaybe<Scalars['String']>
   /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
@@ -32750,115 +32019,60 @@ export type UserElementsNodeAggregationWhereInput = {
   _compoundName_LONGEST_LENGTH_LTE?: InputMaybe<Scalars['Int']>
   _compoundName_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars['Int']>
   /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
-  customCss_EQUAL?: InputMaybe<Scalars['String']>
+  style_EQUAL?: InputMaybe<Scalars['String']>
   /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  customCss_AVERAGE_EQUAL?: InputMaybe<Scalars['Float']>
+  style_AVERAGE_EQUAL?: InputMaybe<Scalars['Float']>
   /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  customCss_LONGEST_EQUAL?: InputMaybe<Scalars['Int']>
+  style_LONGEST_EQUAL?: InputMaybe<Scalars['Int']>
   /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  customCss_SHORTEST_EQUAL?: InputMaybe<Scalars['Int']>
-  customCss_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars['Float']>
-  customCss_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars['Int']>
-  customCss_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars['Int']>
+  style_SHORTEST_EQUAL?: InputMaybe<Scalars['Int']>
+  style_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars['Float']>
+  style_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars['Int']>
+  style_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars['Int']>
   /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
-  customCss_GT?: InputMaybe<Scalars['Int']>
+  style_GT?: InputMaybe<Scalars['Int']>
   /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  customCss_AVERAGE_GT?: InputMaybe<Scalars['Float']>
+  style_AVERAGE_GT?: InputMaybe<Scalars['Float']>
   /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  customCss_LONGEST_GT?: InputMaybe<Scalars['Int']>
+  style_LONGEST_GT?: InputMaybe<Scalars['Int']>
   /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  customCss_SHORTEST_GT?: InputMaybe<Scalars['Int']>
-  customCss_AVERAGE_LENGTH_GT?: InputMaybe<Scalars['Float']>
-  customCss_LONGEST_LENGTH_GT?: InputMaybe<Scalars['Int']>
-  customCss_SHORTEST_LENGTH_GT?: InputMaybe<Scalars['Int']>
+  style_SHORTEST_GT?: InputMaybe<Scalars['Int']>
+  style_AVERAGE_LENGTH_GT?: InputMaybe<Scalars['Float']>
+  style_LONGEST_LENGTH_GT?: InputMaybe<Scalars['Int']>
+  style_SHORTEST_LENGTH_GT?: InputMaybe<Scalars['Int']>
   /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
-  customCss_GTE?: InputMaybe<Scalars['Int']>
+  style_GTE?: InputMaybe<Scalars['Int']>
   /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  customCss_AVERAGE_GTE?: InputMaybe<Scalars['Float']>
+  style_AVERAGE_GTE?: InputMaybe<Scalars['Float']>
   /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  customCss_LONGEST_GTE?: InputMaybe<Scalars['Int']>
+  style_LONGEST_GTE?: InputMaybe<Scalars['Int']>
   /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  customCss_SHORTEST_GTE?: InputMaybe<Scalars['Int']>
-  customCss_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars['Float']>
-  customCss_LONGEST_LENGTH_GTE?: InputMaybe<Scalars['Int']>
-  customCss_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars['Int']>
+  style_SHORTEST_GTE?: InputMaybe<Scalars['Int']>
+  style_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars['Float']>
+  style_LONGEST_LENGTH_GTE?: InputMaybe<Scalars['Int']>
+  style_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars['Int']>
   /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
-  customCss_LT?: InputMaybe<Scalars['Int']>
+  style_LT?: InputMaybe<Scalars['Int']>
   /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  customCss_AVERAGE_LT?: InputMaybe<Scalars['Float']>
+  style_AVERAGE_LT?: InputMaybe<Scalars['Float']>
   /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  customCss_LONGEST_LT?: InputMaybe<Scalars['Int']>
+  style_LONGEST_LT?: InputMaybe<Scalars['Int']>
   /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  customCss_SHORTEST_LT?: InputMaybe<Scalars['Int']>
-  customCss_AVERAGE_LENGTH_LT?: InputMaybe<Scalars['Float']>
-  customCss_LONGEST_LENGTH_LT?: InputMaybe<Scalars['Int']>
-  customCss_SHORTEST_LENGTH_LT?: InputMaybe<Scalars['Int']>
+  style_SHORTEST_LT?: InputMaybe<Scalars['Int']>
+  style_AVERAGE_LENGTH_LT?: InputMaybe<Scalars['Float']>
+  style_LONGEST_LENGTH_LT?: InputMaybe<Scalars['Int']>
+  style_SHORTEST_LENGTH_LT?: InputMaybe<Scalars['Int']>
   /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
-  customCss_LTE?: InputMaybe<Scalars['Int']>
+  style_LTE?: InputMaybe<Scalars['Int']>
   /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  customCss_AVERAGE_LTE?: InputMaybe<Scalars['Float']>
+  style_AVERAGE_LTE?: InputMaybe<Scalars['Float']>
   /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  customCss_LONGEST_LTE?: InputMaybe<Scalars['Int']>
+  style_LONGEST_LTE?: InputMaybe<Scalars['Int']>
   /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  customCss_SHORTEST_LTE?: InputMaybe<Scalars['Int']>
-  customCss_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars['Float']>
-  customCss_LONGEST_LENGTH_LTE?: InputMaybe<Scalars['Int']>
-  customCss_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars['Int']>
-  /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
-  guiCss_EQUAL?: InputMaybe<Scalars['String']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  guiCss_AVERAGE_EQUAL?: InputMaybe<Scalars['Float']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  guiCss_LONGEST_EQUAL?: InputMaybe<Scalars['Int']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  guiCss_SHORTEST_EQUAL?: InputMaybe<Scalars['Int']>
-  guiCss_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars['Float']>
-  guiCss_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars['Int']>
-  guiCss_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars['Int']>
-  /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
-  guiCss_GT?: InputMaybe<Scalars['Int']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  guiCss_AVERAGE_GT?: InputMaybe<Scalars['Float']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  guiCss_LONGEST_GT?: InputMaybe<Scalars['Int']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  guiCss_SHORTEST_GT?: InputMaybe<Scalars['Int']>
-  guiCss_AVERAGE_LENGTH_GT?: InputMaybe<Scalars['Float']>
-  guiCss_LONGEST_LENGTH_GT?: InputMaybe<Scalars['Int']>
-  guiCss_SHORTEST_LENGTH_GT?: InputMaybe<Scalars['Int']>
-  /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
-  guiCss_GTE?: InputMaybe<Scalars['Int']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  guiCss_AVERAGE_GTE?: InputMaybe<Scalars['Float']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  guiCss_LONGEST_GTE?: InputMaybe<Scalars['Int']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  guiCss_SHORTEST_GTE?: InputMaybe<Scalars['Int']>
-  guiCss_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars['Float']>
-  guiCss_LONGEST_LENGTH_GTE?: InputMaybe<Scalars['Int']>
-  guiCss_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars['Int']>
-  /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
-  guiCss_LT?: InputMaybe<Scalars['Int']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  guiCss_AVERAGE_LT?: InputMaybe<Scalars['Float']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  guiCss_LONGEST_LT?: InputMaybe<Scalars['Int']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  guiCss_SHORTEST_LT?: InputMaybe<Scalars['Int']>
-  guiCss_AVERAGE_LENGTH_LT?: InputMaybe<Scalars['Float']>
-  guiCss_LONGEST_LENGTH_LT?: InputMaybe<Scalars['Int']>
-  guiCss_SHORTEST_LENGTH_LT?: InputMaybe<Scalars['Int']>
-  /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
-  guiCss_LTE?: InputMaybe<Scalars['Int']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  guiCss_AVERAGE_LTE?: InputMaybe<Scalars['Float']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  guiCss_LONGEST_LTE?: InputMaybe<Scalars['Int']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  guiCss_SHORTEST_LTE?: InputMaybe<Scalars['Int']>
-  guiCss_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars['Float']>
-  guiCss_LONGEST_LENGTH_LTE?: InputMaybe<Scalars['Int']>
-  guiCss_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars['Int']>
+  style_SHORTEST_LTE?: InputMaybe<Scalars['Int']>
+  style_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars['Float']>
+  style_LONGEST_LENGTH_LTE?: InputMaybe<Scalars['Int']>
+  style_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars['Int']>
   /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
   childMapperPropKey_EQUAL?: InputMaybe<Scalars['String']>
   /** @deprecated Please use the explicit _LENGTH version for string aggregation. */

--- a/libs/backend/domain/element/src/model/element.model.ts
+++ b/libs/backend/domain/element/src/model/element.model.ts
@@ -12,11 +12,9 @@ export class Element implements IElementDTO {
 
   childMapperPropKey?: Nullable<string> | undefined
 
-  customCss?: Nullable<string> | undefined
+  style?: Nullable<string> | undefined
 
   firstChild?: IEntity | null | undefined
-
-  guiCss?: Nullable<string> | undefined
 
   id: string
 

--- a/libs/backend/domain/element/src/repository/element.repo.old.ts
+++ b/libs/backend/domain/element/src/repository/element.repo.old.ts
@@ -49,8 +49,6 @@ export const importElementInitial = async (
             element.childMapperPreviousSibling?.id,
           ),
           childMapperPropKey: element.childMapperPropKey,
-          customCss: element.customCss,
-          guiCss: element.guiCss,
           id: element.id,
           postRenderAction: connectNodeId(element.postRenderAction?.id),
           preRenderAction: connectNodeId(element.preRenderAction?.id),
@@ -75,6 +73,7 @@ export const importElementInitial = async (
             : undefined,
           renderForEachPropKey: element.renderForEachPropKey,
           renderIfExpression: element.renderIfExpression,
+          style: element.style,
         },
       ],
     })

--- a/libs/backend/infra/adapter/neo4j/src/schema/model/element.schema.ts
+++ b/libs/backend/infra/adapter/neo4j/src/schema/model/element.schema.ts
@@ -30,12 +30,10 @@ export const elementSchema = gql`
     # element is the rootElement for this component
     parentComponent: Component
       @relationship(type: "COMPONENT_ROOT", direction: IN)
-    # Used for the css the user types it manually using the integrated code editor. This is
-    # a pure css string.
-    customCss: String
-    # Used for the css set by the styling UI. This is a stringified json object of the form:
-    # {[prop: string]: string}, where the prop is a css property and the value is its value.
-    guiCss: String
+    # Used for the css set by the styling UI and manually. This is a stringified json object
+    # that contains styles for different screen size breakpoints.
+    # See interface for more details: IElementStyle
+    style: String
     childMapperPropKey: String
     childMapperComponent: Component
       @relationship(type: "CHILD_MAPPER_COMPONENT", direction: OUT)

--- a/libs/backend/infra/adapter/neo4j/src/selectionSet/element-selection-set.ts
+++ b/libs/backend/infra/adapter/neo4j/src/selectionSet/element-selection-set.ts
@@ -5,8 +5,7 @@ const baseElementSelectionSet = `
   id
   name
   _compoundName
-  customCss
-  guiCss
+  style
   parentComponent {
     id
     name

--- a/libs/frontend/abstract/core/src/domain/builder/builder.interface.ts
+++ b/libs/frontend/abstract/core/src/domain/builder/builder.interface.ts
@@ -46,7 +46,7 @@ export const defaultBuilderWidthBreakPoints: Record<
   BuilderWidth
 > = {
   [BuilderWidthBreakPoint.MobilePortrait]: {
-    default: 320,
+    default: 360,
     max: 479,
     min: 240,
   },

--- a/libs/frontend/abstract/core/src/domain/builder/builder.service.interface.ts
+++ b/libs/frontend/abstract/core/src/domain/builder/builder.service.interface.ts
@@ -5,7 +5,11 @@ import type { IComponent } from '../component'
 import type { IElement, IElementTree } from '../element'
 import type { IPageNodeRef } from '../page'
 import type { RendererTab } from '../render'
-import type { BuilderDragData, BuilderWidth } from './builder.interface'
+import type {
+  BuilderDragData,
+  BuilderWidth,
+  BuilderWidthBreakPoint,
+} from './builder.interface'
 // TBC: | IComponent
 export type IBuilderComponent = IAtom & {
   // tag: Ref<ITag>
@@ -34,7 +38,7 @@ export interface IBuilderService {
   expandedComponentTreeNodeIds: Array<string>
   expandedPageElementTreeNodeIds: Array<string>
   hoveredNode: Nullable<IPageNodeRef>
-  selectedBuilderWidth: BuilderWidth
+  selectedBuilderBreakpoint: BuilderWidthBreakPoint
   selectedNode: Nullable<IPageNodeRef>
 
   selectComponentNode(node: Nullable<IComponent>): void
@@ -46,6 +50,6 @@ export interface IBuilderService {
   setExpandedComponentTreeNodeIds(expandedNodeIds: Array<string>): void
   setExpandedPageElementTreeNodeIds(expandedNodeIds: Array<string>): void
   setHoveredNode(element: Nullable<IPageNodeRef>): void
-  setSelectedBuilderWidth(width: Nullable<BuilderWidth>): void
+  setSelectedBuilderBreakpoint(width: Nullable<BuilderWidthBreakPoint>): void
   setSelectedNode(node: Nullable<IPageNodeRef>): void
 }

--- a/libs/frontend/abstract/core/src/domain/builder/builder.service.interface.ts
+++ b/libs/frontend/abstract/core/src/domain/builder/builder.service.interface.ts
@@ -27,23 +27,23 @@ export interface IBuilderService {
   builderContainerWidth: number
   componentTagNames: Array<string>
   componentsGroupedByCategory: Record<string, Array<IBuilderComponent>>
-  currentBuilderWidth: BuilderWidth
   currentDragData: Nullable<Frozen<BuilderDragData>>
   expandedComponentTreeNodeIds: Array<string>
   expandedPageElementTreeNodeIds: Array<string>
   hoveredNode: Nullable<IPageNodeRef>
   selectedBuilderBreakpoint: BuilderWidthBreakPoint
+  selectedBuilderWidth: BuilderWidth
   selectedNode: Nullable<IPageNodeRef>
 
   selectComponentNode(node: Nullable<IComponent>): void
   selectElementNode(node: Nullable<IElement>): void
   setActiveTab(tab: RendererTab): void
   setBuilderContainerWidth(width: number): void
-  setCurrentBuilderWidth(width: Nullable<BuilderWidth>): void
   setCurrentDragData(data: Nullable<Frozen<BuilderDragData>>): void
   setExpandedComponentTreeNodeIds(expandedNodeIds: Array<string>): void
   setExpandedPageElementTreeNodeIds(expandedNodeIds: Array<string>): void
   setHoveredNode(element: Nullable<IPageNodeRef>): void
   setSelectedBuilderBreakpoint(width: Nullable<BuilderWidthBreakPoint>): void
+  setSelectedBuilderWidth(width: Nullable<BuilderWidth>): void
   setSelectedNode(node: Nullable<IPageNodeRef>): void
 }

--- a/libs/frontend/abstract/core/src/domain/builder/builder.service.interface.ts
+++ b/libs/frontend/abstract/core/src/domain/builder/builder.service.interface.ts
@@ -27,12 +27,6 @@ export interface IBuilderService {
   builderContainerWidth: number
   componentTagNames: Array<string>
   componentsGroupedByCategory: Record<string, Array<IBuilderComponent>>
-  /**
-   * The difference between current and selected builderWidth is that
-   * - currentBuilderWidth is changed by useBuilderResize
-   * - selectedBuilderWidth is changed by PageDetailHeader and
-   * is being listened to by useBuilderResize
-   */
   currentBuilderWidth: BuilderWidth
   currentDragData: Nullable<Frozen<BuilderDragData>>
   expandedComponentTreeNodeIds: Array<string>

--- a/libs/frontend/abstract/core/src/domain/element/element.dto.interface.ts
+++ b/libs/frontend/abstract/core/src/domain/element/element.dto.interface.ts
@@ -2,8 +2,6 @@ import type { IPropDTO, RenderType } from '@codelab/shared/abstract/core'
 import type { IEntity, Nullable, Nullish } from '@codelab/shared/abstract/types'
 
 export interface ICreateElementData {
-  customCss?: Nullable<string>
-  guiCss?: Nullable<string>
   id: string
   name: string
   parentElement?: Nullable<IEntity>
@@ -15,16 +13,16 @@ export interface ICreateElementData {
    * We should connect to `atom` or `component` in future
    */
   renderType?: Nullable<RenderType>
+  style?: Nullable<string>
 }
 
 export type IUpdateElementData = Pick<
   ICreateElementData,
-  | 'customCss'
-  | 'guiCss'
   | 'name'
   | 'postRenderAction'
   | 'preRenderAction'
   | 'renderType'
+  | 'style'
 > &
   Pick<ICreateElementData, 'id'> & {
     childMapperComponent?: Nullish<IEntity>

--- a/libs/frontend/abstract/core/src/domain/element/element.fragment.graphql
+++ b/libs/frontend/abstract/core/src/domain/element/element.fragment.graphql
@@ -2,8 +2,7 @@ fragment Element on Element {
   __typename
   id
   name
-  customCss
-  guiCss
+  style
   page {
     id
   }
@@ -60,8 +59,7 @@ fragment ProductionElement on Element {
   __typename
   id
   name
-  customCss
-  guiCss
+  style
   page {
     id
   }

--- a/libs/frontend/abstract/core/src/domain/element/element.fragment.graphql.gen.ts
+++ b/libs/frontend/abstract/core/src/domain/element/element.fragment.graphql.gen.ts
@@ -48,8 +48,7 @@ export type ProductionElementFragment = {
   __typename: 'Element'
   id: string
   name: string
-  customCss?: string | null
-  guiCss?: string | null
+  style?: string | null
   childMapperPropKey?: string | null
   renderForEachPropKey?: string | null
   renderIfExpression?: string | null
@@ -80,8 +79,7 @@ export const ElementFragmentDoc = gql`
     __typename
     id
     name
-    customCss
-    guiCss
+    style
     page {
       id
     }
@@ -140,8 +138,7 @@ export const ProductionElementFragmentDoc = gql`
     __typename
     id
     name
-    customCss
-    guiCss
+    style
     page {
       id
     }

--- a/libs/frontend/abstract/core/src/domain/element/element.fragment.graphql.gen.ts
+++ b/libs/frontend/abstract/core/src/domain/element/element.fragment.graphql.gen.ts
@@ -17,8 +17,7 @@ export type ElementFragment = {
   __typename: 'Element'
   id: string
   name: string
-  customCss?: string | null
-  guiCss?: string | null
+  style?: string | null
   childMapperPropKey?: string | null
   renderForEachPropKey?: string | null
   renderIfExpression?: string | null

--- a/libs/frontend/abstract/core/src/domain/element/element.model.interface.ts
+++ b/libs/frontend/abstract/core/src/domain/element/element.model.interface.ts
@@ -132,8 +132,17 @@ export interface IElement
   sourceElement: Nullable<IEntity>
   // store attached to closestContainerNode
   store: Ref<IStore>
+  /**
+   * stringified object, see @IElementStyle interface
+   * to see what is the shape of parsed object
+   */
   style?: Nullable<string>
-  styleCss: string
+  /**
+   * html-ready string that includes styles for all breakpoints
+   * for production - uses media queries to apply styles
+   * for development - uses container queries, for better UX
+   */
+  styleStringWithBreakpoints: string
   treeViewNode: IElementTreeViewDataNode
   urlProps?: IPropData
 

--- a/libs/frontend/abstract/core/src/domain/element/element.model.interface.ts
+++ b/libs/frontend/abstract/core/src/domain/element/element.model.interface.ts
@@ -13,6 +13,7 @@ import type { Ref } from 'mobx-keystone'
 import type { ICacheService } from '../../service'
 import type { IElementTreeViewDataNode } from '../../ui'
 import type { IAction } from '../action'
+import type { BuilderWidthBreakPoint } from '../builder'
 import type { IComponent } from '../component'
 import type { IHook } from '../hook'
 import type { IModel } from '../model.interface'
@@ -61,6 +62,16 @@ export interface IEvaluationContext {
   url: IPropData
 }
 
+export interface IBreakpointStyle {
+  cssString?: string
+  guiString?: string
+}
+
+export type IElementStyle = Record<
+  BuilderWidthBreakPoint,
+  IBreakpointStyle | undefined
+>
+
 export interface IElement
   extends Omit<
       IModel<ElementCreateInput, ElementUpdateInput, void>,
@@ -78,13 +89,11 @@ export interface IElement
   closestParent: IElement | null
   // the closest rootElement of node (page/component) that element belongs to
   closestRootElement: IElement
-  customCss?: Nullable<string>
   // This is a computed property, so we can use model instead of ref
   descendantElements: Array<IElement>
   // used for expressions evaluation
   expressionEvaluationContext: IEvaluationContext
   firstChild?: Nullable<Ref<IElement>>
-  guiCss?: Nullable<string>
   hooks: Array<IHook>
   id: string
   isRoot: boolean
@@ -121,19 +130,25 @@ export interface IElement
   sourceElement: Nullable<IEntity>
   // store attached to closestContainerNode
   store: Ref<IStore>
+  style?: Nullable<string>
+  styleCss: string
+  styleParsed: IElementStyle
   treeViewNode: IElementTreeViewDataNode
   urlProps?: IPropData
 
-  appendToGuiCss(css: CssMap): void
+  appendToGuiCss(css: CssMap, breakpoint: BuilderWidthBreakPoint): void
   attachAsNextSibling(sibling: IElement): void
   attachAsPrevSibling(sibling: IElement): void
   attachToParentAsFirstChild(parentElement: IElement): void
   clone(): IElement
   connectPrevToNextSibling(): void
-  deleteFromGuiCss(propNames: Array<string>): void
+  deleteFromGuiCss(
+    propNames: Array<string>,
+    breakpoint: BuilderWidthBreakPoint,
+  ): void
   detachAsFirstChild(): void
   detachFromParent(): void
-  setCustomCss(css: string): void
+  setCustomCss(css: string, breakpoint: BuilderWidthBreakPoint): void
   setFirstChild(firstChild: Ref<IElement>): void
   setName(name: string): void
   setNextSibling(nextSibling: Ref<IElement>): void

--- a/libs/frontend/abstract/core/src/domain/element/element.model.interface.ts
+++ b/libs/frontend/abstract/core/src/domain/element/element.model.interface.ts
@@ -134,23 +134,19 @@ export interface IElement
   store: Ref<IStore>
   style?: Nullable<string>
   styleCss: string
-  styleParsed: IElementStyle
   treeViewNode: IElementTreeViewDataNode
   urlProps?: IPropData
 
-  appendToGuiCss(css: CssMap, breakpoint: BuilderWidthBreakPoint): void
+  appendToGuiCss(css: CssMap): void
   attachAsNextSibling(sibling: IElement): void
   attachAsPrevSibling(sibling: IElement): void
   attachToParentAsFirstChild(parentElement: IElement): void
   clone(): IElement
   connectPrevToNextSibling(): void
-  deleteFromGuiCss(
-    propNames: Array<string>,
-    breakpoint: BuilderWidthBreakPoint,
-  ): void
+  deleteFromGuiCss(propNames: Array<string>): void
   detachAsFirstChild(): void
   detachFromParent(): void
-  setCustomCss(css: string, breakpoint: BuilderWidthBreakPoint): void
+  setCustomCss(css: string): void
   setFirstChild(firstChild: Ref<IElement>): void
   setName(name: string): void
   setNextSibling(nextSibling: Ref<IElement>): void

--- a/libs/frontend/abstract/core/src/domain/element/element.model.interface.ts
+++ b/libs/frontend/abstract/core/src/domain/element/element.model.interface.ts
@@ -89,11 +89,13 @@ export interface IElement
   closestParent: IElement | null
   // the closest rootElement of node (page/component) that element belongs to
   closestRootElement: IElement
+  customCss?: Nullable<string>
   // This is a computed property, so we can use model instead of ref
   descendantElements: Array<IElement>
   // used for expressions evaluation
   expressionEvaluationContext: IEvaluationContext
   firstChild?: Nullable<Ref<IElement>>
+  guiCss?: Nullable<string>
   hooks: Array<IHook>
   id: string
   isRoot: boolean

--- a/libs/frontend/abstract/core/src/domain/element/element.model.interface.ts
+++ b/libs/frontend/abstract/core/src/domain/element/element.model.interface.ts
@@ -72,6 +72,10 @@ export type IElementStyle = Record<
   IBreakpointStyle | undefined
 >
 
+export interface ElementCssRules {
+  [key: string]: ElementCssRules | string
+}
+
 export interface IElement
   extends Omit<
       IModel<ElementCreateInput, ElementUpdateInput, void>,
@@ -143,6 +147,16 @@ export interface IElement
    * for development - uses container queries, for better UX
    */
   styleStringWithBreakpoints: string
+  /**
+   * styles that are inherited from other breakpoints,
+   * for example, if we have a style for mobile, it will be inherited
+   * for desktop, and this prop will display the inherited styles
+   * when we edit the desktop breakpoint
+   */
+  stylesInheritedFromOtherBreakpoints: {
+    currentStyles: ElementCssRules
+    inheritedStyles: ElementCssRules
+  }
   treeViewNode: IElementTreeViewDataNode
   urlProps?: IPropData
 

--- a/libs/frontend/domain/builder/src/hooks/useBuilderResize.hook.ts
+++ b/libs/frontend/domain/builder/src/hooks/useBuilderResize.hook.ts
@@ -6,7 +6,7 @@ import type { MotionProps, MotionValue, PanInfo } from 'framer-motion'
 import { useMotionValue } from 'framer-motion'
 import { useCallback, useEffect, useState } from 'react'
 
-type UseBuilderDragInput = Pick<IBuilderService, 'setCurrentBuilderWidth'> & {
+type UseBuilderDragInput = Pick<IBuilderService, 'setSelectedBuilderWidth'> & {
   selectedWidth: BuilderWidth
   width?: BuilderWidth
 }
@@ -50,7 +50,7 @@ const clampSet = (
 
 export const useBuilderResize = ({
   selectedWidth,
-  setCurrentBuilderWidth,
+  setSelectedBuilderWidth,
   width,
 }: UseBuilderDragInput): UseBuilderResize => {
   const [isDragging, setIsDragging] = useState(false)
@@ -61,10 +61,10 @@ export const useBuilderResize = ({
       clampSet(mWidth, info.delta.x, selectedWidth)
 
       const roundedWidth = Math.round(mWidth.get())
-      setCurrentBuilderWidth({ ...selectedWidth, default: roundedWidth })
+      setSelectedBuilderWidth({ ...selectedWidth, default: roundedWidth })
     },
 
-    [mWidth, selectedWidth, setCurrentBuilderWidth],
+    [mWidth, selectedWidth, setSelectedBuilderWidth],
   )
 
   useEffect(() => {
@@ -72,10 +72,10 @@ export const useBuilderResize = ({
       return
     }
 
-    setCurrentBuilderWidth(selectedWidth)
+    setSelectedBuilderWidth(selectedWidth)
 
     return mWidth.set(selectedWidth.default)
-  }, [selectedWidth, mWidth, setCurrentBuilderWidth])
+  }, [selectedWidth, mWidth, setSelectedBuilderWidth])
 
   const commonDragProps: Partial<DragHandleProps> = {
     dragConstraints: { bottom: 0, left: 0, right: 0, top: 0 },

--- a/libs/frontend/domain/builder/src/sections/config-pane/ConfigPane-InspectorTabContainer/ConfigPaneInspectorTabContainer.tsx
+++ b/libs/frontend/domain/builder/src/sections/config-pane/ConfigPane-InspectorTabContainer/ConfigPaneInspectorTabContainer.tsx
@@ -122,7 +122,6 @@ export const ConfigPaneInspectorTabContainer = observer(() => {
         isElementPageNodeRef(selectedNode) &&
         isAtomInstance(selectedNode.current.renderType) ? (
           <ElementCssEditor
-            builderService={builderService}
             element={selectedNode.current}
             elementService={elementService}
             key={selectedNode.id}

--- a/libs/frontend/domain/builder/src/sections/config-pane/ConfigPane-InspectorTabContainer/ConfigPaneInspectorTabContainer.tsx
+++ b/libs/frontend/domain/builder/src/sections/config-pane/ConfigPane-InspectorTabContainer/ConfigPaneInspectorTabContainer.tsx
@@ -122,6 +122,7 @@ export const ConfigPaneInspectorTabContainer = observer(() => {
         isElementPageNodeRef(selectedNode) &&
         isAtomInstance(selectedNode.current.renderType) ? (
           <ElementCssEditor
+            builderService={builderService}
             element={selectedNode.current}
             elementService={elementService}
             key={selectedNode.id}

--- a/libs/frontend/domain/builder/src/sections/content/Builder.tsx
+++ b/libs/frontend/domain/builder/src/sections/content/Builder.tsx
@@ -1,6 +1,7 @@
 import {
   BUILDER_CONTAINER_ID,
   DATA_ELEMENT_ID,
+  defaultBuilderWidthBreakPoints,
   DragPosition,
 } from '@codelab/frontend/abstract/core'
 import {
@@ -23,7 +24,7 @@ export const Builder = observer(() => {
   const { builderService, elementService, renderService } = useStore()
   const renderer = renderService.activeRenderer?.current
   const elementTree = builderService.activeElementTree
-  const { selectedBuilderWidth, selectedNode } = builderService
+  const { selectedBuilderBreakpoint, selectedNode } = builderService
   const containerRef = useRef<HTMLDivElement>(null)
 
   useBuilderHotkeys({
@@ -72,11 +73,14 @@ export const Builder = observer(() => {
   }, [])
 
   const builderStyle = useMemo(() => {
+    const { default: width } =
+      defaultBuilderWidthBreakPoints[selectedBuilderBreakpoint]
+
     return {
       container: 'root / inline-size',
-      width: `${selectedBuilderWidth.default}px`,
+      width: `${width}px`,
     }
-  }, [selectedBuilderWidth.default])
+  }, [selectedBuilderBreakpoint])
 
   if (!elementTree || !renderer) {
     return null

--- a/libs/frontend/domain/builder/src/sections/content/Builder.tsx
+++ b/libs/frontend/domain/builder/src/sections/content/Builder.tsx
@@ -53,13 +53,6 @@ export const Builder = observer(() => {
     [isOver],
   )
 
-  const builderStyle = useMemo(() => {
-    return {
-      container: 'root / inline-size',
-      width: `${currentBuilderWidth.default}px`,
-    }
-  }, [currentBuilderWidth.default])
-
   useEffect(() => {
     if (!containerRef.current) {
       return
@@ -77,6 +70,13 @@ export const Builder = observer(() => {
 
     return () => resizeObserver.disconnect()
   }, [])
+
+  const builderStyle = useMemo(() => {
+    return {
+      container: 'root / inline-size',
+      width: `${currentBuilderWidth.default}px`,
+    }
+  }, [currentBuilderWidth.default])
 
   if (!elementTree || !renderer) {
     return null

--- a/libs/frontend/domain/builder/src/sections/content/Builder.tsx
+++ b/libs/frontend/domain/builder/src/sections/content/Builder.tsx
@@ -1,7 +1,6 @@
 import {
   BUILDER_CONTAINER_ID,
   DATA_ELEMENT_ID,
-  defaultBuilderWidthBreakPoints,
   DragPosition,
 } from '@codelab/frontend/abstract/core'
 import {
@@ -24,7 +23,7 @@ export const Builder = observer(() => {
   const { builderService, elementService, renderService } = useStore()
   const renderer = renderService.activeRenderer?.current
   const elementTree = builderService.activeElementTree
-  const { selectedBuilderBreakpoint, selectedNode } = builderService
+  const { currentBuilderWidth, selectedNode } = builderService
   const containerRef = useRef<HTMLDivElement>(null)
 
   useBuilderHotkeys({
@@ -54,6 +53,13 @@ export const Builder = observer(() => {
     [isOver],
   )
 
+  const builderStyle = useMemo(() => {
+    return {
+      container: 'root / inline-size',
+      width: `${currentBuilderWidth.default}px`,
+    }
+  }, [currentBuilderWidth.default])
+
   useEffect(() => {
     if (!containerRef.current) {
       return
@@ -71,16 +77,6 @@ export const Builder = observer(() => {
 
     return () => resizeObserver.disconnect()
   }, [])
-
-  const builderStyle = useMemo(() => {
-    const { default: width } =
-      defaultBuilderWidthBreakPoints[selectedBuilderBreakpoint]
-
-    return {
-      container: 'root / inline-size',
-      width: `${width}px`,
-    }
-  }, [selectedBuilderBreakpoint])
 
   if (!elementTree || !renderer) {
     return null

--- a/libs/frontend/domain/builder/src/sections/content/Builder.tsx
+++ b/libs/frontend/domain/builder/src/sections/content/Builder.tsx
@@ -44,13 +44,16 @@ export const Builder = observer(() => {
   }
 
   const rootStyle = useMemo(
-    () =>
-      isOver
+    () => ({
+      container: 'root / inline-size',
+      width: `${selectedBuilderWidth.default}px`,
+      ...(isOver
         ? makeDropIndicatorStyle(DragPosition.Inside, {
             backgroundColor: 'rgba(0, 255, 255, 0.2)',
           })
-        : {},
-    [isOver],
+        : {}),
+    }),
+    [isOver, selectedBuilderWidth.default],
   )
 
   useEffect(() => {
@@ -71,13 +74,6 @@ export const Builder = observer(() => {
     return () => resizeObserver.disconnect()
   }, [])
 
-  const builderStyle = useMemo(() => {
-    return {
-      container: 'root / inline-size',
-      width: `${selectedBuilderWidth.default}px`,
-    }
-  }, [selectedBuilderWidth.default])
-
   if (!elementTree || !renderer) {
     return null
   }
@@ -88,7 +84,6 @@ export const Builder = observer(() => {
         <StyledBuilderResizeContainer
           id={BUILDER_CONTAINER_ID}
           key={elementTree.id}
-          style={builderStyle}
         >
           <Renderer ref={setNodeRef} renderer={renderer} style={rootStyle} />
           <BuilderClickOverlay

--- a/libs/frontend/domain/builder/src/sections/content/Builder.tsx
+++ b/libs/frontend/domain/builder/src/sections/content/Builder.tsx
@@ -23,7 +23,7 @@ export const Builder = observer(() => {
   const { builderService, elementService, renderService } = useStore()
   const renderer = renderService.activeRenderer?.current
   const elementTree = builderService.activeElementTree
-  const { currentBuilderWidth, selectedNode } = builderService
+  const { selectedBuilderWidth, selectedNode } = builderService
   const containerRef = useRef<HTMLDivElement>(null)
 
   useBuilderHotkeys({
@@ -74,9 +74,9 @@ export const Builder = observer(() => {
   const builderStyle = useMemo(() => {
     return {
       container: 'root / inline-size',
-      width: `${currentBuilderWidth.default}px`,
+      width: `${selectedBuilderWidth.default}px`,
     }
-  }, [currentBuilderWidth.default])
+  }, [selectedBuilderWidth.default])
 
   if (!elementTree || !renderer) {
     return null

--- a/libs/frontend/domain/builder/src/sections/content/BuilderResizeHandle.tsx
+++ b/libs/frontend/domain/builder/src/sections/content/BuilderResizeHandle.tsx
@@ -1,3 +1,4 @@
+import { defaultBuilderWidthBreakPoints } from '@codelab/frontend/abstract/core'
 import { useStore } from '@codelab/frontend/presentation/container'
 import type { PropsWithChildren } from 'react'
 import React, { useEffect, useRef } from 'react'
@@ -7,28 +8,27 @@ import { builderResizeController } from './builder-resize-controller'
 const useResizer = ({ side }: { side: Side }) => {
   const ref = useRef<HTMLDivElement>(null)
   const { builderService } = useStore()
+  const breakpoint = builderService.selectedBuilderBreakpoint
 
   useEffect(() => {
     if (ref.current === null) {
       return
     }
 
-    const disposeResizeController = builderResizeController(ref.current, {
-      getDefaultValue: () => builderService.selectedBuilderWidth.default,
+    const selectedBuilderWidth = defaultBuilderWidthBreakPoints[breakpoint]
 
+    const disposeResizeController = builderResizeController(ref.current, {
+      getDefaultValue: () => selectedBuilderWidth.default,
       getMaxValue: () =>
         Math.min(
           builderService.builderContainerWidth,
-          builderService.selectedBuilderWidth.max,
+          selectedBuilderWidth.max,
         ),
-
-      getMinValue: () => builderService.selectedBuilderWidth.min,
-
+      getMinValue: () => selectedBuilderWidth.min,
       getSide: () => side,
-
       onValueChanged: (value) => {
-        builderService.setSelectedBuilderWidth({
-          ...builderService.selectedBuilderWidth,
+        builderService.setCurrentBuilderWidth({
+          ...selectedBuilderWidth,
           default: value,
         })
       },
@@ -37,7 +37,7 @@ const useResizer = ({ side }: { side: Side }) => {
     return () => {
       disposeResizeController()
     }
-  }, [side])
+  }, [side, breakpoint])
 
   return ref
 }

--- a/libs/frontend/domain/builder/src/sections/content/BuilderResizeHandle.tsx
+++ b/libs/frontend/domain/builder/src/sections/content/BuilderResizeHandle.tsx
@@ -1,4 +1,3 @@
-import { defaultBuilderWidthBreakPoints } from '@codelab/frontend/abstract/core'
 import { useStore } from '@codelab/frontend/presentation/container'
 import type { PropsWithChildren } from 'react'
 import React, { useEffect, useRef } from 'react'
@@ -8,27 +7,24 @@ import { builderResizeController } from './builder-resize-controller'
 const useResizer = ({ side }: { side: Side }) => {
   const ref = useRef<HTMLDivElement>(null)
   const { builderService } = useStore()
-  const breakpoint = builderService.selectedBuilderBreakpoint
 
   useEffect(() => {
     if (ref.current === null) {
       return
     }
 
-    const selectedBuilderWidth = defaultBuilderWidthBreakPoints[breakpoint]
-
     const disposeResizeController = builderResizeController(ref.current, {
-      getDefaultValue: () => selectedBuilderWidth.default,
+      getDefaultValue: () => builderService.currentBuilderWidth.default,
       getMaxValue: () =>
         Math.min(
           builderService.builderContainerWidth,
-          selectedBuilderWidth.max,
+          builderService.currentBuilderWidth.max,
         ),
-      getMinValue: () => selectedBuilderWidth.min,
+      getMinValue: () => builderService.currentBuilderWidth.min,
       getSide: () => side,
       onValueChanged: (value) => {
         builderService.setCurrentBuilderWidth({
-          ...selectedBuilderWidth,
+          ...builderService.currentBuilderWidth,
           default: value,
         })
       },
@@ -37,7 +33,7 @@ const useResizer = ({ side }: { side: Side }) => {
     return () => {
       disposeResizeController()
     }
-  }, [side, breakpoint])
+  }, [side])
 
   return ref
 }

--- a/libs/frontend/domain/builder/src/sections/content/BuilderResizeHandle.tsx
+++ b/libs/frontend/domain/builder/src/sections/content/BuilderResizeHandle.tsx
@@ -14,17 +14,21 @@ const useResizer = ({ side }: { side: Side }) => {
     }
 
     const disposeResizeController = builderResizeController(ref.current, {
-      getDefaultValue: () => builderService.currentBuilderWidth.default,
+      getDefaultValue: () => builderService.selectedBuilderWidth.default,
+
       getMaxValue: () =>
         Math.min(
           builderService.builderContainerWidth,
-          builderService.currentBuilderWidth.max,
+          builderService.selectedBuilderWidth.max,
         ),
-      getMinValue: () => builderService.currentBuilderWidth.min,
+
+      getMinValue: () => builderService.selectedBuilderWidth.min,
+
       getSide: () => side,
+
       onValueChanged: (value) => {
-        builderService.setCurrentBuilderWidth({
-          ...builderService.currentBuilderWidth,
+        builderService.setSelectedBuilderWidth({
+          ...builderService.selectedBuilderWidth,
           default: value,
         })
       },

--- a/libs/frontend/domain/builder/src/store/builder.service.ts
+++ b/libs/frontend/domain/builder/src/store/builder.service.ts
@@ -32,14 +32,14 @@ export class BuilderService
     activeTab: prop<RendererTab>(RendererTab.Page).withSetter(),
     builderContainerWidth: prop<number>(0).withSetter(),
     currentBuilderWidth: prop<BuilderWidth>(
-      () => defaultBuilderWidthBreakPoints.desktop,
+      () => defaultBuilderWidthBreakPoints['mobile-portrait'],
     ),
     currentDragData: prop<Nullable<Frozen<BuilderDragData>>>(null).withSetter(),
     expandedComponentTreeNodeIds: prop<Array<string>>(() => []).withSetter(),
     expandedPageElementTreeNodeIds: prop<Array<string>>(() => []).withSetter(),
     hoveredNode: prop<Nullable<IPageNodeRef>>(null).withSetter(),
     selectedBuilderBreakpoint: prop<BuilderWidthBreakPoint>(
-      () => BuilderWidthBreakPoint.Desktop,
+      () => BuilderWidthBreakPoint.MobilePortrait,
     ).withSetter(),
     /**
      * select a node would add it to expand list

--- a/libs/frontend/domain/builder/src/store/builder.service.ts
+++ b/libs/frontend/domain/builder/src/store/builder.service.ts
@@ -31,9 +31,6 @@ export class BuilderService
   extends Model({
     activeTab: prop<RendererTab>(RendererTab.Page).withSetter(),
     builderContainerWidth: prop<number>(0).withSetter(),
-    currentBuilderWidth: prop<BuilderWidth>(
-      () => defaultBuilderWidthBreakPoints['mobile-portrait'],
-    ),
     currentDragData: prop<Nullable<Frozen<BuilderDragData>>>(null).withSetter(),
     expandedComponentTreeNodeIds: prop<Array<string>>(() => []).withSetter(),
     expandedPageElementTreeNodeIds: prop<Array<string>>(() => []).withSetter(),
@@ -41,6 +38,9 @@ export class BuilderService
     selectedBuilderBreakpoint: prop<BuilderWidthBreakPoint>(
       () => BuilderWidthBreakPoint.MobilePortrait,
     ).withSetter(),
+    selectedBuilderWidth: prop<BuilderWidth>(
+      () => defaultBuilderWidthBreakPoints['mobile-portrait'],
+    ),
     /**
      * select a node would add it to expand list
      * sometimes, it's not necessary to expand the node. E.g:
@@ -200,10 +200,10 @@ export class BuilderService
   }
 
   @modelAction
-  setCurrentBuilderWidth(width: BuilderWidth) {
+  setSelectedBuilderWidth(width: BuilderWidth) {
     // -1 max width means fill the screen, so we use the available
     // container width as long as it's not smaller than the min
-    this.currentBuilderWidth = {
+    this.selectedBuilderWidth = {
       default:
         width.default < 0
           ? Math.max(width.min, this.builderContainerWidth)

--- a/libs/frontend/domain/builder/src/store/builder.service.ts
+++ b/libs/frontend/domain/builder/src/store/builder.service.ts
@@ -201,25 +201,18 @@ export class BuilderService
 
   @modelAction
   setCurrentBuilderWidth(width: BuilderWidth) {
-    this.currentBuilderWidth.default = width.default
-    this.currentBuilderWidth.min = width.min
-    this.currentBuilderWidth.max = width.max
+    // -1 max width means fill the screen, so we use the available
+    // container width as long as it's not smaller than the min
+    this.currentBuilderWidth = {
+      default:
+        width.default < 0
+          ? Math.max(width.min, this.builderContainerWidth)
+          : width.default,
+      max:
+        width.max < 0
+          ? Math.max(width.min, this.builderContainerWidth)
+          : width.max,
+      min: width.min,
+    }
   }
-
-  // @modelAction
-  // setSelectedBuilderWidth(width: BuilderWidth) {
-  //   // -1 max width means fill the screen, so we use the available
-  //   // container width as long as it's not smaller than the min
-  //   this.selectedBuilderWidth = {
-  //     default:
-  //       width.default < 0
-  //         ? Math.max(width.min, this.builderContainerWidth)
-  //         : width.default,
-  //     max:
-  //       width.max < 0
-  //         ? Math.max(width.min, this.builderContainerWidth)
-  //         : width.max,
-  //     min: width.min,
-  //   }
-  // }
 }

--- a/libs/frontend/domain/builder/src/store/builder.service.ts
+++ b/libs/frontend/domain/builder/src/store/builder.service.ts
@@ -7,6 +7,7 @@ import type {
 } from '@codelab/frontend/abstract/core'
 import {
   BuilderWidth,
+  BuilderWidthBreakPoint,
   componentRef,
   defaultBuilderWidthBreakPoints,
   elementRef,
@@ -37,9 +38,9 @@ export class BuilderService
     expandedComponentTreeNodeIds: prop<Array<string>>(() => []).withSetter(),
     expandedPageElementTreeNodeIds: prop<Array<string>>(() => []).withSetter(),
     hoveredNode: prop<Nullable<IPageNodeRef>>(null).withSetter(),
-    selectedBuilderWidth: prop<BuilderWidth>(
-      () => defaultBuilderWidthBreakPoints.desktop,
-    ),
+    selectedBuilderBreakpoint: prop<BuilderWidthBreakPoint>(
+      () => BuilderWidthBreakPoint.Desktop,
+    ).withSetter(),
     /**
      * select a node would add it to expand list
      * sometimes, it's not necessary to expand the node. E.g:
@@ -205,20 +206,20 @@ export class BuilderService
     this.currentBuilderWidth.max = width.max
   }
 
-  @modelAction
-  setSelectedBuilderWidth(width: BuilderWidth) {
-    // -1 max width means fill the screen, so we use the available
-    // container width as long as it's not smaller than the min
-    this.selectedBuilderWidth = {
-      default:
-        width.default < 0
-          ? Math.max(width.min, this.builderContainerWidth)
-          : width.default,
-      max:
-        width.max < 0
-          ? Math.max(width.min, this.builderContainerWidth)
-          : width.max,
-      min: width.min,
-    }
-  }
+  // @modelAction
+  // setSelectedBuilderWidth(width: BuilderWidth) {
+  //   // -1 max width means fill the screen, so we use the available
+  //   // container width as long as it's not smaller than the min
+  //   this.selectedBuilderWidth = {
+  //     default:
+  //       width.default < 0
+  //         ? Math.max(width.min, this.builderContainerWidth)
+  //         : width.default,
+  //     max:
+  //       width.max < 0
+  //         ? Math.max(width.min, this.builderContainerWidth)
+  //         : width.max,
+  //     min: width.min,
+  //   }
+  // }
 }

--- a/libs/frontend/domain/element/jest.config.ts
+++ b/libs/frontend/domain/element/jest.config.ts
@@ -1,0 +1,31 @@
+/* eslint-disable */
+export default {
+  displayName: 'frontend-domain-element',
+  preset: '../../../../jest.preset.js',
+  transform: {
+    '^.+.[tj]sx?$': [
+      '@swc/jest',
+      {
+        jsc: {
+          parser: { syntax: 'typescript', tsx: true, decorators: true },
+          transform: {
+            decoratorMetadata: true,
+            react: { runtime: 'automatic' },
+          },
+        },
+      },
+    ],
+  },
+  moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx'],
+  coverageDirectory: '../../../../coverage/libs/frontend/domain/element',
+  reporters: [
+    'default',
+    [
+      'jest-junit',
+      {
+        outputName: 'frontend-domain-element.xml',
+        reportTestSuiteErrors: true,
+      },
+    ],
+  ],
+}

--- a/libs/frontend/domain/element/project.json
+++ b/libs/frontend/domain/element/project.json
@@ -1,23 +1,46 @@
 {
-  "name": "frontend-domain-element",
   "$schema": "../../../../node_modules/nx/schemas/project-schema.json",
-  "sourceRoot": "libs/frontend/domain/element/src",
+  "name": "frontend-domain-element",
   "projectType": "library",
+  "sourceRoot": "libs/frontend/domain/element/src",
+  "tags": ["scope:frontend", "layer:domain"],
   "targets": {
     "lint": {
-      "executor": "@nx/linter:eslint",
-      "options": {
-        "lintFilePatterns": ["libs/frontend/domain/element/**/*.ts"]
-      },
-      "outputs": ["{options.outputFile}"],
       "configurations": {
         "ci": {
           "format": "junit",
           "outputFile": "tmp/reports/lint/frontend-domain-element.xml",
           "quiet": true
         }
-      }
+      },
+      "executor": "@nx/linter:eslint",
+      "options": {
+        "lintFilePatterns": ["libs/frontend/domain/element/**/*.ts"]
+      },
+      "outputs": ["{options.outputFile}"]
+    },
+    "test:unit": {
+      "configurations": {
+        "ci": {},
+        "dev": {
+          "reporters": ["default"]
+        },
+        "test": {
+          "reporters": ["default"]
+        }
+      },
+      "defaultConfiguration": "dev",
+      "executor": "@nx/jest:jest",
+      "options": {
+        "color": true,
+        "jestConfig": "libs/frontend/domain/element/jest.config.ts",
+        "memoryLimit": 8192,
+        "parallel": 3,
+        "passWithNoTests": true,
+        "runInBand": true,
+        "testPathPattern": ["[^i].spec.ts"]
+      },
+      "outputs": ["{workspaceRoot}/coverage/libs/frontend/domain/element"]
     }
-  },
-  "tags": ["scope:frontend", "layer:domain"]
+  }
 }

--- a/libs/frontend/domain/element/src/css-editor/ElementCssEditor.tsx
+++ b/libs/frontend/domain/element/src/css-editor/ElementCssEditor.tsx
@@ -1,7 +1,6 @@
 import { CaretRightOutlined } from '@ant-design/icons'
 import type {
   CssMap,
-  IBuilderService,
   IElement,
   IElementService,
 } from '@codelab/frontend/abstract/core'
@@ -23,7 +22,6 @@ const { Panel } = Collapse
 const autosaveTimeout = 1000
 
 export interface ElementCssEditorInternalProps {
-  builderService: IBuilderService
   element: IElement
   elementService: IElementService
 }
@@ -34,9 +32,8 @@ export interface ElementCssEditorInternalProps {
     can guiCss be set to?
   */
 export const ElementCssEditor = observer<ElementCssEditorInternalProps>(
-  ({ builderService, element, elementService }) => {
+  ({ element, elementService }) => {
     const guiCssObj = JSON.parse(element.guiCss ?? '{}') as CssMap
-    // fix: still update request sent when no changes
     const lastStateRef = useRef(element.style)
 
     const cssChangeHandler = useDebouncedCallback(

--- a/libs/frontend/domain/element/src/css-editor/ElementCssEditor.tsx
+++ b/libs/frontend/domain/element/src/css-editor/ElementCssEditor.tsx
@@ -1,10 +1,10 @@
 import { CaretRightOutlined } from '@ant-design/icons'
 import type {
   CssMap,
+  IBuilderService,
   IElement,
   IElementService,
 } from '@codelab/frontend/abstract/core'
-import { useStore } from '@codelab/frontend/presentation/container'
 import { CodeMirrorEditor } from '@codelab/frontend/presentation/view'
 import { CodeMirrorLanguage } from '@codelab/shared/abstract/codegen'
 import { useDebouncedEffect } from '@react-hookz/web'
@@ -22,6 +22,7 @@ import { FontEditor } from './font-editor'
 const { Panel } = Collapse
 
 export interface ElementCssEditorInternalProps {
+  builderService: IBuilderService
   element: IElement
   elementService: IElementService
 }
@@ -32,8 +33,7 @@ export interface ElementCssEditorInternalProps {
     can guiCss be set to?
   */
 export const ElementCssEditor = observer<ElementCssEditorInternalProps>(
-  ({ element, elementService }) => {
-    const { builderService } = useStore()
+  ({ builderService, element, elementService }) => {
     const breakpoint = builderService.selectedBuilderBreakpoint
     const { cssString, guiString } = element.styleParsed[breakpoint] ?? {}
     const guiCssObj = JSON.parse(guiString ?? '{}') as CssMap

--- a/libs/frontend/domain/element/src/css-editor/ElementCssEditor.tsx
+++ b/libs/frontend/domain/element/src/css-editor/ElementCssEditor.tsx
@@ -10,6 +10,7 @@ import { useDebouncedCallback, useDebouncedEffect } from '@react-hookz/web'
 import { Col, Collapse, Row } from 'antd'
 import { observer } from 'mobx-react-lite'
 import React, { useCallback, useEffect, useRef } from 'react'
+import styled from 'styled-components'
 import { getElementModel } from '../utils/get-element-model'
 import { BackgroundEditor } from './css-background-editor/BackgroundEditor'
 import { BordersEditor } from './css-borders-editor/BordersEditor'
@@ -17,9 +18,16 @@ import { EffectsEditor } from './css-effects-editor/EffectsEditor'
 import { LayoutEditor } from './css-layout-editor'
 import { ShadowsEditor } from './css-shadows-editor'
 import { FontEditor } from './font-editor'
+import { InheritedStyles } from './inherited-styles/InheritedStyles'
 
 const { Panel } = Collapse
 const autosaveTimeout = 1000
+
+const Label = styled.span`
+  display: inline-flex;
+  align-items: center;
+  height: 32px;
+`
 
 export interface ElementCssEditorInternalProps {
   element: IElement
@@ -76,6 +84,11 @@ export const ElementCssEditor = observer<ElementCssEditorInternalProps>(
     return (
       <Row style={{ marginBottom: '10%' }}>
         <Col span={24}>
+          <Label>Inherited css :</Label>
+          <InheritedStyles element={element} />
+        </Col>
+        <Col span={24}>
+          <Label>Current breakpoint css :</Label>
           <CodeMirrorEditor
             height="100%"
             language={CodeMirrorLanguage.Css}

--- a/libs/frontend/domain/element/src/css-editor/ElementCssEditor.tsx
+++ b/libs/frontend/domain/element/src/css-editor/ElementCssEditor.tsx
@@ -35,12 +35,12 @@ export interface ElementCssEditorInternalProps {
   */
 export const ElementCssEditor = observer<ElementCssEditorInternalProps>(
   ({ builderService, element, elementService }) => {
-    const breakpoint = builderService.selectedBuilderBreakpoint
     const guiCssObj = JSON.parse(element.guiCss ?? '{}') as CssMap
+    // fix: still update request sent when no changes
     const lastStateRef = useRef(element.style)
 
     const cssChangeHandler = useDebouncedCallback(
-      (value: string) => element.setCustomCss(value, breakpoint),
+      (value: string) => element.setCustomCss(value),
       [element],
       autosaveTimeout,
     )
@@ -73,7 +73,7 @@ export const ElementCssEditor = observer<ElementCssEditorInternalProps>(
        * because if the panel is closed too quickly, the autosave won't catch the latest changes
        */
       () => () => updateElementStyles(element),
-      [element.style, updateElementStyles],
+      [element, updateElementStyles],
     )
 
     return (

--- a/libs/frontend/domain/element/src/css-editor/css-layout-editor/LayoutEditor.tsx
+++ b/libs/frontend/domain/element/src/css-editor/css-layout-editor/LayoutEditor.tsx
@@ -20,25 +20,24 @@ export const LayoutEditor = observer(
     return (
       <Collapse
         bordered={false}
-        className="site-collapse-custom-collapse"
         defaultActiveKey={['1']}
         expandIcon={({ isActive }) => (
           <CaretRightOutlined rotate={isActive ? 90 : 0} />
         )}
       >
-        <Panel className="site-collapse-custom-panel" header="Display" key="1">
+        <Panel header="Display" key="1">
           <DisplayEditor element={element} guiCssObj={guiCssObj} />
         </Panel>
-        <Panel className="site-collapse-custom-panel" header="Margins" key="2">
+        <Panel header="Margins" key="2">
           <MarginsEditor element={element} guiCssObj={guiCssObj} />
         </Panel>
-        <Panel className="site-collapse-custom-panel" header="Padding" key="3">
+        <Panel header="Padding" key="3">
           <PaddingEditor element={element} guiCssObj={guiCssObj} />
         </Panel>
-        <Panel className="site-collapse-custom-panel" header="Size" key="4">
+        <Panel header="Size" key="4">
           <SizeEditor element={element} guiCssObj={guiCssObj} />
         </Panel>
-        <Panel className="site-collapse-custom-panel" header="Position" key="5">
+        <Panel header="Position" key="5">
           <PositionEditor element={element} guiCssObj={guiCssObj} />
         </Panel>
       </Collapse>

--- a/libs/frontend/domain/element/src/css-editor/css-shadows-editor/ShadowsEditor.tsx
+++ b/libs/frontend/domain/element/src/css-editor/css-shadows-editor/ShadowsEditor.tsx
@@ -17,24 +17,15 @@ export const ShadowsEditor = observer(
     return (
       <Collapse
         bordered={false}
-        className="site-collapse-custom-collapse"
         defaultActiveKey={['1']}
         expandIcon={({ isActive }) => (
           <CaretRightOutlined rotate={isActive ? 90 : 0} />
         )}
       >
-        <Panel
-          className="site-collapse-custom-panel"
-          header="BoxShadow"
-          key="1"
-        >
+        <Panel header="BoxShadow" key="1">
           <BoxShadow element={element} guiCssObj={guiCssObj} />
         </Panel>
-        <Panel
-          className="site-collapse-custom-panel"
-          header="TextShadow"
-          key="2"
-        >
+        <Panel header="TextShadow" key="2">
           <TextShadow element={element} guiCssObj={guiCssObj} />
         </Panel>
       </Collapse>

--- a/libs/frontend/domain/element/src/css-editor/inherited-styles/InheritedStyles.tsx
+++ b/libs/frontend/domain/element/src/css-editor/inherited-styles/InheritedStyles.tsx
@@ -1,0 +1,76 @@
+import type { ElementCssRules, IElement } from '@codelab/frontend/abstract/core'
+import { Card, Typography } from 'antd'
+import { observer } from 'mobx-react-lite'
+import React from 'react'
+import styled from 'styled-components'
+
+interface InheritedStylesProps {
+  element: IElement
+}
+
+interface RuleState {
+  level: number
+  overridden: boolean
+  style: string
+}
+
+const StyledCard = styled(Card)`
+  background-color: #fafafa;
+  margin-bottom: 0.5rem;
+
+  .ant-card-body {
+    padding: 0.5rem 1rem;
+  }
+`
+
+const getRules = (
+  currentStyles: ElementCssRules | undefined,
+  inheritedStyles: ElementCssRules,
+  level = 0,
+): Array<RuleState> => {
+  const rootRules = []
+  const nestedRules = []
+
+  for (const [key, value] of Object.entries(inheritedStyles)) {
+    const overridden = Boolean(currentStyles?.[key])
+
+    if (typeof value === 'string') {
+      rootRules.push({ level, overridden, style: `${key}: ${value};` })
+    } else if (typeof currentStyles?.[key] !== 'string') {
+      nestedRules.push({ level, overridden: false, style: `${key} {` })
+      nestedRules.push(
+        ...getRules(currentStyles?.[key] as ElementCssRules, value, level + 1),
+      )
+      nestedRules.push({ level, overridden: false, style: `}\n` })
+    }
+  }
+
+  return [...rootRules, ...nestedRules]
+}
+
+export const InheritedStyles = observer(({ element }: InheritedStylesProps) => {
+  const { currentStyles, inheritedStyles } =
+    element.stylesInheritedFromOtherBreakpoints
+
+  const rootProps = getRules(currentStyles, inheritedStyles).map(
+    ({ level, overridden, style }) => (
+      <Typography.Text
+        delete={overridden}
+        disabled={overridden}
+        style={{ display: 'block', marginLeft: `${level}rem` }}
+      >
+        {style}
+      </Typography.Text>
+    ),
+  )
+
+  return (
+    <StyledCard>
+      {rootProps.length > 0 ? (
+        rootProps
+      ) : (
+        <Typography.Text type="secondary">No inherited styles</Typography.Text>
+      )}
+    </StyledCard>
+  )
+})

--- a/libs/frontend/domain/element/src/store/element.model.ts
+++ b/libs/frontend/domain/element/src/store/element.model.ts
@@ -343,20 +343,27 @@ export class Element
     const mediaQueryString = isProduction ? '@media' : '@container root'
     const breakpointStyles = []
 
-    for (const breakpoint in parsedCss) {
+    const breakpoints = [
+      BuilderWidthBreakPoint.MobilePortrait,
+      BuilderWidthBreakPoint.MobileLandscape,
+      BuilderWidthBreakPoint.Tablet,
+      BuilderWidthBreakPoint.Desktop,
+    ]
+
+    for (const breakpoint of breakpoints) {
       const breakpointStyle = parsedCss[breakpoint as BuilderWidthBreakPoint]
 
       const breakpointWidth =
         defaultBuilderWidthBreakPoints[breakpoint as BuilderWidthBreakPoint]
 
-      const upperBound =
-        breakpoint === BuilderWidthBreakPoint.Desktop
-          ? 9999
-          : breakpointWidth.max
+      const lowerBound =
+        breakpoint === BuilderWidthBreakPoint.MobilePortrait
+          ? 0
+          : breakpointWidth.min
 
       if (breakpointStyle) {
         breakpointStyles.push(
-          `${mediaQueryString} (width < ${upperBound}px) {
+          `${mediaQueryString} (width > ${lowerBound}px) {
             ${breakpointStyle.cssString ?? ''}
           }`,
         )

--- a/libs/frontend/domain/element/src/store/element.model.ts
+++ b/libs/frontend/domain/element/src/store/element.model.ts
@@ -68,7 +68,7 @@ import {
   prop,
   Ref,
 } from 'mobx-keystone'
-import { getRenderType } from './utils'
+import { getRenderType, jsonStringToCss } from './utils'
 
 const create = ({
   childMapperComponent,
@@ -369,7 +369,7 @@ export class Element
         breakpointStyles.push(
           `${mediaQueryString} (width > ${lowerBound}px) {
             ${breakpointStyle.cssString ?? ''}
-            ${breakpointStyle.guiString ?? ''}
+            ${jsonStringToCss(breakpointStyle.guiString ?? '{}')}
           }`,
         )
       }
@@ -400,7 +400,8 @@ export class Element
   }
 
   @modelAction
-  setCustomCss(cssString: string, breakpoint: BuilderWidthBreakPoint) {
+  setCustomCss(cssString: string) {
+    const breakpoint = this.builderService.selectedBuilderBreakpoint
     const styleObject = this.styleParsed
     styleObject[breakpoint] = { ...styleObject[breakpoint], cssString }
     this.style = JSON.stringify(styleObject)
@@ -408,21 +409,31 @@ export class Element
 
   @modelAction
   appendToGuiCss(css: CssMap) {
-    // const curGuiCss = JSON.parse(this.guiCss || '{}')
-    // const newGuiCss = { ...curGuiCss, ...css }
-    // this.guiCss = JSON.stringify(newGuiCss)
+    const breakpoint = this.builderService.selectedBuilderBreakpoint
+    const styleObject = this.styleParsed
+    const curGuiCss = JSON.parse(this.guiCss || '{}')
+    const newGuiCss = { ...curGuiCss, ...css }
+    const guiString = JSON.stringify(newGuiCss)
+
+    styleObject[breakpoint] = { ...styleObject[breakpoint], guiString }
+    this.style = JSON.stringify(styleObject)
   }
 
   @modelAction
   deleteFromGuiCss(propNames: Array<string>) {
-    // const curGuiCss = JSON.parse(this.guiCss || '{}')
-    // propNames.forEach((propName) => {
-    //   if (curGuiCss[propName]) {
-    //     // eslint-disable-next-line @typescript-eslint/no-dynamic-delete
-    //     delete curGuiCss[propName]
-    //   }
-    // })
-    // this.guiCss = JSON.stringify(curGuiCss)
+    const breakpoint = this.builderService.selectedBuilderBreakpoint
+    const styleObject = this.styleParsed
+    const curGuiCss = JSON.parse(this.guiCss || '{}')
+    propNames.forEach((propName) => {
+      if (curGuiCss[propName]) {
+        // eslint-disable-next-line @typescript-eslint/no-dynamic-delete
+        delete curGuiCss[propName]
+      }
+    })
+
+    const guiString = JSON.stringify(curGuiCss)
+    styleObject[breakpoint] = { ...styleObject[breakpoint], guiString }
+    this.style = JSON.stringify(styleObject)
   }
 
   @modelAction

--- a/libs/frontend/domain/element/src/store/element.model.ts
+++ b/libs/frontend/domain/element/src/store/element.model.ts
@@ -20,6 +20,7 @@ import {
   DATA_ELEMENT_ID,
   defaultBuilderWidthBreakPoints,
   elementRef,
+  getBuilderService,
   getComponentService,
   getElementService,
   getRenderService,
@@ -183,6 +184,11 @@ export class Element
   }
 
   @computed
+  get builderService() {
+    return getBuilderService(this)
+  }
+
+  @computed
   get closestRootElement(): IElement {
     return this.closestParent
       ? this.closestParent.closestRootElement
@@ -334,8 +340,6 @@ export class Element
   }
 
   get styleCss(): string {
-    // debugger
-
     const parsedCss = this.styleParsed
     const activeRenderer = this.renderService.activeRenderer?.current
     const rendererType = activeRenderer?.rendererType
@@ -365,12 +369,29 @@ export class Element
         breakpointStyles.push(
           `${mediaQueryString} (width > ${lowerBound}px) {
             ${breakpointStyle.cssString ?? ''}
+            ${breakpointStyle.guiString ?? ''}
           }`,
         )
       }
     }
 
     return breakpointStyles.join('\n')
+  }
+
+  @computed
+  get customCss() {
+    const breakpoint = this.builderService.selectedBuilderBreakpoint
+    const { cssString } = this.styleParsed[breakpoint] ?? {}
+
+    return cssString
+  }
+
+  @computed
+  get guiCss() {
+    const breakpoint = this.builderService.selectedBuilderBreakpoint
+    const { guiString } = this.styleParsed[breakpoint] ?? {}
+
+    return guiString
   }
 
   @computed

--- a/libs/frontend/domain/element/src/store/element.model.ts
+++ b/libs/frontend/domain/element/src/store/element.model.ts
@@ -367,7 +367,7 @@ export class Element
 
       if (breakpointStyle) {
         breakpointStyles.push(
-          `${mediaQueryString} (width > ${lowerBound}px) {
+          `${mediaQueryString} (width >= ${lowerBound}px) {
             ${breakpointStyle.cssString ?? ''}
             ${jsonStringToCss(breakpointStyle.guiString ?? '{}')}
           }`,

--- a/libs/frontend/domain/element/src/store/element.model.ts
+++ b/libs/frontend/domain/element/src/store/element.model.ts
@@ -339,7 +339,7 @@ export class Element
     return slugify(this.name)
   }
 
-  get styleCss(): string {
+  get styleStringWithBreakpoints(): string {
     const parsedCss = this.styleParsed
     const activeRenderer = this.renderService.activeRenderer?.current
     const rendererType = activeRenderer?.rendererType

--- a/libs/frontend/domain/element/src/store/element.model.ts
+++ b/libs/frontend/domain/element/src/store/element.model.ts
@@ -818,7 +818,6 @@ export class Element
     const elementRenderType = getRenderType(renderType)
 
     this.name = name ?? this.name
-    // this.setStyle(style ?? this.style)
     this.style = style ?? this.style
     this.renderIfExpression = renderIfExpression ?? null
     this.renderForEachPropKey = renderForEachPropKey ?? null

--- a/libs/frontend/domain/element/src/store/element.service.ts
+++ b/libs/frontend/domain/element/src/store/element.service.ts
@@ -710,8 +710,6 @@ export class ElementService
         ? { id: element.childMapperPreviousSibling.id }
         : null,
       childMapperPropKey: element.childMapperPropKey,
-      customCss: element.customCss,
-      guiCss: element.guiCss,
       id: v4(),
       name: duplicateName,
       props,
@@ -725,6 +723,7 @@ export class ElementService
               : RenderTypeKind.Atom,
           }
         : null,
+      style: element.style,
     }
 
     const elementCloneModel = this.add(cloneElementDto)

--- a/libs/frontend/domain/element/src/store/utils.spec.ts
+++ b/libs/frontend/domain/element/src/store/utils.spec.ts
@@ -1,8 +1,5 @@
 import { parseCssStringIntoObject } from './utils'
 
-/**
- * Should render a prop value of ReactNode
- */
 describe('parseCssStringIntoObject', () => {
   it('should parse css string with nested blocks', () => {
     const unformattedCssWithNestedRules = `

--- a/libs/frontend/domain/element/src/store/utils.spec.ts
+++ b/libs/frontend/domain/element/src/store/utils.spec.ts
@@ -1,0 +1,38 @@
+import { parseCssStringIntoObject } from './utils'
+
+/**
+ * Should render a prop value of ReactNode
+ */
+describe('parseCssStringIntoObject', () => {
+  it('should parse css string with nested blocks', () => {
+    const unformattedCssWithNestedRules = `
+    margin-top :    50px; 
+    color: orange ; 
+   
+    p  { 
+       color : orange;border:none;
+   }
+   
+    *::after  {
+     border:  1px solid red !important;
+   top:12rem;
+   }`
+
+    const parsedCssString = parseCssStringIntoObject(
+      unformattedCssWithNestedRules,
+    )
+
+    expect(parsedCssString).toEqual({
+      '*::after': {
+        border: '1px solid red !important',
+        top: '12rem',
+      },
+      color: 'orange',
+      'margin-top': '50px',
+      p: {
+        border: 'none',
+        color: 'orange',
+      },
+    })
+  })
+})

--- a/libs/frontend/domain/element/src/store/utils.ts
+++ b/libs/frontend/domain/element/src/store/utils.ts
@@ -17,3 +17,14 @@ export const getRenderType = (
 
   return null
 }
+
+export const jsonStringToCss = (json: string | null | undefined) => {
+  const jsonObject = JSON.parse(json ?? '{}')
+  let css = ''
+
+  for (const key in jsonObject) {
+    css += `${key}: ${jsonObject[key]};`
+  }
+
+  return css
+}

--- a/libs/frontend/domain/element/src/store/utils.ts
+++ b/libs/frontend/domain/element/src/store/utils.ts
@@ -28,3 +28,158 @@ export const jsonStringToCss = (json: string | null | undefined) => {
 
   return css
 }
+
+/**
+ * @param cssString user-defined css string
+ * @returns new string without trailing spaces and new lines
+ */
+const replaceNewLineAndSpaces = (cssString: string) => {
+  cssString = cssString.trim()
+  cssString = cssString.replace(/\n/g, ' ')
+  cssString = cssString.replace(/\s+/g, ' ')
+
+  return cssString
+}
+
+/**
+ * @param cssString user-defined css string
+ * @param startIndex starting index of the css string where to look for rule key
+ * @returns rule "key", like "color" or "margin-top", and the index of the last character of the key
+ */
+const getStyleKey = (cssString: string, startIndex: number) => {
+  let index = startIndex
+  let key = ''
+  let stopSymbol = ''
+
+  while (index < cssString.length) {
+    const char = cssString[index++]
+
+    if (char === ':') {
+      let index2 = index + 1
+      let shouldStop = false
+
+      while (index2 < cssString.length) {
+        const char2 = cssString[index2++]
+
+        if (char2 === '{') {
+          shouldStop = false
+          break
+        }
+
+        if (char2 === ';') {
+          shouldStop = true
+          break
+        }
+      }
+
+      if (shouldStop) {
+        stopSymbol = char
+        break
+      }
+    }
+
+    if (char === '{') {
+      stopSymbol = char
+      break
+    }
+
+    key += char
+  }
+
+  key = key.trim()
+
+  return { endIndex: index - 1, key, stopSymbol }
+}
+
+const getStyleValue = (
+  str: string,
+  startIndex: number,
+  keyStopSymbol: string,
+) => {
+  let index = startIndex
+  let value = ''
+  const stopSymbol = keyStopSymbol === '{' ? '}' : ';'
+
+  while (index < str.length) {
+    const char = str[index++]
+
+    if (char === stopSymbol) {
+      break
+    }
+
+    value += char
+  }
+
+  value = value.trim()
+
+  return { endIndex: index - 1, value }
+}
+
+/**
+ * @param str user-defined css string
+ * @param startIndex starting index of the css string where to look for the end of the block
+ * @returns index of the last character of the block
+ */
+const findEndOfBlockIndex = (str: string, startIndex: number) => {
+  const stack = []
+
+  for (let i = startIndex; i < str.length; i++) {
+    const char = str[i]
+
+    if (char === '{') {
+      stack.push(char)
+      continue
+    }
+
+    if (char === '}') {
+      stack.pop()
+
+      if (stack.length === 0) {
+        return i
+      }
+    }
+  }
+
+  return str.length
+}
+
+/**
+ * @param cssString user-defined css string
+ * @returns parsed css object based on any given css string
+ */
+export const parseCssStringIntoObject = (cssString: string) => {
+  const trimmedCssString = replaceNewLineAndSpaces(cssString)
+  const result = {} as Record<string, unknown>
+  let index = 0
+
+  while (index < trimmedCssString.length) {
+    const { endIndex, key, stopSymbol } = getStyleKey(trimmedCssString, index)
+
+    if (stopSymbol === '{') {
+      const endOfBlockIndex = findEndOfBlockIndex(trimmedCssString, index)
+
+      index = endOfBlockIndex + 1
+
+      const nestedBlockStr = trimmedCssString.substring(
+        endIndex + 1,
+        endOfBlockIndex,
+      )
+
+      const value = parseCssStringIntoObject(nestedBlockStr)
+
+      result[key] = value
+    } else {
+      const { endIndex: endIndex2, value } = getStyleValue(
+        trimmedCssString,
+        endIndex + 1,
+        stopSymbol,
+      )
+
+      index = endIndex2 + 1
+
+      result[key] = value
+    }
+  }
+
+  return result
+}

--- a/libs/frontend/domain/element/src/use-cases/element/create-element/CreateElementForm.tsx
+++ b/libs/frontend/domain/element/src/use-cases/element/create-element/CreateElementForm.tsx
@@ -104,8 +104,7 @@ export const CreateElementForm = observer(
         <AutoFields
           omitFields={[
             'parentElement',
-            'customCss',
-            'guiCss',
+            'style',
             'propsData',
             'prevSibling',
             'preRenderAction',

--- a/libs/frontend/domain/element/src/use-cases/element/create-element/create-element.schema.ts
+++ b/libs/frontend/domain/element/src/use-cases/element/create-element/create-element.schema.ts
@@ -11,11 +11,7 @@ export const createElementSchema: JSONSchemaType<
 > = {
   properties: {
     ...idSchema,
-    customCss: {
-      nullable: true,
-      type: 'string',
-    },
-    guiCss: {
+    style: {
       nullable: true,
       type: 'string',
     },

--- a/libs/frontend/domain/element/src/use-cases/element/update-element/UpdateElementForm.tsx
+++ b/libs/frontend/domain/element/src/use-cases/element/update-element/UpdateElementForm.tsx
@@ -79,8 +79,7 @@ export const UpdateElementForm = observer<UpdateElementFormProps>(
             'renderIfExpression',
             'renderForEachPropKey',
             // We edit it in the css tab
-            'customCss',
-            'guiCss',
+            'style',
             'preRenderAction',
             'postRenderAction',
             'renderType',

--- a/libs/frontend/domain/element/tsconfig.json
+++ b/libs/frontend/domain/element/tsconfig.json
@@ -14,6 +14,9 @@
   "references": [
     {
       "path": "./tsconfig.lib.json"
+    },
+    {
+      "path": "./tsconfig.spec.json"
     }
   ]
 }

--- a/libs/frontend/domain/element/tsconfig.spec.json
+++ b/libs/frontend/domain/element/tsconfig.spec.json
@@ -1,0 +1,26 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "types": ["jest", "node", "@testing-library/jest-dom", "@fancyapps/ui"],
+    "noPropertyAccessFromIndexSignature": false,
+    "outDir": "../../../../dist/out-tsc",
+    "jsx": "react-jsx",
+
+    "strict": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "include": [
+    "jest.config.ts",
+    "**/*.test.ts",
+    "**/*.spec.ts",
+    "**/*.test.tsx",
+    "**/*.spec.tsx",
+    "**/*.test.js",
+    "**/*.spec.js",
+    "**/*.test.jsx",
+    "**/*.spec.jsx",
+    "**/*.d.ts"
+  ]
+}

--- a/libs/frontend/domain/page/src/view/BuilderSizeMenu.tsx
+++ b/libs/frontend/domain/page/src/view/BuilderSizeMenu.tsx
@@ -37,14 +37,14 @@ const menuItemCommonStyle = {
 
 export const BuilderSizeMenu = observer(() => {
   const { builderService } = useStore()
-  const breakpoint = builderService.selectedBuilderBreakpoint
-  const currentBuilderWidth = builderService.currentBuilderWidth
+  const selectedWidthBreakpoint = builderService.selectedBuilderBreakpoint
+  const selectedBuilderWidth = builderService.selectedBuilderWidth
 
   const handleBreakpointSelected = useCallback(
-    (newBreakpoint: BuilderWidthBreakPoint) => {
-      builderService.setSelectedBuilderBreakpoint(newBreakpoint)
-      builderService.setCurrentBuilderWidth(
-        defaultBuilderWidthBreakPoints[newBreakpoint],
+    (breakpoint: BuilderWidthBreakPoint) => {
+      builderService.setSelectedBuilderBreakpoint(breakpoint)
+      builderService.setSelectedBuilderWidth(
+        defaultBuilderWidthBreakPoints[breakpoint],
       )
     },
     [],
@@ -113,7 +113,7 @@ export const BuilderSizeMenu = observer(() => {
           }))}
         mode="horizontal"
         selectable={false}
-        selectedKeys={[breakpoint]}
+        selectedKeys={[selectedWidthBreakpoint]}
         style={{
           blockSize: '100%',
         }}
@@ -124,16 +124,16 @@ export const BuilderSizeMenu = observer(() => {
       <Space direction="horizontal" size="small">
         <InputNumber
           controls={false}
-          max={currentBuilderWidth.max}
-          min={currentBuilderWidth.min}
+          max={builderService.selectedBuilderWidth.max}
+          min={builderService.selectedBuilderWidth.min}
           onChange={(value) =>
-            builderService.setCurrentBuilderWidth({
-              ...currentBuilderWidth,
+            builderService.setSelectedBuilderWidth({
+              ...builderService.selectedBuilderWidth,
               default: Number(value),
             })
           }
           size="small"
-          value={currentBuilderWidth.default}
+          value={builderService.selectedBuilderWidth.default}
         />
         <span>px</span>
       </Space>

--- a/libs/frontend/domain/page/src/view/BuilderSizeMenu.tsx
+++ b/libs/frontend/domain/page/src/view/BuilderSizeMenu.tsx
@@ -11,7 +11,7 @@ import { useStore } from '@codelab/frontend/presentation/container'
 import { Divider, InputNumber, Menu, Space } from 'antd'
 import type { ItemType } from 'antd/lib/menu/hooks/useItems'
 import { observer } from 'mobx-react-lite'
-import React, { useCallback, useState } from 'react'
+import React, { useCallback } from 'react'
 
 export type MenuItemProps = ItemType & {
   hide?: boolean
@@ -37,16 +37,14 @@ const menuItemCommonStyle = {
 
 export const BuilderSizeMenu = observer(() => {
   const { builderService } = useStore()
-
-  const [selectedWidthBreakpoint, setSelectedWidthBreakpoint] = useState(
-    BuilderWidthBreakPoint.Desktop,
-  )
+  const breakpoint = builderService.selectedBuilderBreakpoint
+  const selectedWidthBreakpoint = defaultBuilderWidthBreakPoints[breakpoint]
 
   const handleBreakpointSelected = useCallback(
-    (breakpoint: BuilderWidthBreakPoint) => {
-      setSelectedWidthBreakpoint(breakpoint)
-      builderService.setSelectedBuilderWidth(
-        defaultBuilderWidthBreakPoints[breakpoint],
+    (newBreakpoint: BuilderWidthBreakPoint) => {
+      builderService.setSelectedBuilderBreakpoint(newBreakpoint)
+      builderService.setCurrentBuilderWidth(
+        defaultBuilderWidthBreakPoints[newBreakpoint],
       )
     },
     [],
@@ -115,7 +113,7 @@ export const BuilderSizeMenu = observer(() => {
           }))}
         mode="horizontal"
         selectable={false}
-        selectedKeys={[selectedWidthBreakpoint]}
+        selectedKeys={[breakpoint]}
         style={{
           blockSize: '100%',
         }}
@@ -126,16 +124,16 @@ export const BuilderSizeMenu = observer(() => {
       <Space direction="horizontal" size="small">
         <InputNumber
           controls={false}
-          max={builderService.selectedBuilderWidth.max}
-          min={builderService.selectedBuilderWidth.min}
+          max={selectedWidthBreakpoint.max}
+          min={selectedWidthBreakpoint.min}
           onChange={(value) =>
-            builderService.setSelectedBuilderWidth({
-              ...builderService.selectedBuilderWidth,
+            builderService.setCurrentBuilderWidth({
+              ...selectedWidthBreakpoint,
               default: Number(value),
             })
           }
           size="small"
-          value={builderService.selectedBuilderWidth.default}
+          value={selectedWidthBreakpoint.default}
         />
         <span>px</span>
       </Space>

--- a/libs/frontend/domain/page/src/view/BuilderSizeMenu.tsx
+++ b/libs/frontend/domain/page/src/view/BuilderSizeMenu.tsx
@@ -38,7 +38,7 @@ const menuItemCommonStyle = {
 export const BuilderSizeMenu = observer(() => {
   const { builderService } = useStore()
   const breakpoint = builderService.selectedBuilderBreakpoint
-  const selectedWidthBreakpoint = defaultBuilderWidthBreakPoints[breakpoint]
+  const currentBuilderWidth = builderService.currentBuilderWidth
 
   const handleBreakpointSelected = useCallback(
     (newBreakpoint: BuilderWidthBreakPoint) => {
@@ -124,16 +124,16 @@ export const BuilderSizeMenu = observer(() => {
       <Space direction="horizontal" size="small">
         <InputNumber
           controls={false}
-          max={selectedWidthBreakpoint.max}
-          min={selectedWidthBreakpoint.min}
+          max={currentBuilderWidth.max}
+          min={currentBuilderWidth.min}
           onChange={(value) =>
             builderService.setCurrentBuilderWidth({
-              ...selectedWidthBreakpoint,
+              ...currentBuilderWidth,
               default: Number(value),
             })
           }
           size="small"
-          value={selectedWidthBreakpoint.default}
+          value={currentBuilderWidth.default}
         />
         <span>px</span>
       </Space>

--- a/libs/frontend/domain/renderer/src/element/get-styled-components.ts
+++ b/libs/frontend/domain/renderer/src/element/get-styled-components.ts
@@ -24,14 +24,3 @@ export const renderComponentWithStyles = (
 
   return React.createElement(ReusableStyledComponent, props, children)
 }
-
-export const jsonStringToCss = (json: string | null | undefined) => {
-  const jsonObject = JSON.parse(json ?? '{}')
-  let css = ''
-
-  for (const key in jsonObject) {
-    css += `${key}: ${jsonObject[key]};`
-  }
-
-  return css
-}

--- a/libs/frontend/domain/renderer/src/renderPipes/atom-render-pipe.ts
+++ b/libs/frontend/domain/renderer/src/renderPipes/atom-render-pipe.ts
@@ -8,7 +8,6 @@ import {
 import type { IAtomType } from '@codelab/shared/abstract/core'
 import { ExtendedModel, model, prop } from 'mobx-keystone'
 import { atomFactory } from '../atoms'
-import { jsonStringToCss } from '../element/get-styled-components'
 import { RenderOutput } from '../utils'
 import { BaseRenderPipe } from './render-pipe.base'
 
@@ -47,10 +46,7 @@ export class AtomRenderPipe
       return this.next.render(element, props)
     }
 
-    const elementCss = [
-      element.customCss,
-      jsonStringToCss(element.guiCss),
-    ].join(' ')
+    const css = element.styleCss
 
     if (this.renderer.debugMode) {
       console.info(`AtomRenderPipe: Rendering atom ${atomType}`, {
@@ -66,7 +62,7 @@ export class AtomRenderPipe
         /**
          * This is rendered to style with css prop and styled-components
          */
-        css: elementCss,
+        css,
       },
     })
   }

--- a/libs/frontend/domain/renderer/src/renderPipes/atom-render-pipe.ts
+++ b/libs/frontend/domain/renderer/src/renderPipes/atom-render-pipe.ts
@@ -60,7 +60,7 @@ export class AtomRenderPipe
         /**
          * This is rendered to style with css prop and styled-components
          */
-        css: element.styleCss,
+        css: element.styleStringWithBreakpoints,
       },
     })
   }

--- a/libs/frontend/domain/renderer/src/renderPipes/atom-render-pipe.ts
+++ b/libs/frontend/domain/renderer/src/renderPipes/atom-render-pipe.ts
@@ -46,8 +46,6 @@ export class AtomRenderPipe
       return this.next.render(element, props)
     }
 
-    const css = element.styleCss
-
     if (this.renderer.debugMode) {
       console.info(`AtomRenderPipe: Rendering atom ${atomType}`, {
         element: element.name,
@@ -62,7 +60,7 @@ export class AtomRenderPipe
         /**
          * This is rendered to style with css prop and styled-components
          */
-        css,
+        css: element.styleCss,
       },
     })
   }

--- a/libs/shared/abstract/codegen/src/types.api.graphql.gen.ts
+++ b/libs/shared/abstract/codegen/src/types.api.graphql.gen.ts
@@ -657,36 +657,6 @@ export type ApiActionElementNodeAggregationWhereInput = {
   childMapperPropKey_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars['Int']['input']>
   childMapperPropKey_SHORTEST_LENGTH_LT?: InputMaybe<Scalars['Int']['input']>
   childMapperPropKey_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars['Int']['input']>
-  customCss_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars['Float']['input']>
-  customCss_AVERAGE_LENGTH_GT?: InputMaybe<Scalars['Float']['input']>
-  customCss_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars['Float']['input']>
-  customCss_AVERAGE_LENGTH_LT?: InputMaybe<Scalars['Float']['input']>
-  customCss_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars['Float']['input']>
-  customCss_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars['Int']['input']>
-  customCss_LONGEST_LENGTH_GT?: InputMaybe<Scalars['Int']['input']>
-  customCss_LONGEST_LENGTH_GTE?: InputMaybe<Scalars['Int']['input']>
-  customCss_LONGEST_LENGTH_LT?: InputMaybe<Scalars['Int']['input']>
-  customCss_LONGEST_LENGTH_LTE?: InputMaybe<Scalars['Int']['input']>
-  customCss_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars['Int']['input']>
-  customCss_SHORTEST_LENGTH_GT?: InputMaybe<Scalars['Int']['input']>
-  customCss_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars['Int']['input']>
-  customCss_SHORTEST_LENGTH_LT?: InputMaybe<Scalars['Int']['input']>
-  customCss_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars['Int']['input']>
-  guiCss_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars['Float']['input']>
-  guiCss_AVERAGE_LENGTH_GT?: InputMaybe<Scalars['Float']['input']>
-  guiCss_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars['Float']['input']>
-  guiCss_AVERAGE_LENGTH_LT?: InputMaybe<Scalars['Float']['input']>
-  guiCss_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars['Float']['input']>
-  guiCss_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars['Int']['input']>
-  guiCss_LONGEST_LENGTH_GT?: InputMaybe<Scalars['Int']['input']>
-  guiCss_LONGEST_LENGTH_GTE?: InputMaybe<Scalars['Int']['input']>
-  guiCss_LONGEST_LENGTH_LT?: InputMaybe<Scalars['Int']['input']>
-  guiCss_LONGEST_LENGTH_LTE?: InputMaybe<Scalars['Int']['input']>
-  guiCss_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars['Int']['input']>
-  guiCss_SHORTEST_LENGTH_GT?: InputMaybe<Scalars['Int']['input']>
-  guiCss_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars['Int']['input']>
-  guiCss_SHORTEST_LENGTH_LT?: InputMaybe<Scalars['Int']['input']>
-  guiCss_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars['Int']['input']>
   renderForEachPropKey_AVERAGE_LENGTH_EQUAL?: InputMaybe<
     Scalars['Float']['input']
   >
@@ -4293,36 +4263,6 @@ export type BaseActionElementNodeAggregationWhereInput = {
   childMapperPropKey_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars['Int']['input']>
   childMapperPropKey_SHORTEST_LENGTH_LT?: InputMaybe<Scalars['Int']['input']>
   childMapperPropKey_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars['Int']['input']>
-  customCss_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars['Float']['input']>
-  customCss_AVERAGE_LENGTH_GT?: InputMaybe<Scalars['Float']['input']>
-  customCss_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars['Float']['input']>
-  customCss_AVERAGE_LENGTH_LT?: InputMaybe<Scalars['Float']['input']>
-  customCss_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars['Float']['input']>
-  customCss_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars['Int']['input']>
-  customCss_LONGEST_LENGTH_GT?: InputMaybe<Scalars['Int']['input']>
-  customCss_LONGEST_LENGTH_GTE?: InputMaybe<Scalars['Int']['input']>
-  customCss_LONGEST_LENGTH_LT?: InputMaybe<Scalars['Int']['input']>
-  customCss_LONGEST_LENGTH_LTE?: InputMaybe<Scalars['Int']['input']>
-  customCss_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars['Int']['input']>
-  customCss_SHORTEST_LENGTH_GT?: InputMaybe<Scalars['Int']['input']>
-  customCss_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars['Int']['input']>
-  customCss_SHORTEST_LENGTH_LT?: InputMaybe<Scalars['Int']['input']>
-  customCss_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars['Int']['input']>
-  guiCss_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars['Float']['input']>
-  guiCss_AVERAGE_LENGTH_GT?: InputMaybe<Scalars['Float']['input']>
-  guiCss_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars['Float']['input']>
-  guiCss_AVERAGE_LENGTH_LT?: InputMaybe<Scalars['Float']['input']>
-  guiCss_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars['Float']['input']>
-  guiCss_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars['Int']['input']>
-  guiCss_LONGEST_LENGTH_GT?: InputMaybe<Scalars['Int']['input']>
-  guiCss_LONGEST_LENGTH_GTE?: InputMaybe<Scalars['Int']['input']>
-  guiCss_LONGEST_LENGTH_LT?: InputMaybe<Scalars['Int']['input']>
-  guiCss_LONGEST_LENGTH_LTE?: InputMaybe<Scalars['Int']['input']>
-  guiCss_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars['Int']['input']>
-  guiCss_SHORTEST_LENGTH_GT?: InputMaybe<Scalars['Int']['input']>
-  guiCss_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars['Int']['input']>
-  guiCss_SHORTEST_LENGTH_LT?: InputMaybe<Scalars['Int']['input']>
-  guiCss_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars['Int']['input']>
   renderForEachPropKey_AVERAGE_LENGTH_EQUAL?: InputMaybe<
     Scalars['Float']['input']
   >
@@ -4945,36 +4885,6 @@ export type CodeActionElementNodeAggregationWhereInput = {
   childMapperPropKey_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars['Int']['input']>
   childMapperPropKey_SHORTEST_LENGTH_LT?: InputMaybe<Scalars['Int']['input']>
   childMapperPropKey_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars['Int']['input']>
-  customCss_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars['Float']['input']>
-  customCss_AVERAGE_LENGTH_GT?: InputMaybe<Scalars['Float']['input']>
-  customCss_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars['Float']['input']>
-  customCss_AVERAGE_LENGTH_LT?: InputMaybe<Scalars['Float']['input']>
-  customCss_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars['Float']['input']>
-  customCss_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars['Int']['input']>
-  customCss_LONGEST_LENGTH_GT?: InputMaybe<Scalars['Int']['input']>
-  customCss_LONGEST_LENGTH_GTE?: InputMaybe<Scalars['Int']['input']>
-  customCss_LONGEST_LENGTH_LT?: InputMaybe<Scalars['Int']['input']>
-  customCss_LONGEST_LENGTH_LTE?: InputMaybe<Scalars['Int']['input']>
-  customCss_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars['Int']['input']>
-  customCss_SHORTEST_LENGTH_GT?: InputMaybe<Scalars['Int']['input']>
-  customCss_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars['Int']['input']>
-  customCss_SHORTEST_LENGTH_LT?: InputMaybe<Scalars['Int']['input']>
-  customCss_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars['Int']['input']>
-  guiCss_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars['Float']['input']>
-  guiCss_AVERAGE_LENGTH_GT?: InputMaybe<Scalars['Float']['input']>
-  guiCss_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars['Float']['input']>
-  guiCss_AVERAGE_LENGTH_LT?: InputMaybe<Scalars['Float']['input']>
-  guiCss_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars['Float']['input']>
-  guiCss_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars['Int']['input']>
-  guiCss_LONGEST_LENGTH_GT?: InputMaybe<Scalars['Int']['input']>
-  guiCss_LONGEST_LENGTH_GTE?: InputMaybe<Scalars['Int']['input']>
-  guiCss_LONGEST_LENGTH_LT?: InputMaybe<Scalars['Int']['input']>
-  guiCss_LONGEST_LENGTH_LTE?: InputMaybe<Scalars['Int']['input']>
-  guiCss_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars['Int']['input']>
-  guiCss_SHORTEST_LENGTH_GT?: InputMaybe<Scalars['Int']['input']>
-  guiCss_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars['Int']['input']>
-  guiCss_SHORTEST_LENGTH_LT?: InputMaybe<Scalars['Int']['input']>
-  guiCss_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars['Int']['input']>
   renderForEachPropKey_AVERAGE_LENGTH_EQUAL?: InputMaybe<
     Scalars['Float']['input']
   >
@@ -5758,36 +5668,6 @@ export type ComponentChildrenContainerElementNodeAggregationWhereInput = {
   childMapperPropKey_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars['Int']['input']>
   childMapperPropKey_SHORTEST_LENGTH_LT?: InputMaybe<Scalars['Int']['input']>
   childMapperPropKey_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars['Int']['input']>
-  customCss_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars['Float']['input']>
-  customCss_AVERAGE_LENGTH_GT?: InputMaybe<Scalars['Float']['input']>
-  customCss_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars['Float']['input']>
-  customCss_AVERAGE_LENGTH_LT?: InputMaybe<Scalars['Float']['input']>
-  customCss_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars['Float']['input']>
-  customCss_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars['Int']['input']>
-  customCss_LONGEST_LENGTH_GT?: InputMaybe<Scalars['Int']['input']>
-  customCss_LONGEST_LENGTH_GTE?: InputMaybe<Scalars['Int']['input']>
-  customCss_LONGEST_LENGTH_LT?: InputMaybe<Scalars['Int']['input']>
-  customCss_LONGEST_LENGTH_LTE?: InputMaybe<Scalars['Int']['input']>
-  customCss_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars['Int']['input']>
-  customCss_SHORTEST_LENGTH_GT?: InputMaybe<Scalars['Int']['input']>
-  customCss_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars['Int']['input']>
-  customCss_SHORTEST_LENGTH_LT?: InputMaybe<Scalars['Int']['input']>
-  customCss_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars['Int']['input']>
-  guiCss_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars['Float']['input']>
-  guiCss_AVERAGE_LENGTH_GT?: InputMaybe<Scalars['Float']['input']>
-  guiCss_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars['Float']['input']>
-  guiCss_AVERAGE_LENGTH_LT?: InputMaybe<Scalars['Float']['input']>
-  guiCss_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars['Float']['input']>
-  guiCss_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars['Int']['input']>
-  guiCss_LONGEST_LENGTH_GT?: InputMaybe<Scalars['Int']['input']>
-  guiCss_LONGEST_LENGTH_GTE?: InputMaybe<Scalars['Int']['input']>
-  guiCss_LONGEST_LENGTH_LT?: InputMaybe<Scalars['Int']['input']>
-  guiCss_LONGEST_LENGTH_LTE?: InputMaybe<Scalars['Int']['input']>
-  guiCss_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars['Int']['input']>
-  guiCss_SHORTEST_LENGTH_GT?: InputMaybe<Scalars['Int']['input']>
-  guiCss_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars['Int']['input']>
-  guiCss_SHORTEST_LENGTH_LT?: InputMaybe<Scalars['Int']['input']>
-  guiCss_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars['Int']['input']>
   renderForEachPropKey_AVERAGE_LENGTH_EQUAL?: InputMaybe<
     Scalars['Float']['input']
   >
@@ -6276,36 +6156,6 @@ export type ComponentRootElementNodeAggregationWhereInput = {
   childMapperPropKey_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars['Int']['input']>
   childMapperPropKey_SHORTEST_LENGTH_LT?: InputMaybe<Scalars['Int']['input']>
   childMapperPropKey_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars['Int']['input']>
-  customCss_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars['Float']['input']>
-  customCss_AVERAGE_LENGTH_GT?: InputMaybe<Scalars['Float']['input']>
-  customCss_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars['Float']['input']>
-  customCss_AVERAGE_LENGTH_LT?: InputMaybe<Scalars['Float']['input']>
-  customCss_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars['Float']['input']>
-  customCss_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars['Int']['input']>
-  customCss_LONGEST_LENGTH_GT?: InputMaybe<Scalars['Int']['input']>
-  customCss_LONGEST_LENGTH_GTE?: InputMaybe<Scalars['Int']['input']>
-  customCss_LONGEST_LENGTH_LT?: InputMaybe<Scalars['Int']['input']>
-  customCss_LONGEST_LENGTH_LTE?: InputMaybe<Scalars['Int']['input']>
-  customCss_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars['Int']['input']>
-  customCss_SHORTEST_LENGTH_GT?: InputMaybe<Scalars['Int']['input']>
-  customCss_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars['Int']['input']>
-  customCss_SHORTEST_LENGTH_LT?: InputMaybe<Scalars['Int']['input']>
-  customCss_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars['Int']['input']>
-  guiCss_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars['Float']['input']>
-  guiCss_AVERAGE_LENGTH_GT?: InputMaybe<Scalars['Float']['input']>
-  guiCss_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars['Float']['input']>
-  guiCss_AVERAGE_LENGTH_LT?: InputMaybe<Scalars['Float']['input']>
-  guiCss_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars['Float']['input']>
-  guiCss_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars['Int']['input']>
-  guiCss_LONGEST_LENGTH_GT?: InputMaybe<Scalars['Int']['input']>
-  guiCss_LONGEST_LENGTH_GTE?: InputMaybe<Scalars['Int']['input']>
-  guiCss_LONGEST_LENGTH_LT?: InputMaybe<Scalars['Int']['input']>
-  guiCss_LONGEST_LENGTH_LTE?: InputMaybe<Scalars['Int']['input']>
-  guiCss_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars['Int']['input']>
-  guiCss_SHORTEST_LENGTH_GT?: InputMaybe<Scalars['Int']['input']>
-  guiCss_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars['Int']['input']>
-  guiCss_SHORTEST_LENGTH_LT?: InputMaybe<Scalars['Int']['input']>
-  guiCss_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars['Int']['input']>
   renderForEachPropKey_AVERAGE_LENGTH_EQUAL?: InputMaybe<
     Scalars['Float']['input']
   >
@@ -7104,6 +6954,7 @@ export type Element = {
   renderIfExpression?: Maybe<Scalars['String']['output']>
   renderType?: Maybe<RenderType>
   slug: Scalars['String']['output']
+  style?: Maybe<Scalars['String']['output']>
 }
 
 export type ElementChildMapperComponentArgs = {
@@ -7599,36 +7450,6 @@ export type ElementChildMapperPreviousSiblingNodeAggregationWhereInput = {
   childMapperPropKey_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars['Int']['input']>
   childMapperPropKey_SHORTEST_LENGTH_LT?: InputMaybe<Scalars['Int']['input']>
   childMapperPropKey_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars['Int']['input']>
-  customCss_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars['Float']['input']>
-  customCss_AVERAGE_LENGTH_GT?: InputMaybe<Scalars['Float']['input']>
-  customCss_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars['Float']['input']>
-  customCss_AVERAGE_LENGTH_LT?: InputMaybe<Scalars['Float']['input']>
-  customCss_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars['Float']['input']>
-  customCss_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars['Int']['input']>
-  customCss_LONGEST_LENGTH_GT?: InputMaybe<Scalars['Int']['input']>
-  customCss_LONGEST_LENGTH_GTE?: InputMaybe<Scalars['Int']['input']>
-  customCss_LONGEST_LENGTH_LT?: InputMaybe<Scalars['Int']['input']>
-  customCss_LONGEST_LENGTH_LTE?: InputMaybe<Scalars['Int']['input']>
-  customCss_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars['Int']['input']>
-  customCss_SHORTEST_LENGTH_GT?: InputMaybe<Scalars['Int']['input']>
-  customCss_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars['Int']['input']>
-  customCss_SHORTEST_LENGTH_LT?: InputMaybe<Scalars['Int']['input']>
-  customCss_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars['Int']['input']>
-  guiCss_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars['Float']['input']>
-  guiCss_AVERAGE_LENGTH_GT?: InputMaybe<Scalars['Float']['input']>
-  guiCss_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars['Float']['input']>
-  guiCss_AVERAGE_LENGTH_LT?: InputMaybe<Scalars['Float']['input']>
-  guiCss_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars['Float']['input']>
-  guiCss_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars['Int']['input']>
-  guiCss_LONGEST_LENGTH_GT?: InputMaybe<Scalars['Int']['input']>
-  guiCss_LONGEST_LENGTH_GTE?: InputMaybe<Scalars['Int']['input']>
-  guiCss_LONGEST_LENGTH_LT?: InputMaybe<Scalars['Int']['input']>
-  guiCss_LONGEST_LENGTH_LTE?: InputMaybe<Scalars['Int']['input']>
-  guiCss_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars['Int']['input']>
-  guiCss_SHORTEST_LENGTH_GT?: InputMaybe<Scalars['Int']['input']>
-  guiCss_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars['Int']['input']>
-  guiCss_SHORTEST_LENGTH_LT?: InputMaybe<Scalars['Int']['input']>
-  guiCss_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars['Int']['input']>
   renderForEachPropKey_AVERAGE_LENGTH_EQUAL?: InputMaybe<
     Scalars['Float']['input']
   >
@@ -8027,36 +7848,6 @@ export type ElementFirstChildNodeAggregationWhereInput = {
   childMapperPropKey_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars['Int']['input']>
   childMapperPropKey_SHORTEST_LENGTH_LT?: InputMaybe<Scalars['Int']['input']>
   childMapperPropKey_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars['Int']['input']>
-  customCss_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars['Float']['input']>
-  customCss_AVERAGE_LENGTH_GT?: InputMaybe<Scalars['Float']['input']>
-  customCss_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars['Float']['input']>
-  customCss_AVERAGE_LENGTH_LT?: InputMaybe<Scalars['Float']['input']>
-  customCss_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars['Float']['input']>
-  customCss_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars['Int']['input']>
-  customCss_LONGEST_LENGTH_GT?: InputMaybe<Scalars['Int']['input']>
-  customCss_LONGEST_LENGTH_GTE?: InputMaybe<Scalars['Int']['input']>
-  customCss_LONGEST_LENGTH_LT?: InputMaybe<Scalars['Int']['input']>
-  customCss_LONGEST_LENGTH_LTE?: InputMaybe<Scalars['Int']['input']>
-  customCss_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars['Int']['input']>
-  customCss_SHORTEST_LENGTH_GT?: InputMaybe<Scalars['Int']['input']>
-  customCss_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars['Int']['input']>
-  customCss_SHORTEST_LENGTH_LT?: InputMaybe<Scalars['Int']['input']>
-  customCss_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars['Int']['input']>
-  guiCss_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars['Float']['input']>
-  guiCss_AVERAGE_LENGTH_GT?: InputMaybe<Scalars['Float']['input']>
-  guiCss_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars['Float']['input']>
-  guiCss_AVERAGE_LENGTH_LT?: InputMaybe<Scalars['Float']['input']>
-  guiCss_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars['Float']['input']>
-  guiCss_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars['Int']['input']>
-  guiCss_LONGEST_LENGTH_GT?: InputMaybe<Scalars['Int']['input']>
-  guiCss_LONGEST_LENGTH_GTE?: InputMaybe<Scalars['Int']['input']>
-  guiCss_LONGEST_LENGTH_LT?: InputMaybe<Scalars['Int']['input']>
-  guiCss_LONGEST_LENGTH_LTE?: InputMaybe<Scalars['Int']['input']>
-  guiCss_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars['Int']['input']>
-  guiCss_SHORTEST_LENGTH_GT?: InputMaybe<Scalars['Int']['input']>
-  guiCss_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars['Int']['input']>
-  guiCss_SHORTEST_LENGTH_LT?: InputMaybe<Scalars['Int']['input']>
-  guiCss_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars['Int']['input']>
   renderForEachPropKey_AVERAGE_LENGTH_EQUAL?: InputMaybe<
     Scalars['Float']['input']
   >
@@ -8238,36 +8029,6 @@ export type ElementNextSiblingNodeAggregationWhereInput = {
   childMapperPropKey_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars['Int']['input']>
   childMapperPropKey_SHORTEST_LENGTH_LT?: InputMaybe<Scalars['Int']['input']>
   childMapperPropKey_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars['Int']['input']>
-  customCss_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars['Float']['input']>
-  customCss_AVERAGE_LENGTH_GT?: InputMaybe<Scalars['Float']['input']>
-  customCss_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars['Float']['input']>
-  customCss_AVERAGE_LENGTH_LT?: InputMaybe<Scalars['Float']['input']>
-  customCss_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars['Float']['input']>
-  customCss_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars['Int']['input']>
-  customCss_LONGEST_LENGTH_GT?: InputMaybe<Scalars['Int']['input']>
-  customCss_LONGEST_LENGTH_GTE?: InputMaybe<Scalars['Int']['input']>
-  customCss_LONGEST_LENGTH_LT?: InputMaybe<Scalars['Int']['input']>
-  customCss_LONGEST_LENGTH_LTE?: InputMaybe<Scalars['Int']['input']>
-  customCss_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars['Int']['input']>
-  customCss_SHORTEST_LENGTH_GT?: InputMaybe<Scalars['Int']['input']>
-  customCss_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars['Int']['input']>
-  customCss_SHORTEST_LENGTH_LT?: InputMaybe<Scalars['Int']['input']>
-  customCss_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars['Int']['input']>
-  guiCss_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars['Float']['input']>
-  guiCss_AVERAGE_LENGTH_GT?: InputMaybe<Scalars['Float']['input']>
-  guiCss_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars['Float']['input']>
-  guiCss_AVERAGE_LENGTH_LT?: InputMaybe<Scalars['Float']['input']>
-  guiCss_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars['Float']['input']>
-  guiCss_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars['Int']['input']>
-  guiCss_LONGEST_LENGTH_GT?: InputMaybe<Scalars['Int']['input']>
-  guiCss_LONGEST_LENGTH_GTE?: InputMaybe<Scalars['Int']['input']>
-  guiCss_LONGEST_LENGTH_LT?: InputMaybe<Scalars['Int']['input']>
-  guiCss_LONGEST_LENGTH_LTE?: InputMaybe<Scalars['Int']['input']>
-  guiCss_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars['Int']['input']>
-  guiCss_SHORTEST_LENGTH_GT?: InputMaybe<Scalars['Int']['input']>
-  guiCss_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars['Int']['input']>
-  guiCss_SHORTEST_LENGTH_LT?: InputMaybe<Scalars['Int']['input']>
-  guiCss_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars['Int']['input']>
   renderForEachPropKey_AVERAGE_LENGTH_EQUAL?: InputMaybe<
     Scalars['Float']['input']
   >
@@ -8722,36 +8483,6 @@ export type ElementParentNodeAggregationWhereInput = {
   childMapperPropKey_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars['Int']['input']>
   childMapperPropKey_SHORTEST_LENGTH_LT?: InputMaybe<Scalars['Int']['input']>
   childMapperPropKey_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars['Int']['input']>
-  customCss_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars['Float']['input']>
-  customCss_AVERAGE_LENGTH_GT?: InputMaybe<Scalars['Float']['input']>
-  customCss_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars['Float']['input']>
-  customCss_AVERAGE_LENGTH_LT?: InputMaybe<Scalars['Float']['input']>
-  customCss_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars['Float']['input']>
-  customCss_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars['Int']['input']>
-  customCss_LONGEST_LENGTH_GT?: InputMaybe<Scalars['Int']['input']>
-  customCss_LONGEST_LENGTH_GTE?: InputMaybe<Scalars['Int']['input']>
-  customCss_LONGEST_LENGTH_LT?: InputMaybe<Scalars['Int']['input']>
-  customCss_LONGEST_LENGTH_LTE?: InputMaybe<Scalars['Int']['input']>
-  customCss_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars['Int']['input']>
-  customCss_SHORTEST_LENGTH_GT?: InputMaybe<Scalars['Int']['input']>
-  customCss_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars['Int']['input']>
-  customCss_SHORTEST_LENGTH_LT?: InputMaybe<Scalars['Int']['input']>
-  customCss_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars['Int']['input']>
-  guiCss_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars['Float']['input']>
-  guiCss_AVERAGE_LENGTH_GT?: InputMaybe<Scalars['Float']['input']>
-  guiCss_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars['Float']['input']>
-  guiCss_AVERAGE_LENGTH_LT?: InputMaybe<Scalars['Float']['input']>
-  guiCss_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars['Float']['input']>
-  guiCss_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars['Int']['input']>
-  guiCss_LONGEST_LENGTH_GT?: InputMaybe<Scalars['Int']['input']>
-  guiCss_LONGEST_LENGTH_GTE?: InputMaybe<Scalars['Int']['input']>
-  guiCss_LONGEST_LENGTH_LT?: InputMaybe<Scalars['Int']['input']>
-  guiCss_LONGEST_LENGTH_LTE?: InputMaybe<Scalars['Int']['input']>
-  guiCss_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars['Int']['input']>
-  guiCss_SHORTEST_LENGTH_GT?: InputMaybe<Scalars['Int']['input']>
-  guiCss_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars['Int']['input']>
-  guiCss_SHORTEST_LENGTH_LT?: InputMaybe<Scalars['Int']['input']>
-  guiCss_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars['Int']['input']>
   renderForEachPropKey_AVERAGE_LENGTH_EQUAL?: InputMaybe<
     Scalars['Float']['input']
   >
@@ -9055,36 +8786,6 @@ export type ElementPrevSiblingNodeAggregationWhereInput = {
   childMapperPropKey_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars['Int']['input']>
   childMapperPropKey_SHORTEST_LENGTH_LT?: InputMaybe<Scalars['Int']['input']>
   childMapperPropKey_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars['Int']['input']>
-  customCss_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars['Float']['input']>
-  customCss_AVERAGE_LENGTH_GT?: InputMaybe<Scalars['Float']['input']>
-  customCss_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars['Float']['input']>
-  customCss_AVERAGE_LENGTH_LT?: InputMaybe<Scalars['Float']['input']>
-  customCss_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars['Float']['input']>
-  customCss_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars['Int']['input']>
-  customCss_LONGEST_LENGTH_GT?: InputMaybe<Scalars['Int']['input']>
-  customCss_LONGEST_LENGTH_GTE?: InputMaybe<Scalars['Int']['input']>
-  customCss_LONGEST_LENGTH_LT?: InputMaybe<Scalars['Int']['input']>
-  customCss_LONGEST_LENGTH_LTE?: InputMaybe<Scalars['Int']['input']>
-  customCss_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars['Int']['input']>
-  customCss_SHORTEST_LENGTH_GT?: InputMaybe<Scalars['Int']['input']>
-  customCss_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars['Int']['input']>
-  customCss_SHORTEST_LENGTH_LT?: InputMaybe<Scalars['Int']['input']>
-  customCss_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars['Int']['input']>
-  guiCss_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars['Float']['input']>
-  guiCss_AVERAGE_LENGTH_GT?: InputMaybe<Scalars['Float']['input']>
-  guiCss_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars['Float']['input']>
-  guiCss_AVERAGE_LENGTH_LT?: InputMaybe<Scalars['Float']['input']>
-  guiCss_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars['Float']['input']>
-  guiCss_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars['Int']['input']>
-  guiCss_LONGEST_LENGTH_GT?: InputMaybe<Scalars['Int']['input']>
-  guiCss_LONGEST_LENGTH_GTE?: InputMaybe<Scalars['Int']['input']>
-  guiCss_LONGEST_LENGTH_LT?: InputMaybe<Scalars['Int']['input']>
-  guiCss_LONGEST_LENGTH_LTE?: InputMaybe<Scalars['Int']['input']>
-  guiCss_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars['Int']['input']>
-  guiCss_SHORTEST_LENGTH_GT?: InputMaybe<Scalars['Int']['input']>
-  guiCss_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars['Int']['input']>
-  guiCss_SHORTEST_LENGTH_LT?: InputMaybe<Scalars['Int']['input']>
-  guiCss_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars['Int']['input']>
   renderForEachPropKey_AVERAGE_LENGTH_EQUAL?: InputMaybe<
     Scalars['Float']['input']
   >
@@ -12064,36 +11765,6 @@ export type HookElementNodeAggregationWhereInput = {
   childMapperPropKey_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars['Int']['input']>
   childMapperPropKey_SHORTEST_LENGTH_LT?: InputMaybe<Scalars['Int']['input']>
   childMapperPropKey_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars['Int']['input']>
-  customCss_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars['Float']['input']>
-  customCss_AVERAGE_LENGTH_GT?: InputMaybe<Scalars['Float']['input']>
-  customCss_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars['Float']['input']>
-  customCss_AVERAGE_LENGTH_LT?: InputMaybe<Scalars['Float']['input']>
-  customCss_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars['Float']['input']>
-  customCss_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars['Int']['input']>
-  customCss_LONGEST_LENGTH_GT?: InputMaybe<Scalars['Int']['input']>
-  customCss_LONGEST_LENGTH_GTE?: InputMaybe<Scalars['Int']['input']>
-  customCss_LONGEST_LENGTH_LT?: InputMaybe<Scalars['Int']['input']>
-  customCss_LONGEST_LENGTH_LTE?: InputMaybe<Scalars['Int']['input']>
-  customCss_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars['Int']['input']>
-  customCss_SHORTEST_LENGTH_GT?: InputMaybe<Scalars['Int']['input']>
-  customCss_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars['Int']['input']>
-  customCss_SHORTEST_LENGTH_LT?: InputMaybe<Scalars['Int']['input']>
-  customCss_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars['Int']['input']>
-  guiCss_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars['Float']['input']>
-  guiCss_AVERAGE_LENGTH_GT?: InputMaybe<Scalars['Float']['input']>
-  guiCss_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars['Float']['input']>
-  guiCss_AVERAGE_LENGTH_LT?: InputMaybe<Scalars['Float']['input']>
-  guiCss_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars['Float']['input']>
-  guiCss_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars['Int']['input']>
-  guiCss_LONGEST_LENGTH_GT?: InputMaybe<Scalars['Int']['input']>
-  guiCss_LONGEST_LENGTH_GTE?: InputMaybe<Scalars['Int']['input']>
-  guiCss_LONGEST_LENGTH_LT?: InputMaybe<Scalars['Int']['input']>
-  guiCss_LONGEST_LENGTH_LTE?: InputMaybe<Scalars['Int']['input']>
-  guiCss_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars['Int']['input']>
-  guiCss_SHORTEST_LENGTH_GT?: InputMaybe<Scalars['Int']['input']>
-  guiCss_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars['Int']['input']>
-  guiCss_SHORTEST_LENGTH_LT?: InputMaybe<Scalars['Int']['input']>
-  guiCss_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars['Int']['input']>
   renderForEachPropKey_AVERAGE_LENGTH_EQUAL?: InputMaybe<
     Scalars['Float']['input']
   >
@@ -14800,36 +14471,6 @@ export type PagePageContentContainerNodeAggregationWhereInput = {
   childMapperPropKey_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars['Int']['input']>
   childMapperPropKey_SHORTEST_LENGTH_LT?: InputMaybe<Scalars['Int']['input']>
   childMapperPropKey_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars['Int']['input']>
-  customCss_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars['Float']['input']>
-  customCss_AVERAGE_LENGTH_GT?: InputMaybe<Scalars['Float']['input']>
-  customCss_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars['Float']['input']>
-  customCss_AVERAGE_LENGTH_LT?: InputMaybe<Scalars['Float']['input']>
-  customCss_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars['Float']['input']>
-  customCss_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars['Int']['input']>
-  customCss_LONGEST_LENGTH_GT?: InputMaybe<Scalars['Int']['input']>
-  customCss_LONGEST_LENGTH_GTE?: InputMaybe<Scalars['Int']['input']>
-  customCss_LONGEST_LENGTH_LT?: InputMaybe<Scalars['Int']['input']>
-  customCss_LONGEST_LENGTH_LTE?: InputMaybe<Scalars['Int']['input']>
-  customCss_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars['Int']['input']>
-  customCss_SHORTEST_LENGTH_GT?: InputMaybe<Scalars['Int']['input']>
-  customCss_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars['Int']['input']>
-  customCss_SHORTEST_LENGTH_LT?: InputMaybe<Scalars['Int']['input']>
-  customCss_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars['Int']['input']>
-  guiCss_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars['Float']['input']>
-  guiCss_AVERAGE_LENGTH_GT?: InputMaybe<Scalars['Float']['input']>
-  guiCss_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars['Float']['input']>
-  guiCss_AVERAGE_LENGTH_LT?: InputMaybe<Scalars['Float']['input']>
-  guiCss_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars['Float']['input']>
-  guiCss_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars['Int']['input']>
-  guiCss_LONGEST_LENGTH_GT?: InputMaybe<Scalars['Int']['input']>
-  guiCss_LONGEST_LENGTH_GTE?: InputMaybe<Scalars['Int']['input']>
-  guiCss_LONGEST_LENGTH_LT?: InputMaybe<Scalars['Int']['input']>
-  guiCss_LONGEST_LENGTH_LTE?: InputMaybe<Scalars['Int']['input']>
-  guiCss_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars['Int']['input']>
-  guiCss_SHORTEST_LENGTH_GT?: InputMaybe<Scalars['Int']['input']>
-  guiCss_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars['Int']['input']>
-  guiCss_SHORTEST_LENGTH_LT?: InputMaybe<Scalars['Int']['input']>
-  guiCss_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars['Int']['input']>
   renderForEachPropKey_AVERAGE_LENGTH_EQUAL?: InputMaybe<
     Scalars['Float']['input']
   >
@@ -15018,36 +14659,6 @@ export type PageRootElementNodeAggregationWhereInput = {
   childMapperPropKey_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars['Int']['input']>
   childMapperPropKey_SHORTEST_LENGTH_LT?: InputMaybe<Scalars['Int']['input']>
   childMapperPropKey_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars['Int']['input']>
-  customCss_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars['Float']['input']>
-  customCss_AVERAGE_LENGTH_GT?: InputMaybe<Scalars['Float']['input']>
-  customCss_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars['Float']['input']>
-  customCss_AVERAGE_LENGTH_LT?: InputMaybe<Scalars['Float']['input']>
-  customCss_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars['Float']['input']>
-  customCss_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars['Int']['input']>
-  customCss_LONGEST_LENGTH_GT?: InputMaybe<Scalars['Int']['input']>
-  customCss_LONGEST_LENGTH_GTE?: InputMaybe<Scalars['Int']['input']>
-  customCss_LONGEST_LENGTH_LT?: InputMaybe<Scalars['Int']['input']>
-  customCss_LONGEST_LENGTH_LTE?: InputMaybe<Scalars['Int']['input']>
-  customCss_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars['Int']['input']>
-  customCss_SHORTEST_LENGTH_GT?: InputMaybe<Scalars['Int']['input']>
-  customCss_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars['Int']['input']>
-  customCss_SHORTEST_LENGTH_LT?: InputMaybe<Scalars['Int']['input']>
-  customCss_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars['Int']['input']>
-  guiCss_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars['Float']['input']>
-  guiCss_AVERAGE_LENGTH_GT?: InputMaybe<Scalars['Float']['input']>
-  guiCss_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars['Float']['input']>
-  guiCss_AVERAGE_LENGTH_LT?: InputMaybe<Scalars['Float']['input']>
-  guiCss_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars['Float']['input']>
-  guiCss_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars['Int']['input']>
-  guiCss_LONGEST_LENGTH_GT?: InputMaybe<Scalars['Int']['input']>
-  guiCss_LONGEST_LENGTH_GTE?: InputMaybe<Scalars['Int']['input']>
-  guiCss_LONGEST_LENGTH_LT?: InputMaybe<Scalars['Int']['input']>
-  guiCss_LONGEST_LENGTH_LTE?: InputMaybe<Scalars['Int']['input']>
-  guiCss_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars['Int']['input']>
-  guiCss_SHORTEST_LENGTH_GT?: InputMaybe<Scalars['Int']['input']>
-  guiCss_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars['Int']['input']>
-  guiCss_SHORTEST_LENGTH_LT?: InputMaybe<Scalars['Int']['input']>
-  guiCss_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars['Int']['input']>
   renderForEachPropKey_AVERAGE_LENGTH_EQUAL?: InputMaybe<
     Scalars['Float']['input']
   >
@@ -21540,36 +21151,6 @@ export type UserElementsNodeAggregationWhereInput = {
   childMapperPropKey_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars['Int']['input']>
   childMapperPropKey_SHORTEST_LENGTH_LT?: InputMaybe<Scalars['Int']['input']>
   childMapperPropKey_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars['Int']['input']>
-  customCss_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars['Float']['input']>
-  customCss_AVERAGE_LENGTH_GT?: InputMaybe<Scalars['Float']['input']>
-  customCss_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars['Float']['input']>
-  customCss_AVERAGE_LENGTH_LT?: InputMaybe<Scalars['Float']['input']>
-  customCss_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars['Float']['input']>
-  customCss_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars['Int']['input']>
-  customCss_LONGEST_LENGTH_GT?: InputMaybe<Scalars['Int']['input']>
-  customCss_LONGEST_LENGTH_GTE?: InputMaybe<Scalars['Int']['input']>
-  customCss_LONGEST_LENGTH_LT?: InputMaybe<Scalars['Int']['input']>
-  customCss_LONGEST_LENGTH_LTE?: InputMaybe<Scalars['Int']['input']>
-  customCss_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars['Int']['input']>
-  customCss_SHORTEST_LENGTH_GT?: InputMaybe<Scalars['Int']['input']>
-  customCss_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars['Int']['input']>
-  customCss_SHORTEST_LENGTH_LT?: InputMaybe<Scalars['Int']['input']>
-  customCss_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars['Int']['input']>
-  guiCss_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars['Float']['input']>
-  guiCss_AVERAGE_LENGTH_GT?: InputMaybe<Scalars['Float']['input']>
-  guiCss_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars['Float']['input']>
-  guiCss_AVERAGE_LENGTH_LT?: InputMaybe<Scalars['Float']['input']>
-  guiCss_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars['Float']['input']>
-  guiCss_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars['Int']['input']>
-  guiCss_LONGEST_LENGTH_GT?: InputMaybe<Scalars['Int']['input']>
-  guiCss_LONGEST_LENGTH_GTE?: InputMaybe<Scalars['Int']['input']>
-  guiCss_LONGEST_LENGTH_LT?: InputMaybe<Scalars['Int']['input']>
-  guiCss_LONGEST_LENGTH_LTE?: InputMaybe<Scalars['Int']['input']>
-  guiCss_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars['Int']['input']>
-  guiCss_SHORTEST_LENGTH_GT?: InputMaybe<Scalars['Int']['input']>
-  guiCss_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars['Int']['input']>
-  guiCss_SHORTEST_LENGTH_LT?: InputMaybe<Scalars['Int']['input']>
-  guiCss_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars['Int']['input']>
   renderForEachPropKey_AVERAGE_LENGTH_EQUAL?: InputMaybe<
     Scalars['Float']['input']
   >
@@ -22345,8 +21926,7 @@ export type ElementFragment = {
   __typename: 'Element'
   id: string
   name: string
-  customCss?: string | null
-  guiCss?: string | null
+  style?: string | null
   childMapperPropKey?: string | null
   renderForEachPropKey?: string | null
   renderIfExpression?: string | null

--- a/libs/shared/abstract/codegen/src/types.api.graphql.gen.ts
+++ b/libs/shared/abstract/codegen/src/types.api.graphql.gen.ts
@@ -615,11 +615,10 @@ export type ApiActionElementElementNodeAggregateSelection = {
   __typename?: 'ApiActionElementElementNodeAggregateSelection'
   _compoundName: StringAggregateSelectionNonNullable
   childMapperPropKey: StringAggregateSelectionNullable
-  customCss: StringAggregateSelectionNullable
-  guiCss: StringAggregateSelectionNullable
   id: IdAggregateSelectionNonNullable
   renderForEachPropKey: StringAggregateSelectionNullable
   renderIfExpression: StringAggregateSelectionNullable
+  style: StringAggregateSelectionNullable
 }
 
 export type ApiActionElementNodeAggregationWhereInput = {
@@ -730,6 +729,21 @@ export type ApiActionElementNodeAggregationWhereInput = {
   renderIfExpression_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars['Int']['input']>
   renderIfExpression_SHORTEST_LENGTH_LT?: InputMaybe<Scalars['Int']['input']>
   renderIfExpression_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars['Int']['input']>
+  style_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars['Float']['input']>
+  style_AVERAGE_LENGTH_GT?: InputMaybe<Scalars['Float']['input']>
+  style_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars['Float']['input']>
+  style_AVERAGE_LENGTH_LT?: InputMaybe<Scalars['Float']['input']>
+  style_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars['Float']['input']>
+  style_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars['Int']['input']>
+  style_LONGEST_LENGTH_GT?: InputMaybe<Scalars['Int']['input']>
+  style_LONGEST_LENGTH_GTE?: InputMaybe<Scalars['Int']['input']>
+  style_LONGEST_LENGTH_LT?: InputMaybe<Scalars['Int']['input']>
+  style_LONGEST_LENGTH_LTE?: InputMaybe<Scalars['Int']['input']>
+  style_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars['Int']['input']>
+  style_SHORTEST_LENGTH_GT?: InputMaybe<Scalars['Int']['input']>
+  style_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars['Int']['input']>
+  style_SHORTEST_LENGTH_LT?: InputMaybe<Scalars['Int']['input']>
+  style_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars['Int']['input']>
 }
 
 export type ApiActionErrorActionApiActionConnectFieldInput = {
@@ -4351,6 +4365,21 @@ export type BaseActionElementNodeAggregationWhereInput = {
   renderIfExpression_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars['Int']['input']>
   renderIfExpression_SHORTEST_LENGTH_LT?: InputMaybe<Scalars['Int']['input']>
   renderIfExpression_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars['Int']['input']>
+  style_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars['Float']['input']>
+  style_AVERAGE_LENGTH_GT?: InputMaybe<Scalars['Float']['input']>
+  style_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars['Float']['input']>
+  style_AVERAGE_LENGTH_LT?: InputMaybe<Scalars['Float']['input']>
+  style_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars['Float']['input']>
+  style_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars['Int']['input']>
+  style_LONGEST_LENGTH_GT?: InputMaybe<Scalars['Int']['input']>
+  style_LONGEST_LENGTH_GTE?: InputMaybe<Scalars['Int']['input']>
+  style_LONGEST_LENGTH_LT?: InputMaybe<Scalars['Int']['input']>
+  style_LONGEST_LENGTH_LTE?: InputMaybe<Scalars['Int']['input']>
+  style_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars['Int']['input']>
+  style_SHORTEST_LENGTH_GT?: InputMaybe<Scalars['Int']['input']>
+  style_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars['Int']['input']>
+  style_SHORTEST_LENGTH_LT?: InputMaybe<Scalars['Int']['input']>
+  style_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars['Int']['input']>
 }
 
 export type BaseActionElementRelationship = {
@@ -4874,11 +4903,10 @@ export type CodeActionElementElementNodeAggregateSelection = {
   __typename?: 'CodeActionElementElementNodeAggregateSelection'
   _compoundName: StringAggregateSelectionNonNullable
   childMapperPropKey: StringAggregateSelectionNullable
-  customCss: StringAggregateSelectionNullable
-  guiCss: StringAggregateSelectionNullable
   id: IdAggregateSelectionNonNullable
   renderForEachPropKey: StringAggregateSelectionNullable
   renderIfExpression: StringAggregateSelectionNullable
+  style: StringAggregateSelectionNullable
 }
 
 export type CodeActionElementNodeAggregationWhereInput = {
@@ -4989,6 +5017,21 @@ export type CodeActionElementNodeAggregationWhereInput = {
   renderIfExpression_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars['Int']['input']>
   renderIfExpression_SHORTEST_LENGTH_LT?: InputMaybe<Scalars['Int']['input']>
   renderIfExpression_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars['Int']['input']>
+  style_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars['Float']['input']>
+  style_AVERAGE_LENGTH_GT?: InputMaybe<Scalars['Float']['input']>
+  style_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars['Float']['input']>
+  style_AVERAGE_LENGTH_LT?: InputMaybe<Scalars['Float']['input']>
+  style_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars['Float']['input']>
+  style_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars['Int']['input']>
+  style_LONGEST_LENGTH_GT?: InputMaybe<Scalars['Int']['input']>
+  style_LONGEST_LENGTH_GTE?: InputMaybe<Scalars['Int']['input']>
+  style_LONGEST_LENGTH_LT?: InputMaybe<Scalars['Int']['input']>
+  style_LONGEST_LENGTH_LTE?: InputMaybe<Scalars['Int']['input']>
+  style_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars['Int']['input']>
+  style_SHORTEST_LENGTH_GT?: InputMaybe<Scalars['Int']['input']>
+  style_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars['Int']['input']>
+  style_SHORTEST_LENGTH_LT?: InputMaybe<Scalars['Int']['input']>
+  style_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars['Int']['input']>
 }
 
 export type CodeActionOnCreateInput = {
@@ -5787,6 +5830,21 @@ export type ComponentChildrenContainerElementNodeAggregationWhereInput = {
   renderIfExpression_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars['Int']['input']>
   renderIfExpression_SHORTEST_LENGTH_LT?: InputMaybe<Scalars['Int']['input']>
   renderIfExpression_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars['Int']['input']>
+  style_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars['Float']['input']>
+  style_AVERAGE_LENGTH_GT?: InputMaybe<Scalars['Float']['input']>
+  style_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars['Float']['input']>
+  style_AVERAGE_LENGTH_LT?: InputMaybe<Scalars['Float']['input']>
+  style_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars['Float']['input']>
+  style_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars['Int']['input']>
+  style_LONGEST_LENGTH_GT?: InputMaybe<Scalars['Int']['input']>
+  style_LONGEST_LENGTH_GTE?: InputMaybe<Scalars['Int']['input']>
+  style_LONGEST_LENGTH_LT?: InputMaybe<Scalars['Int']['input']>
+  style_LONGEST_LENGTH_LTE?: InputMaybe<Scalars['Int']['input']>
+  style_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars['Int']['input']>
+  style_SHORTEST_LENGTH_GT?: InputMaybe<Scalars['Int']['input']>
+  style_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars['Int']['input']>
+  style_SHORTEST_LENGTH_LT?: InputMaybe<Scalars['Int']['input']>
+  style_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars['Int']['input']>
 }
 
 export type ComponentChildrenContainerElementRelationship = {
@@ -5881,11 +5939,10 @@ export type ComponentElementChildrenContainerElementNodeAggregateSelection = {
   __typename?: 'ComponentElementChildrenContainerElementNodeAggregateSelection'
   _compoundName: StringAggregateSelectionNonNullable
   childMapperPropKey: StringAggregateSelectionNullable
-  customCss: StringAggregateSelectionNullable
-  guiCss: StringAggregateSelectionNullable
   id: IdAggregateSelectionNonNullable
   renderForEachPropKey: StringAggregateSelectionNullable
   renderIfExpression: StringAggregateSelectionNullable
+  style: StringAggregateSelectionNullable
 }
 
 export type ComponentElementRootElementAggregationSelection = {
@@ -5898,11 +5955,10 @@ export type ComponentElementRootElementNodeAggregateSelection = {
   __typename?: 'ComponentElementRootElementNodeAggregateSelection'
   _compoundName: StringAggregateSelectionNonNullable
   childMapperPropKey: StringAggregateSelectionNullable
-  customCss: StringAggregateSelectionNullable
-  guiCss: StringAggregateSelectionNullable
   id: IdAggregateSelectionNonNullable
   renderForEachPropKey: StringAggregateSelectionNullable
   renderIfExpression: StringAggregateSelectionNullable
+  style: StringAggregateSelectionNullable
 }
 
 export type ComponentInterfaceTypeApiAggregationSelection = {
@@ -6292,6 +6348,21 @@ export type ComponentRootElementNodeAggregationWhereInput = {
   renderIfExpression_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars['Int']['input']>
   renderIfExpression_SHORTEST_LENGTH_LT?: InputMaybe<Scalars['Int']['input']>
   renderIfExpression_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars['Int']['input']>
+  style_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars['Float']['input']>
+  style_AVERAGE_LENGTH_GT?: InputMaybe<Scalars['Float']['input']>
+  style_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars['Float']['input']>
+  style_AVERAGE_LENGTH_LT?: InputMaybe<Scalars['Float']['input']>
+  style_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars['Float']['input']>
+  style_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars['Int']['input']>
+  style_LONGEST_LENGTH_GT?: InputMaybe<Scalars['Int']['input']>
+  style_LONGEST_LENGTH_GTE?: InputMaybe<Scalars['Int']['input']>
+  style_LONGEST_LENGTH_LT?: InputMaybe<Scalars['Int']['input']>
+  style_LONGEST_LENGTH_LTE?: InputMaybe<Scalars['Int']['input']>
+  style_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars['Int']['input']>
+  style_SHORTEST_LENGTH_GT?: InputMaybe<Scalars['Int']['input']>
+  style_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars['Int']['input']>
+  style_SHORTEST_LENGTH_LT?: InputMaybe<Scalars['Int']['input']>
+  style_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars['Int']['input']>
 }
 
 export type ComponentRootElementRelationship = {
@@ -6995,12 +7066,10 @@ export type Element = {
   childMapperPreviousSiblingAggregate?: Maybe<ElementElementChildMapperPreviousSiblingAggregationSelection>
   childMapperPreviousSiblingConnection: ElementChildMapperPreviousSiblingConnection
   childMapperPropKey?: Maybe<Scalars['String']['output']>
-  customCss?: Maybe<Scalars['String']['output']>
   descendantElements: Array<Element>
   firstChild?: Maybe<Element>
   firstChildAggregate?: Maybe<ElementElementFirstChildAggregationSelection>
   firstChildConnection: ElementFirstChildConnection
-  guiCss?: Maybe<Scalars['String']['output']>
   id: Scalars['ID']['output']
   name: Scalars['String']['output']
   nextSibling?: Maybe<Element>
@@ -7279,11 +7348,10 @@ export type ElementAggregateSelection = {
   _compoundName: StringAggregateSelectionNonNullable
   childMapperPropKey: StringAggregateSelectionNullable
   count: Scalars['Int']['output']
-  customCss: StringAggregateSelectionNullable
-  guiCss: StringAggregateSelectionNullable
   id: IdAggregateSelectionNonNullable
   renderForEachPropKey: StringAggregateSelectionNullable
   renderIfExpression: StringAggregateSelectionNullable
+  style: StringAggregateSelectionNullable
 }
 
 export type ElementAtomRenderAtomTypeAggregationSelection = {
@@ -7603,6 +7671,21 @@ export type ElementChildMapperPreviousSiblingNodeAggregationWhereInput = {
   renderIfExpression_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars['Int']['input']>
   renderIfExpression_SHORTEST_LENGTH_LT?: InputMaybe<Scalars['Int']['input']>
   renderIfExpression_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars['Int']['input']>
+  style_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars['Float']['input']>
+  style_AVERAGE_LENGTH_GT?: InputMaybe<Scalars['Float']['input']>
+  style_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars['Float']['input']>
+  style_AVERAGE_LENGTH_LT?: InputMaybe<Scalars['Float']['input']>
+  style_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars['Float']['input']>
+  style_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars['Int']['input']>
+  style_LONGEST_LENGTH_GT?: InputMaybe<Scalars['Int']['input']>
+  style_LONGEST_LENGTH_GTE?: InputMaybe<Scalars['Int']['input']>
+  style_LONGEST_LENGTH_LT?: InputMaybe<Scalars['Int']['input']>
+  style_LONGEST_LENGTH_LTE?: InputMaybe<Scalars['Int']['input']>
+  style_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars['Int']['input']>
+  style_SHORTEST_LENGTH_GT?: InputMaybe<Scalars['Int']['input']>
+  style_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars['Int']['input']>
+  style_SHORTEST_LENGTH_LT?: InputMaybe<Scalars['Int']['input']>
+  style_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars['Int']['input']>
 }
 
 export type ElementChildMapperPreviousSiblingRelationship = {
@@ -7707,9 +7790,7 @@ export type ElementCreateInput = {
   childMapperComponent?: InputMaybe<ElementChildMapperComponentFieldInput>
   childMapperPreviousSibling?: InputMaybe<ElementChildMapperPreviousSiblingFieldInput>
   childMapperPropKey?: InputMaybe<Scalars['String']['input']>
-  customCss?: InputMaybe<Scalars['String']['input']>
   firstChild?: InputMaybe<ElementFirstChildFieldInput>
-  guiCss?: InputMaybe<Scalars['String']['input']>
   id: Scalars['ID']['input']
   nextSibling?: InputMaybe<ElementNextSiblingFieldInput>
   page?: InputMaybe<ElementPageFieldInput>
@@ -7723,6 +7804,7 @@ export type ElementCreateInput = {
   renderComponentType?: InputMaybe<ElementRenderComponentTypeFieldInput>
   renderForEachPropKey?: InputMaybe<Scalars['String']['input']>
   renderIfExpression?: InputMaybe<Scalars['String']['input']>
+  style?: InputMaybe<Scalars['String']['input']>
 }
 
 export type ElementDeleteInput = {
@@ -7773,11 +7855,10 @@ export type ElementElementChildMapperPreviousSiblingNodeAggregateSelection = {
   __typename?: 'ElementElementChildMapperPreviousSiblingNodeAggregateSelection'
   _compoundName: StringAggregateSelectionNonNullable
   childMapperPropKey: StringAggregateSelectionNullable
-  customCss: StringAggregateSelectionNullable
-  guiCss: StringAggregateSelectionNullable
   id: IdAggregateSelectionNonNullable
   renderForEachPropKey: StringAggregateSelectionNullable
   renderIfExpression: StringAggregateSelectionNullable
+  style: StringAggregateSelectionNullable
 }
 
 export type ElementElementFirstChildAggregationSelection = {
@@ -7790,11 +7871,10 @@ export type ElementElementFirstChildNodeAggregateSelection = {
   __typename?: 'ElementElementFirstChildNodeAggregateSelection'
   _compoundName: StringAggregateSelectionNonNullable
   childMapperPropKey: StringAggregateSelectionNullable
-  customCss: StringAggregateSelectionNullable
-  guiCss: StringAggregateSelectionNullable
   id: IdAggregateSelectionNonNullable
   renderForEachPropKey: StringAggregateSelectionNullable
   renderIfExpression: StringAggregateSelectionNullable
+  style: StringAggregateSelectionNullable
 }
 
 export type ElementElementNextSiblingAggregationSelection = {
@@ -7807,11 +7887,10 @@ export type ElementElementNextSiblingNodeAggregateSelection = {
   __typename?: 'ElementElementNextSiblingNodeAggregateSelection'
   _compoundName: StringAggregateSelectionNonNullable
   childMapperPropKey: StringAggregateSelectionNullable
-  customCss: StringAggregateSelectionNullable
-  guiCss: StringAggregateSelectionNullable
   id: IdAggregateSelectionNonNullable
   renderForEachPropKey: StringAggregateSelectionNullable
   renderIfExpression: StringAggregateSelectionNullable
+  style: StringAggregateSelectionNullable
 }
 
 export type ElementElementParentAggregationSelection = {
@@ -7824,11 +7903,10 @@ export type ElementElementParentNodeAggregateSelection = {
   __typename?: 'ElementElementParentNodeAggregateSelection'
   _compoundName: StringAggregateSelectionNonNullable
   childMapperPropKey: StringAggregateSelectionNullable
-  customCss: StringAggregateSelectionNullable
-  guiCss: StringAggregateSelectionNullable
   id: IdAggregateSelectionNonNullable
   renderForEachPropKey: StringAggregateSelectionNullable
   renderIfExpression: StringAggregateSelectionNullable
+  style: StringAggregateSelectionNullable
 }
 
 export type ElementElementPrevSiblingAggregationSelection = {
@@ -7841,11 +7919,10 @@ export type ElementElementPrevSiblingNodeAggregateSelection = {
   __typename?: 'ElementElementPrevSiblingNodeAggregateSelection'
   _compoundName: StringAggregateSelectionNonNullable
   childMapperPropKey: StringAggregateSelectionNullable
-  customCss: StringAggregateSelectionNullable
-  guiCss: StringAggregateSelectionNullable
   id: IdAggregateSelectionNonNullable
   renderForEachPropKey: StringAggregateSelectionNullable
   renderIfExpression: StringAggregateSelectionNullable
+  style: StringAggregateSelectionNullable
 }
 
 export type ElementFirstChildAggregateInput = {
@@ -8022,6 +8099,21 @@ export type ElementFirstChildNodeAggregationWhereInput = {
   renderIfExpression_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars['Int']['input']>
   renderIfExpression_SHORTEST_LENGTH_LT?: InputMaybe<Scalars['Int']['input']>
   renderIfExpression_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars['Int']['input']>
+  style_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars['Float']['input']>
+  style_AVERAGE_LENGTH_GT?: InputMaybe<Scalars['Float']['input']>
+  style_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars['Float']['input']>
+  style_AVERAGE_LENGTH_LT?: InputMaybe<Scalars['Float']['input']>
+  style_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars['Float']['input']>
+  style_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars['Int']['input']>
+  style_LONGEST_LENGTH_GT?: InputMaybe<Scalars['Int']['input']>
+  style_LONGEST_LENGTH_GTE?: InputMaybe<Scalars['Int']['input']>
+  style_LONGEST_LENGTH_LT?: InputMaybe<Scalars['Int']['input']>
+  style_LONGEST_LENGTH_LTE?: InputMaybe<Scalars['Int']['input']>
+  style_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars['Int']['input']>
+  style_SHORTEST_LENGTH_GT?: InputMaybe<Scalars['Int']['input']>
+  style_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars['Int']['input']>
+  style_SHORTEST_LENGTH_LT?: InputMaybe<Scalars['Int']['input']>
+  style_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars['Int']['input']>
 }
 
 export type ElementFirstChildRelationship = {
@@ -8218,6 +8310,21 @@ export type ElementNextSiblingNodeAggregationWhereInput = {
   renderIfExpression_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars['Int']['input']>
   renderIfExpression_SHORTEST_LENGTH_LT?: InputMaybe<Scalars['Int']['input']>
   renderIfExpression_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars['Int']['input']>
+  style_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars['Float']['input']>
+  style_AVERAGE_LENGTH_GT?: InputMaybe<Scalars['Float']['input']>
+  style_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars['Float']['input']>
+  style_AVERAGE_LENGTH_LT?: InputMaybe<Scalars['Float']['input']>
+  style_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars['Float']['input']>
+  style_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars['Int']['input']>
+  style_LONGEST_LENGTH_GT?: InputMaybe<Scalars['Int']['input']>
+  style_LONGEST_LENGTH_GTE?: InputMaybe<Scalars['Int']['input']>
+  style_LONGEST_LENGTH_LT?: InputMaybe<Scalars['Int']['input']>
+  style_LONGEST_LENGTH_LTE?: InputMaybe<Scalars['Int']['input']>
+  style_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars['Int']['input']>
+  style_SHORTEST_LENGTH_GT?: InputMaybe<Scalars['Int']['input']>
+  style_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars['Int']['input']>
+  style_SHORTEST_LENGTH_LT?: InputMaybe<Scalars['Int']['input']>
+  style_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars['Int']['input']>
 }
 
 export type ElementNextSiblingRelationship = {
@@ -8243,11 +8350,10 @@ export type ElementNextSiblingUpdateFieldInput = {
 export type ElementOnCreateInput = {
   _compoundName: Scalars['String']['input']
   childMapperPropKey?: InputMaybe<Scalars['String']['input']>
-  customCss?: InputMaybe<Scalars['String']['input']>
-  guiCss?: InputMaybe<Scalars['String']['input']>
   id: Scalars['ID']['input']
   renderForEachPropKey?: InputMaybe<Scalars['String']['input']>
   renderIfExpression?: InputMaybe<Scalars['String']['input']>
+  style?: InputMaybe<Scalars['String']['input']>
 }
 
 export type ElementOptions = {
@@ -8688,6 +8794,21 @@ export type ElementParentNodeAggregationWhereInput = {
   renderIfExpression_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars['Int']['input']>
   renderIfExpression_SHORTEST_LENGTH_LT?: InputMaybe<Scalars['Int']['input']>
   renderIfExpression_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars['Int']['input']>
+  style_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars['Float']['input']>
+  style_AVERAGE_LENGTH_GT?: InputMaybe<Scalars['Float']['input']>
+  style_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars['Float']['input']>
+  style_AVERAGE_LENGTH_LT?: InputMaybe<Scalars['Float']['input']>
+  style_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars['Float']['input']>
+  style_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars['Int']['input']>
+  style_LONGEST_LENGTH_GT?: InputMaybe<Scalars['Int']['input']>
+  style_LONGEST_LENGTH_GTE?: InputMaybe<Scalars['Int']['input']>
+  style_LONGEST_LENGTH_LT?: InputMaybe<Scalars['Int']['input']>
+  style_LONGEST_LENGTH_LTE?: InputMaybe<Scalars['Int']['input']>
+  style_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars['Int']['input']>
+  style_SHORTEST_LENGTH_GT?: InputMaybe<Scalars['Int']['input']>
+  style_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars['Int']['input']>
+  style_SHORTEST_LENGTH_LT?: InputMaybe<Scalars['Int']['input']>
+  style_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars['Int']['input']>
 }
 
 export type ElementParentRelationship = {
@@ -9006,6 +9127,21 @@ export type ElementPrevSiblingNodeAggregationWhereInput = {
   renderIfExpression_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars['Int']['input']>
   renderIfExpression_SHORTEST_LENGTH_LT?: InputMaybe<Scalars['Int']['input']>
   renderIfExpression_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars['Int']['input']>
+  style_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars['Float']['input']>
+  style_AVERAGE_LENGTH_GT?: InputMaybe<Scalars['Float']['input']>
+  style_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars['Float']['input']>
+  style_AVERAGE_LENGTH_LT?: InputMaybe<Scalars['Float']['input']>
+  style_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars['Float']['input']>
+  style_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars['Int']['input']>
+  style_LONGEST_LENGTH_GT?: InputMaybe<Scalars['Int']['input']>
+  style_LONGEST_LENGTH_GTE?: InputMaybe<Scalars['Int']['input']>
+  style_LONGEST_LENGTH_LT?: InputMaybe<Scalars['Int']['input']>
+  style_LONGEST_LENGTH_LTE?: InputMaybe<Scalars['Int']['input']>
+  style_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars['Int']['input']>
+  style_SHORTEST_LENGTH_GT?: InputMaybe<Scalars['Int']['input']>
+  style_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars['Int']['input']>
+  style_SHORTEST_LENGTH_LT?: InputMaybe<Scalars['Int']['input']>
+  style_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars['Int']['input']>
 }
 
 export type ElementPrevSiblingRelationship = {
@@ -9455,11 +9591,10 @@ export type ElementRenderComponentTypeUpdateFieldInput = {
 export type ElementSort = {
   _compoundName?: InputMaybe<SortDirection>
   childMapperPropKey?: InputMaybe<SortDirection>
-  customCss?: InputMaybe<SortDirection>
-  guiCss?: InputMaybe<SortDirection>
   id?: InputMaybe<SortDirection>
   renderForEachPropKey?: InputMaybe<SortDirection>
   renderIfExpression?: InputMaybe<SortDirection>
+  style?: InputMaybe<SortDirection>
 }
 
 /**
@@ -9743,9 +9878,7 @@ export type ElementUpdateInput = {
   childMapperComponent?: InputMaybe<ElementChildMapperComponentUpdateFieldInput>
   childMapperPreviousSibling?: InputMaybe<ElementChildMapperPreviousSiblingUpdateFieldInput>
   childMapperPropKey?: InputMaybe<Scalars['String']['input']>
-  customCss?: InputMaybe<Scalars['String']['input']>
   firstChild?: InputMaybe<ElementFirstChildUpdateFieldInput>
-  guiCss?: InputMaybe<Scalars['String']['input']>
   id?: InputMaybe<Scalars['ID']['input']>
   nextSibling?: InputMaybe<ElementNextSiblingUpdateFieldInput>
   page?: InputMaybe<ElementPageUpdateFieldInput>
@@ -9759,6 +9892,7 @@ export type ElementUpdateInput = {
   renderComponentType?: InputMaybe<ElementRenderComponentTypeUpdateFieldInput>
   renderForEachPropKey?: InputMaybe<Scalars['String']['input']>
   renderIfExpression?: InputMaybe<Scalars['String']['input']>
+  style?: InputMaybe<Scalars['String']['input']>
 }
 
 export type ElementWhere = {
@@ -9789,23 +9923,11 @@ export type ElementWhere = {
   >
   childMapperPropKey_MATCHES?: InputMaybe<Scalars['String']['input']>
   childMapperPropKey_STARTS_WITH?: InputMaybe<Scalars['String']['input']>
-  customCss?: InputMaybe<Scalars['String']['input']>
-  customCss_CONTAINS?: InputMaybe<Scalars['String']['input']>
-  customCss_ENDS_WITH?: InputMaybe<Scalars['String']['input']>
-  customCss_IN?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>
-  customCss_MATCHES?: InputMaybe<Scalars['String']['input']>
-  customCss_STARTS_WITH?: InputMaybe<Scalars['String']['input']>
   firstChild?: InputMaybe<ElementWhere>
   firstChildAggregate?: InputMaybe<ElementFirstChildAggregateInput>
   firstChildConnection?: InputMaybe<ElementFirstChildConnectionWhere>
   firstChildConnection_NOT?: InputMaybe<ElementFirstChildConnectionWhere>
   firstChild_NOT?: InputMaybe<ElementWhere>
-  guiCss?: InputMaybe<Scalars['String']['input']>
-  guiCss_CONTAINS?: InputMaybe<Scalars['String']['input']>
-  guiCss_ENDS_WITH?: InputMaybe<Scalars['String']['input']>
-  guiCss_IN?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>
-  guiCss_MATCHES?: InputMaybe<Scalars['String']['input']>
-  guiCss_STARTS_WITH?: InputMaybe<Scalars['String']['input']>
   id?: InputMaybe<Scalars['ID']['input']>
   id_CONTAINS?: InputMaybe<Scalars['ID']['input']>
   id_ENDS_WITH?: InputMaybe<Scalars['ID']['input']>
@@ -9872,6 +9994,12 @@ export type ElementWhere = {
   >
   renderIfExpression_MATCHES?: InputMaybe<Scalars['String']['input']>
   renderIfExpression_STARTS_WITH?: InputMaybe<Scalars['String']['input']>
+  style?: InputMaybe<Scalars['String']['input']>
+  style_CONTAINS?: InputMaybe<Scalars['String']['input']>
+  style_ENDS_WITH?: InputMaybe<Scalars['String']['input']>
+  style_IN?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>
+  style_MATCHES?: InputMaybe<Scalars['String']['input']>
+  style_STARTS_WITH?: InputMaybe<Scalars['String']['input']>
 }
 
 export type ElementsConnection = {
@@ -11888,11 +12016,10 @@ export type HookElementElementNodeAggregateSelection = {
   __typename?: 'HookElementElementNodeAggregateSelection'
   _compoundName: StringAggregateSelectionNonNullable
   childMapperPropKey: StringAggregateSelectionNullable
-  customCss: StringAggregateSelectionNullable
-  guiCss: StringAggregateSelectionNullable
   id: IdAggregateSelectionNonNullable
   renderForEachPropKey: StringAggregateSelectionNullable
   renderIfExpression: StringAggregateSelectionNullable
+  style: StringAggregateSelectionNullable
 }
 
 export type HookElementFieldInput = {
@@ -12009,6 +12136,21 @@ export type HookElementNodeAggregationWhereInput = {
   renderIfExpression_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars['Int']['input']>
   renderIfExpression_SHORTEST_LENGTH_LT?: InputMaybe<Scalars['Int']['input']>
   renderIfExpression_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars['Int']['input']>
+  style_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars['Float']['input']>
+  style_AVERAGE_LENGTH_GT?: InputMaybe<Scalars['Float']['input']>
+  style_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars['Float']['input']>
+  style_AVERAGE_LENGTH_LT?: InputMaybe<Scalars['Float']['input']>
+  style_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars['Float']['input']>
+  style_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars['Int']['input']>
+  style_LONGEST_LENGTH_GT?: InputMaybe<Scalars['Int']['input']>
+  style_LONGEST_LENGTH_GTE?: InputMaybe<Scalars['Int']['input']>
+  style_LONGEST_LENGTH_LT?: InputMaybe<Scalars['Int']['input']>
+  style_LONGEST_LENGTH_LTE?: InputMaybe<Scalars['Int']['input']>
+  style_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars['Int']['input']>
+  style_SHORTEST_LENGTH_GT?: InputMaybe<Scalars['Int']['input']>
+  style_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars['Int']['input']>
+  style_SHORTEST_LENGTH_LT?: InputMaybe<Scalars['Int']['input']>
+  style_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars['Int']['input']>
 }
 
 export type HookElementRelationship = {
@@ -14504,11 +14646,10 @@ export type PageElementPageContentContainerNodeAggregateSelection = {
   __typename?: 'PageElementPageContentContainerNodeAggregateSelection'
   _compoundName: StringAggregateSelectionNonNullable
   childMapperPropKey: StringAggregateSelectionNullable
-  customCss: StringAggregateSelectionNullable
-  guiCss: StringAggregateSelectionNullable
   id: IdAggregateSelectionNonNullable
   renderForEachPropKey: StringAggregateSelectionNullable
   renderIfExpression: StringAggregateSelectionNullable
+  style: StringAggregateSelectionNullable
 }
 
 export type PageElementRootElementAggregationSelection = {
@@ -14521,11 +14662,10 @@ export type PageElementRootElementNodeAggregateSelection = {
   __typename?: 'PageElementRootElementNodeAggregateSelection'
   _compoundName: StringAggregateSelectionNonNullable
   childMapperPropKey: StringAggregateSelectionNullable
-  customCss: StringAggregateSelectionNullable
-  guiCss: StringAggregateSelectionNullable
   id: IdAggregateSelectionNonNullable
   renderForEachPropKey: StringAggregateSelectionNullable
   renderIfExpression: StringAggregateSelectionNullable
+  style: StringAggregateSelectionNullable
 }
 
 /** Pagination information (Relay) */
@@ -14732,6 +14872,21 @@ export type PagePageContentContainerNodeAggregationWhereInput = {
   renderIfExpression_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars['Int']['input']>
   renderIfExpression_SHORTEST_LENGTH_LT?: InputMaybe<Scalars['Int']['input']>
   renderIfExpression_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars['Int']['input']>
+  style_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars['Float']['input']>
+  style_AVERAGE_LENGTH_GT?: InputMaybe<Scalars['Float']['input']>
+  style_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars['Float']['input']>
+  style_AVERAGE_LENGTH_LT?: InputMaybe<Scalars['Float']['input']>
+  style_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars['Float']['input']>
+  style_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars['Int']['input']>
+  style_LONGEST_LENGTH_GT?: InputMaybe<Scalars['Int']['input']>
+  style_LONGEST_LENGTH_GTE?: InputMaybe<Scalars['Int']['input']>
+  style_LONGEST_LENGTH_LT?: InputMaybe<Scalars['Int']['input']>
+  style_LONGEST_LENGTH_LTE?: InputMaybe<Scalars['Int']['input']>
+  style_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars['Int']['input']>
+  style_SHORTEST_LENGTH_GT?: InputMaybe<Scalars['Int']['input']>
+  style_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars['Int']['input']>
+  style_SHORTEST_LENGTH_LT?: InputMaybe<Scalars['Int']['input']>
+  style_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars['Int']['input']>
 }
 
 export type PagePageContentContainerRelationship = {
@@ -14935,6 +15090,21 @@ export type PageRootElementNodeAggregationWhereInput = {
   renderIfExpression_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars['Int']['input']>
   renderIfExpression_SHORTEST_LENGTH_LT?: InputMaybe<Scalars['Int']['input']>
   renderIfExpression_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars['Int']['input']>
+  style_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars['Float']['input']>
+  style_AVERAGE_LENGTH_GT?: InputMaybe<Scalars['Float']['input']>
+  style_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars['Float']['input']>
+  style_AVERAGE_LENGTH_LT?: InputMaybe<Scalars['Float']['input']>
+  style_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars['Float']['input']>
+  style_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars['Int']['input']>
+  style_LONGEST_LENGTH_GT?: InputMaybe<Scalars['Int']['input']>
+  style_LONGEST_LENGTH_GTE?: InputMaybe<Scalars['Int']['input']>
+  style_LONGEST_LENGTH_LT?: InputMaybe<Scalars['Int']['input']>
+  style_LONGEST_LENGTH_LTE?: InputMaybe<Scalars['Int']['input']>
+  style_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars['Int']['input']>
+  style_SHORTEST_LENGTH_GT?: InputMaybe<Scalars['Int']['input']>
+  style_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars['Int']['input']>
+  style_SHORTEST_LENGTH_LT?: InputMaybe<Scalars['Int']['input']>
+  style_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars['Int']['input']>
 }
 
 export type PageRootElementRelationship = {
@@ -21262,11 +21432,10 @@ export type UserElementElementsNodeAggregateSelection = {
   __typename?: 'UserElementElementsNodeAggregateSelection'
   _compoundName: StringAggregateSelectionNonNullable
   childMapperPropKey: StringAggregateSelectionNullable
-  customCss: StringAggregateSelectionNullable
-  guiCss: StringAggregateSelectionNullable
   id: IdAggregateSelectionNonNullable
   renderForEachPropKey: StringAggregateSelectionNullable
   renderIfExpression: StringAggregateSelectionNullable
+  style: StringAggregateSelectionNullable
 }
 
 export type UserElementsAggregateInput = {
@@ -21443,6 +21612,21 @@ export type UserElementsNodeAggregationWhereInput = {
   renderIfExpression_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars['Int']['input']>
   renderIfExpression_SHORTEST_LENGTH_LT?: InputMaybe<Scalars['Int']['input']>
   renderIfExpression_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars['Int']['input']>
+  style_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars['Float']['input']>
+  style_AVERAGE_LENGTH_GT?: InputMaybe<Scalars['Float']['input']>
+  style_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars['Float']['input']>
+  style_AVERAGE_LENGTH_LT?: InputMaybe<Scalars['Float']['input']>
+  style_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars['Float']['input']>
+  style_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars['Int']['input']>
+  style_LONGEST_LENGTH_GT?: InputMaybe<Scalars['Int']['input']>
+  style_LONGEST_LENGTH_GTE?: InputMaybe<Scalars['Int']['input']>
+  style_LONGEST_LENGTH_LT?: InputMaybe<Scalars['Int']['input']>
+  style_LONGEST_LENGTH_LTE?: InputMaybe<Scalars['Int']['input']>
+  style_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars['Int']['input']>
+  style_SHORTEST_LENGTH_GT?: InputMaybe<Scalars['Int']['input']>
+  style_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars['Int']['input']>
+  style_SHORTEST_LENGTH_LT?: InputMaybe<Scalars['Int']['input']>
+  style_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars['Int']['input']>
 }
 
 export type UserElementsRelationship = {
@@ -22200,8 +22384,7 @@ export type ProductionElementFragment = {
   __typename: 'Element'
   id: string
   name: string
-  customCss?: string | null
-  guiCss?: string | null
+  style?: string | null
   childMapperPropKey?: string | null
   renderForEachPropKey?: string | null
   renderIfExpression?: string | null

--- a/libs/shared/abstract/core/src/element.dto.interface.ts
+++ b/libs/shared/abstract/core/src/element.dto.interface.ts
@@ -8,9 +8,7 @@ export interface IElementDTO {
   childMapperComponent?: Nullable<IEntity>
   childMapperPreviousSibling?: Nullable<IEntity>
   childMapperPropKey?: Nullable<string>
-  customCss?: Nullable<string>
   firstChild?: Nullable<IEntity>
-  guiCss?: Nullable<string>
   id: string
   name: string
   nextSibling?: Nullable<IEntity>
@@ -24,6 +22,7 @@ export interface IElementDTO {
   renderForEachPropKey?: Nullable<string>
   renderIfExpression?: Nullable<string>
   renderType?: Nullable<RenderType>
+  style?: Nullable<string>
 }
 
 export interface ICreateIElementDTO extends IElementDTO {

--- a/schema.graphql
+++ b/schema.graphql
@@ -548,11 +548,10 @@ type ApiActionElementElementAggregationSelection {
 type ApiActionElementElementNodeAggregateSelection {
   _compoundName: StringAggregateSelectionNonNullable!
   childMapperPropKey: StringAggregateSelectionNullable!
-  customCss: StringAggregateSelectionNullable!
-  guiCss: StringAggregateSelectionNullable!
   id: IDAggregateSelectionNonNullable!
   renderForEachPropKey: StringAggregateSelectionNullable!
   renderIfExpression: StringAggregateSelectionNullable!
+  style: StringAggregateSelectionNullable!
 }
 
 input ApiActionElementNodeAggregationWhereInput {
@@ -649,6 +648,21 @@ input ApiActionElementNodeAggregationWhereInput {
   renderIfExpression_SHORTEST_LENGTH_GTE: Int
   renderIfExpression_SHORTEST_LENGTH_LT: Int
   renderIfExpression_SHORTEST_LENGTH_LTE: Int
+  style_AVERAGE_LENGTH_EQUAL: Float
+  style_AVERAGE_LENGTH_GT: Float
+  style_AVERAGE_LENGTH_GTE: Float
+  style_AVERAGE_LENGTH_LT: Float
+  style_AVERAGE_LENGTH_LTE: Float
+  style_LONGEST_LENGTH_EQUAL: Int
+  style_LONGEST_LENGTH_GT: Int
+  style_LONGEST_LENGTH_GTE: Int
+  style_LONGEST_LENGTH_LT: Int
+  style_LONGEST_LENGTH_LTE: Int
+  style_SHORTEST_LENGTH_EQUAL: Int
+  style_SHORTEST_LENGTH_GT: Int
+  style_SHORTEST_LENGTH_GTE: Int
+  style_SHORTEST_LENGTH_LT: Int
+  style_SHORTEST_LENGTH_LTE: Int
 }
 
 input ApiActionErrorActionApiActionConnectFieldInput {
@@ -4227,6 +4241,21 @@ input BaseActionElementNodeAggregationWhereInput {
   renderIfExpression_SHORTEST_LENGTH_GTE: Int
   renderIfExpression_SHORTEST_LENGTH_LT: Int
   renderIfExpression_SHORTEST_LENGTH_LTE: Int
+  style_AVERAGE_LENGTH_EQUAL: Float
+  style_AVERAGE_LENGTH_GT: Float
+  style_AVERAGE_LENGTH_GTE: Float
+  style_AVERAGE_LENGTH_LT: Float
+  style_AVERAGE_LENGTH_LTE: Float
+  style_LONGEST_LENGTH_EQUAL: Int
+  style_LONGEST_LENGTH_GT: Int
+  style_LONGEST_LENGTH_GTE: Int
+  style_LONGEST_LENGTH_LT: Int
+  style_LONGEST_LENGTH_LTE: Int
+  style_SHORTEST_LENGTH_EQUAL: Int
+  style_SHORTEST_LENGTH_GT: Int
+  style_SHORTEST_LENGTH_GTE: Int
+  style_SHORTEST_LENGTH_LT: Int
+  style_SHORTEST_LENGTH_LTE: Int
 }
 
 type BaseActionElementRelationship {
@@ -4732,11 +4761,10 @@ type CodeActionElementElementAggregationSelection {
 type CodeActionElementElementNodeAggregateSelection {
   _compoundName: StringAggregateSelectionNonNullable!
   childMapperPropKey: StringAggregateSelectionNullable!
-  customCss: StringAggregateSelectionNullable!
-  guiCss: StringAggregateSelectionNullable!
   id: IDAggregateSelectionNonNullable!
   renderForEachPropKey: StringAggregateSelectionNullable!
   renderIfExpression: StringAggregateSelectionNullable!
+  style: StringAggregateSelectionNullable!
 }
 
 input CodeActionElementNodeAggregationWhereInput {
@@ -4833,6 +4861,21 @@ input CodeActionElementNodeAggregationWhereInput {
   renderIfExpression_SHORTEST_LENGTH_GTE: Int
   renderIfExpression_SHORTEST_LENGTH_LT: Int
   renderIfExpression_SHORTEST_LENGTH_LTE: Int
+  style_AVERAGE_LENGTH_EQUAL: Float
+  style_AVERAGE_LENGTH_GT: Float
+  style_AVERAGE_LENGTH_GTE: Float
+  style_AVERAGE_LENGTH_LT: Float
+  style_AVERAGE_LENGTH_LTE: Float
+  style_LONGEST_LENGTH_EQUAL: Int
+  style_LONGEST_LENGTH_GT: Int
+  style_LONGEST_LENGTH_GTE: Int
+  style_LONGEST_LENGTH_LT: Int
+  style_LONGEST_LENGTH_LTE: Int
+  style_SHORTEST_LENGTH_EQUAL: Int
+  style_SHORTEST_LENGTH_GT: Int
+  style_SHORTEST_LENGTH_GTE: Int
+  style_SHORTEST_LENGTH_LT: Int
+  style_SHORTEST_LENGTH_LTE: Int
 }
 
 input CodeActionOnCreateInput {
@@ -5559,6 +5602,21 @@ input ComponentChildrenContainerElementNodeAggregationWhereInput {
   renderIfExpression_SHORTEST_LENGTH_GTE: Int
   renderIfExpression_SHORTEST_LENGTH_LT: Int
   renderIfExpression_SHORTEST_LENGTH_LTE: Int
+  style_AVERAGE_LENGTH_EQUAL: Float
+  style_AVERAGE_LENGTH_GT: Float
+  style_AVERAGE_LENGTH_GTE: Float
+  style_AVERAGE_LENGTH_LT: Float
+  style_AVERAGE_LENGTH_LTE: Float
+  style_LONGEST_LENGTH_EQUAL: Int
+  style_LONGEST_LENGTH_GT: Int
+  style_LONGEST_LENGTH_GTE: Int
+  style_LONGEST_LENGTH_LT: Int
+  style_LONGEST_LENGTH_LTE: Int
+  style_SHORTEST_LENGTH_EQUAL: Int
+  style_SHORTEST_LENGTH_GT: Int
+  style_SHORTEST_LENGTH_GTE: Int
+  style_SHORTEST_LENGTH_LT: Int
+  style_SHORTEST_LENGTH_LTE: Int
 }
 
 type ComponentChildrenContainerElementRelationship {
@@ -5649,11 +5707,10 @@ type ComponentElementChildrenContainerElementAggregationSelection {
 type ComponentElementChildrenContainerElementNodeAggregateSelection {
   _compoundName: StringAggregateSelectionNonNullable!
   childMapperPropKey: StringAggregateSelectionNullable!
-  customCss: StringAggregateSelectionNullable!
-  guiCss: StringAggregateSelectionNullable!
   id: IDAggregateSelectionNonNullable!
   renderForEachPropKey: StringAggregateSelectionNullable!
   renderIfExpression: StringAggregateSelectionNullable!
+  style: StringAggregateSelectionNullable!
 }
 
 type ComponentElementRootElementAggregationSelection {
@@ -5664,11 +5721,10 @@ type ComponentElementRootElementAggregationSelection {
 type ComponentElementRootElementNodeAggregateSelection {
   _compoundName: StringAggregateSelectionNonNullable!
   childMapperPropKey: StringAggregateSelectionNullable!
-  customCss: StringAggregateSelectionNullable!
-  guiCss: StringAggregateSelectionNullable!
   id: IDAggregateSelectionNonNullable!
   renderForEachPropKey: StringAggregateSelectionNullable!
   renderIfExpression: StringAggregateSelectionNullable!
+  style: StringAggregateSelectionNullable!
 }
 
 type ComponentInterfaceTypeApiAggregationSelection {
@@ -6045,6 +6101,21 @@ input ComponentRootElementNodeAggregationWhereInput {
   renderIfExpression_SHORTEST_LENGTH_GTE: Int
   renderIfExpression_SHORTEST_LENGTH_LT: Int
   renderIfExpression_SHORTEST_LENGTH_LTE: Int
+  style_AVERAGE_LENGTH_EQUAL: Float
+  style_AVERAGE_LENGTH_GT: Float
+  style_AVERAGE_LENGTH_GTE: Float
+  style_AVERAGE_LENGTH_LT: Float
+  style_AVERAGE_LENGTH_LTE: Float
+  style_LONGEST_LENGTH_EQUAL: Int
+  style_LONGEST_LENGTH_GT: Int
+  style_LONGEST_LENGTH_GTE: Int
+  style_LONGEST_LENGTH_LT: Int
+  style_LONGEST_LENGTH_LTE: Int
+  style_SHORTEST_LENGTH_EQUAL: Int
+  style_SHORTEST_LENGTH_GT: Int
+  style_SHORTEST_LENGTH_GTE: Int
+  style_SHORTEST_LENGTH_LT: Int
+  style_SHORTEST_LENGTH_LTE: Int
 }
 
 type ComponentRootElementRelationship {
@@ -6727,7 +6798,6 @@ type Element {
     where: ElementChildMapperPreviousSiblingConnectionWhere
   ): ElementChildMapperPreviousSiblingConnection!
   childMapperPropKey: String
-  customCss: String
   descendantElements: [Element!]!
   firstChild(
     directed: Boolean = true
@@ -6745,7 +6815,6 @@ type Element {
     sort: [ElementFirstChildConnectionSort!]
     where: ElementFirstChildConnectionWhere
   ): ElementFirstChildConnection!
-  guiCss: String
   id: ID!
   name: String!
   nextSibling(
@@ -6902,11 +6971,10 @@ type ElementAggregateSelection {
   _compoundName: StringAggregateSelectionNonNullable!
   childMapperPropKey: StringAggregateSelectionNullable!
   count: Int!
-  customCss: StringAggregateSelectionNullable!
-  guiCss: StringAggregateSelectionNullable!
   id: IDAggregateSelectionNonNullable!
   renderForEachPropKey: StringAggregateSelectionNullable!
   renderIfExpression: StringAggregateSelectionNullable!
+  style: StringAggregateSelectionNullable!
 }
 
 type ElementAtomRenderAtomTypeAggregationSelection {
@@ -7208,6 +7276,21 @@ input ElementChildMapperPreviousSiblingNodeAggregationWhereInput {
   renderIfExpression_SHORTEST_LENGTH_GTE: Int
   renderIfExpression_SHORTEST_LENGTH_LT: Int
   renderIfExpression_SHORTEST_LENGTH_LTE: Int
+  style_AVERAGE_LENGTH_EQUAL: Float
+  style_AVERAGE_LENGTH_GT: Float
+  style_AVERAGE_LENGTH_GTE: Float
+  style_AVERAGE_LENGTH_LT: Float
+  style_AVERAGE_LENGTH_LTE: Float
+  style_LONGEST_LENGTH_EQUAL: Int
+  style_LONGEST_LENGTH_GT: Int
+  style_LONGEST_LENGTH_GTE: Int
+  style_LONGEST_LENGTH_LT: Int
+  style_LONGEST_LENGTH_LTE: Int
+  style_SHORTEST_LENGTH_EQUAL: Int
+  style_SHORTEST_LENGTH_GT: Int
+  style_SHORTEST_LENGTH_GTE: Int
+  style_SHORTEST_LENGTH_LT: Int
+  style_SHORTEST_LENGTH_LTE: Int
 }
 
 type ElementChildMapperPreviousSiblingRelationship {
@@ -7305,9 +7388,7 @@ input ElementCreateInput {
   childMapperComponent: ElementChildMapperComponentFieldInput
   childMapperPreviousSibling: ElementChildMapperPreviousSiblingFieldInput
   childMapperPropKey: String
-  customCss: String
   firstChild: ElementFirstChildFieldInput
-  guiCss: String
   id: ID!
   nextSibling: ElementNextSiblingFieldInput
   page: ElementPageFieldInput
@@ -7321,6 +7402,7 @@ input ElementCreateInput {
   renderComponentType: ElementRenderComponentTypeFieldInput
   renderForEachPropKey: String
   renderIfExpression: String
+  style: String
 }
 
 input ElementDeleteInput {
@@ -7368,11 +7450,10 @@ type ElementElementChildMapperPreviousSiblingAggregationSelection {
 type ElementElementChildMapperPreviousSiblingNodeAggregateSelection {
   _compoundName: StringAggregateSelectionNonNullable!
   childMapperPropKey: StringAggregateSelectionNullable!
-  customCss: StringAggregateSelectionNullable!
-  guiCss: StringAggregateSelectionNullable!
   id: IDAggregateSelectionNonNullable!
   renderForEachPropKey: StringAggregateSelectionNullable!
   renderIfExpression: StringAggregateSelectionNullable!
+  style: StringAggregateSelectionNullable!
 }
 
 type ElementElementFirstChildAggregationSelection {
@@ -7383,11 +7464,10 @@ type ElementElementFirstChildAggregationSelection {
 type ElementElementFirstChildNodeAggregateSelection {
   _compoundName: StringAggregateSelectionNonNullable!
   childMapperPropKey: StringAggregateSelectionNullable!
-  customCss: StringAggregateSelectionNullable!
-  guiCss: StringAggregateSelectionNullable!
   id: IDAggregateSelectionNonNullable!
   renderForEachPropKey: StringAggregateSelectionNullable!
   renderIfExpression: StringAggregateSelectionNullable!
+  style: StringAggregateSelectionNullable!
 }
 
 type ElementElementNextSiblingAggregationSelection {
@@ -7398,11 +7478,10 @@ type ElementElementNextSiblingAggregationSelection {
 type ElementElementNextSiblingNodeAggregateSelection {
   _compoundName: StringAggregateSelectionNonNullable!
   childMapperPropKey: StringAggregateSelectionNullable!
-  customCss: StringAggregateSelectionNullable!
-  guiCss: StringAggregateSelectionNullable!
   id: IDAggregateSelectionNonNullable!
   renderForEachPropKey: StringAggregateSelectionNullable!
   renderIfExpression: StringAggregateSelectionNullable!
+  style: StringAggregateSelectionNullable!
 }
 
 type ElementElementParentAggregationSelection {
@@ -7413,11 +7492,10 @@ type ElementElementParentAggregationSelection {
 type ElementElementParentNodeAggregateSelection {
   _compoundName: StringAggregateSelectionNonNullable!
   childMapperPropKey: StringAggregateSelectionNullable!
-  customCss: StringAggregateSelectionNullable!
-  guiCss: StringAggregateSelectionNullable!
   id: IDAggregateSelectionNonNullable!
   renderForEachPropKey: StringAggregateSelectionNullable!
   renderIfExpression: StringAggregateSelectionNullable!
+  style: StringAggregateSelectionNullable!
 }
 
 type ElementElementPrevSiblingAggregationSelection {
@@ -7428,11 +7506,10 @@ type ElementElementPrevSiblingAggregationSelection {
 type ElementElementPrevSiblingNodeAggregateSelection {
   _compoundName: StringAggregateSelectionNonNullable!
   childMapperPropKey: StringAggregateSelectionNullable!
-  customCss: StringAggregateSelectionNullable!
-  guiCss: StringAggregateSelectionNullable!
   id: IDAggregateSelectionNonNullable!
   renderForEachPropKey: StringAggregateSelectionNullable!
   renderIfExpression: StringAggregateSelectionNullable!
+  style: StringAggregateSelectionNullable!
 }
 
 input ElementFirstChildAggregateInput {
@@ -7597,6 +7674,21 @@ input ElementFirstChildNodeAggregationWhereInput {
   renderIfExpression_SHORTEST_LENGTH_GTE: Int
   renderIfExpression_SHORTEST_LENGTH_LT: Int
   renderIfExpression_SHORTEST_LENGTH_LTE: Int
+  style_AVERAGE_LENGTH_EQUAL: Float
+  style_AVERAGE_LENGTH_GT: Float
+  style_AVERAGE_LENGTH_GTE: Float
+  style_AVERAGE_LENGTH_LT: Float
+  style_AVERAGE_LENGTH_LTE: Float
+  style_LONGEST_LENGTH_EQUAL: Int
+  style_LONGEST_LENGTH_GT: Int
+  style_LONGEST_LENGTH_GTE: Int
+  style_LONGEST_LENGTH_LT: Int
+  style_LONGEST_LENGTH_LTE: Int
+  style_SHORTEST_LENGTH_EQUAL: Int
+  style_SHORTEST_LENGTH_GT: Int
+  style_SHORTEST_LENGTH_GTE: Int
+  style_SHORTEST_LENGTH_LT: Int
+  style_SHORTEST_LENGTH_LTE: Int
 }
 
 type ElementFirstChildRelationship {
@@ -7780,6 +7872,21 @@ input ElementNextSiblingNodeAggregationWhereInput {
   renderIfExpression_SHORTEST_LENGTH_GTE: Int
   renderIfExpression_SHORTEST_LENGTH_LT: Int
   renderIfExpression_SHORTEST_LENGTH_LTE: Int
+  style_AVERAGE_LENGTH_EQUAL: Float
+  style_AVERAGE_LENGTH_GT: Float
+  style_AVERAGE_LENGTH_GTE: Float
+  style_AVERAGE_LENGTH_LT: Float
+  style_AVERAGE_LENGTH_LTE: Float
+  style_LONGEST_LENGTH_EQUAL: Int
+  style_LONGEST_LENGTH_GT: Int
+  style_LONGEST_LENGTH_GTE: Int
+  style_LONGEST_LENGTH_LT: Int
+  style_LONGEST_LENGTH_LTE: Int
+  style_SHORTEST_LENGTH_EQUAL: Int
+  style_SHORTEST_LENGTH_GT: Int
+  style_SHORTEST_LENGTH_GTE: Int
+  style_SHORTEST_LENGTH_LT: Int
+  style_SHORTEST_LENGTH_LTE: Int
 }
 
 type ElementNextSiblingRelationship {
@@ -7804,11 +7911,10 @@ input ElementNextSiblingUpdateFieldInput {
 input ElementOnCreateInput {
   _compoundName: String!
   childMapperPropKey: String
-  customCss: String
-  guiCss: String
   id: ID!
   renderForEachPropKey: String
   renderIfExpression: String
+  style: String
 }
 
 input ElementOptions {
@@ -8240,6 +8346,21 @@ input ElementParentNodeAggregationWhereInput {
   renderIfExpression_SHORTEST_LENGTH_GTE: Int
   renderIfExpression_SHORTEST_LENGTH_LT: Int
   renderIfExpression_SHORTEST_LENGTH_LTE: Int
+  style_AVERAGE_LENGTH_EQUAL: Float
+  style_AVERAGE_LENGTH_GT: Float
+  style_AVERAGE_LENGTH_GTE: Float
+  style_AVERAGE_LENGTH_LT: Float
+  style_AVERAGE_LENGTH_LTE: Float
+  style_LONGEST_LENGTH_EQUAL: Int
+  style_LONGEST_LENGTH_GT: Int
+  style_LONGEST_LENGTH_GTE: Int
+  style_LONGEST_LENGTH_LT: Int
+  style_LONGEST_LENGTH_LTE: Int
+  style_SHORTEST_LENGTH_EQUAL: Int
+  style_SHORTEST_LENGTH_GT: Int
+  style_SHORTEST_LENGTH_GTE: Int
+  style_SHORTEST_LENGTH_LT: Int
+  style_SHORTEST_LENGTH_LTE: Int
 }
 
 type ElementParentRelationship {
@@ -8541,6 +8662,21 @@ input ElementPrevSiblingNodeAggregationWhereInput {
   renderIfExpression_SHORTEST_LENGTH_GTE: Int
   renderIfExpression_SHORTEST_LENGTH_LT: Int
   renderIfExpression_SHORTEST_LENGTH_LTE: Int
+  style_AVERAGE_LENGTH_EQUAL: Float
+  style_AVERAGE_LENGTH_GT: Float
+  style_AVERAGE_LENGTH_GTE: Float
+  style_AVERAGE_LENGTH_LT: Float
+  style_AVERAGE_LENGTH_LTE: Float
+  style_LONGEST_LENGTH_EQUAL: Int
+  style_LONGEST_LENGTH_GT: Int
+  style_LONGEST_LENGTH_GTE: Int
+  style_LONGEST_LENGTH_LT: Int
+  style_LONGEST_LENGTH_LTE: Int
+  style_SHORTEST_LENGTH_EQUAL: Int
+  style_SHORTEST_LENGTH_GT: Int
+  style_SHORTEST_LENGTH_GTE: Int
+  style_SHORTEST_LENGTH_LT: Int
+  style_SHORTEST_LENGTH_LTE: Int
 }
 
 type ElementPrevSiblingRelationship {
@@ -8989,11 +9125,10 @@ Fields to sort Elements by. The order in which sorts are applied is not guarante
 input ElementSort {
   _compoundName: SortDirection
   childMapperPropKey: SortDirection
-  customCss: SortDirection
-  guiCss: SortDirection
   id: SortDirection
   renderForEachPropKey: SortDirection
   renderIfExpression: SortDirection
+  style: SortDirection
 }
 
 """
@@ -9238,9 +9373,7 @@ input ElementUpdateInput {
   childMapperComponent: ElementChildMapperComponentUpdateFieldInput
   childMapperPreviousSibling: ElementChildMapperPreviousSiblingUpdateFieldInput
   childMapperPropKey: String
-  customCss: String
   firstChild: ElementFirstChildUpdateFieldInput
-  guiCss: String
   id: ID
   nextSibling: ElementNextSiblingUpdateFieldInput
   page: ElementPageUpdateFieldInput
@@ -9254,6 +9387,7 @@ input ElementUpdateInput {
   renderComponentType: ElementRenderComponentTypeUpdateFieldInput
   renderForEachPropKey: String
   renderIfExpression: String
+  style: String
 }
 
 input ElementWhere {
@@ -9282,23 +9416,11 @@ input ElementWhere {
   childMapperPropKey_IN: [String]
   childMapperPropKey_MATCHES: String
   childMapperPropKey_STARTS_WITH: String
-  customCss: String
-  customCss_CONTAINS: String
-  customCss_ENDS_WITH: String
-  customCss_IN: [String]
-  customCss_MATCHES: String
-  customCss_STARTS_WITH: String
   firstChild: ElementWhere
   firstChildAggregate: ElementFirstChildAggregateInput
   firstChildConnection: ElementFirstChildConnectionWhere
   firstChildConnection_NOT: ElementFirstChildConnectionWhere
   firstChild_NOT: ElementWhere
-  guiCss: String
-  guiCss_CONTAINS: String
-  guiCss_ENDS_WITH: String
-  guiCss_IN: [String]
-  guiCss_MATCHES: String
-  guiCss_STARTS_WITH: String
   id: ID
   id_CONTAINS: ID
   id_ENDS_WITH: ID
@@ -9361,6 +9483,12 @@ input ElementWhere {
   renderIfExpression_IN: [String]
   renderIfExpression_MATCHES: String
   renderIfExpression_STARTS_WITH: String
+  style: String
+  style_CONTAINS: String
+  style_ENDS_WITH: String
+  style_IN: [String]
+  style_MATCHES: String
+  style_STARTS_WITH: String
 }
 
 type ElementsConnection {
@@ -11308,11 +11436,10 @@ type HookElementElementAggregationSelection {
 type HookElementElementNodeAggregateSelection {
   _compoundName: StringAggregateSelectionNonNullable!
   childMapperPropKey: StringAggregateSelectionNullable!
-  customCss: StringAggregateSelectionNullable!
-  guiCss: StringAggregateSelectionNullable!
   id: IDAggregateSelectionNonNullable!
   renderForEachPropKey: StringAggregateSelectionNullable!
   renderIfExpression: StringAggregateSelectionNullable!
+  style: StringAggregateSelectionNullable!
 }
 
 input HookElementFieldInput {
@@ -11415,6 +11542,21 @@ input HookElementNodeAggregationWhereInput {
   renderIfExpression_SHORTEST_LENGTH_GTE: Int
   renderIfExpression_SHORTEST_LENGTH_LT: Int
   renderIfExpression_SHORTEST_LENGTH_LTE: Int
+  style_AVERAGE_LENGTH_EQUAL: Float
+  style_AVERAGE_LENGTH_GT: Float
+  style_AVERAGE_LENGTH_GTE: Float
+  style_AVERAGE_LENGTH_LT: Float
+  style_AVERAGE_LENGTH_LTE: Float
+  style_LONGEST_LENGTH_EQUAL: Int
+  style_LONGEST_LENGTH_GT: Int
+  style_LONGEST_LENGTH_GTE: Int
+  style_LONGEST_LENGTH_LT: Int
+  style_LONGEST_LENGTH_LTE: Int
+  style_SHORTEST_LENGTH_EQUAL: Int
+  style_SHORTEST_LENGTH_GT: Int
+  style_SHORTEST_LENGTH_GTE: Int
+  style_SHORTEST_LENGTH_LT: Int
+  style_SHORTEST_LENGTH_LTE: Int
 }
 
 type HookElementRelationship {
@@ -13634,11 +13776,10 @@ type PageElementPageContentContainerAggregationSelection {
 type PageElementPageContentContainerNodeAggregateSelection {
   _compoundName: StringAggregateSelectionNonNullable!
   childMapperPropKey: StringAggregateSelectionNullable!
-  customCss: StringAggregateSelectionNullable!
-  guiCss: StringAggregateSelectionNullable!
   id: IDAggregateSelectionNonNullable!
   renderForEachPropKey: StringAggregateSelectionNullable!
   renderIfExpression: StringAggregateSelectionNullable!
+  style: StringAggregateSelectionNullable!
 }
 
 type PageElementRootElementAggregationSelection {
@@ -13649,11 +13790,10 @@ type PageElementRootElementAggregationSelection {
 type PageElementRootElementNodeAggregateSelection {
   _compoundName: StringAggregateSelectionNonNullable!
   childMapperPropKey: StringAggregateSelectionNullable!
-  customCss: StringAggregateSelectionNullable!
-  guiCss: StringAggregateSelectionNullable!
   id: IDAggregateSelectionNonNullable!
   renderForEachPropKey: StringAggregateSelectionNullable!
   renderIfExpression: StringAggregateSelectionNullable!
+  style: StringAggregateSelectionNullable!
 }
 
 """
@@ -13852,6 +13992,21 @@ input PagePageContentContainerNodeAggregationWhereInput {
   renderIfExpression_SHORTEST_LENGTH_GTE: Int
   renderIfExpression_SHORTEST_LENGTH_LT: Int
   renderIfExpression_SHORTEST_LENGTH_LTE: Int
+  style_AVERAGE_LENGTH_EQUAL: Float
+  style_AVERAGE_LENGTH_GT: Float
+  style_AVERAGE_LENGTH_GTE: Float
+  style_AVERAGE_LENGTH_LT: Float
+  style_AVERAGE_LENGTH_LTE: Float
+  style_LONGEST_LENGTH_EQUAL: Int
+  style_LONGEST_LENGTH_GT: Int
+  style_LONGEST_LENGTH_GTE: Int
+  style_LONGEST_LENGTH_LT: Int
+  style_LONGEST_LENGTH_LTE: Int
+  style_SHORTEST_LENGTH_EQUAL: Int
+  style_SHORTEST_LENGTH_GT: Int
+  style_SHORTEST_LENGTH_GTE: Int
+  style_SHORTEST_LENGTH_LT: Int
+  style_SHORTEST_LENGTH_LTE: Int
 }
 
 type PagePageContentContainerRelationship {
@@ -14042,6 +14197,21 @@ input PageRootElementNodeAggregationWhereInput {
   renderIfExpression_SHORTEST_LENGTH_GTE: Int
   renderIfExpression_SHORTEST_LENGTH_LT: Int
   renderIfExpression_SHORTEST_LENGTH_LTE: Int
+  style_AVERAGE_LENGTH_EQUAL: Float
+  style_AVERAGE_LENGTH_GT: Float
+  style_AVERAGE_LENGTH_GTE: Float
+  style_AVERAGE_LENGTH_LT: Float
+  style_AVERAGE_LENGTH_LTE: Float
+  style_LONGEST_LENGTH_EQUAL: Int
+  style_LONGEST_LENGTH_GT: Int
+  style_LONGEST_LENGTH_GTE: Int
+  style_LONGEST_LENGTH_LT: Int
+  style_LONGEST_LENGTH_LTE: Int
+  style_SHORTEST_LENGTH_EQUAL: Int
+  style_SHORTEST_LENGTH_GT: Int
+  style_SHORTEST_LENGTH_GTE: Int
+  style_SHORTEST_LENGTH_LT: Int
+  style_SHORTEST_LENGTH_LTE: Int
 }
 
 type PageRootElementRelationship {
@@ -19497,11 +19667,10 @@ type UserElementElementsAggregationSelection {
 type UserElementElementsNodeAggregateSelection {
   _compoundName: StringAggregateSelectionNonNullable!
   childMapperPropKey: StringAggregateSelectionNullable!
-  customCss: StringAggregateSelectionNullable!
-  guiCss: StringAggregateSelectionNullable!
   id: IDAggregateSelectionNonNullable!
   renderForEachPropKey: StringAggregateSelectionNullable!
   renderIfExpression: StringAggregateSelectionNullable!
+  style: StringAggregateSelectionNullable!
 }
 
 input UserElementsAggregateInput {
@@ -19666,6 +19835,21 @@ input UserElementsNodeAggregationWhereInput {
   renderIfExpression_SHORTEST_LENGTH_GTE: Int
   renderIfExpression_SHORTEST_LENGTH_LT: Int
   renderIfExpression_SHORTEST_LENGTH_LTE: Int
+  style_AVERAGE_LENGTH_EQUAL: Float
+  style_AVERAGE_LENGTH_GT: Float
+  style_AVERAGE_LENGTH_GTE: Float
+  style_AVERAGE_LENGTH_LT: Float
+  style_AVERAGE_LENGTH_LTE: Float
+  style_LONGEST_LENGTH_EQUAL: Int
+  style_LONGEST_LENGTH_GT: Int
+  style_LONGEST_LENGTH_GTE: Int
+  style_LONGEST_LENGTH_LT: Int
+  style_LONGEST_LENGTH_LTE: Int
+  style_SHORTEST_LENGTH_EQUAL: Int
+  style_SHORTEST_LENGTH_GT: Int
+  style_SHORTEST_LENGTH_GTE: Int
+  style_SHORTEST_LENGTH_LT: Int
+  style_SHORTEST_LENGTH_LTE: Int
 }
 
 type UserElementsRelationship {

--- a/schema.graphql
+++ b/schema.graphql
@@ -588,36 +588,6 @@ input ApiActionElementNodeAggregationWhereInput {
   childMapperPropKey_SHORTEST_LENGTH_GTE: Int
   childMapperPropKey_SHORTEST_LENGTH_LT: Int
   childMapperPropKey_SHORTEST_LENGTH_LTE: Int
-  customCss_AVERAGE_LENGTH_EQUAL: Float
-  customCss_AVERAGE_LENGTH_GT: Float
-  customCss_AVERAGE_LENGTH_GTE: Float
-  customCss_AVERAGE_LENGTH_LT: Float
-  customCss_AVERAGE_LENGTH_LTE: Float
-  customCss_LONGEST_LENGTH_EQUAL: Int
-  customCss_LONGEST_LENGTH_GT: Int
-  customCss_LONGEST_LENGTH_GTE: Int
-  customCss_LONGEST_LENGTH_LT: Int
-  customCss_LONGEST_LENGTH_LTE: Int
-  customCss_SHORTEST_LENGTH_EQUAL: Int
-  customCss_SHORTEST_LENGTH_GT: Int
-  customCss_SHORTEST_LENGTH_GTE: Int
-  customCss_SHORTEST_LENGTH_LT: Int
-  customCss_SHORTEST_LENGTH_LTE: Int
-  guiCss_AVERAGE_LENGTH_EQUAL: Float
-  guiCss_AVERAGE_LENGTH_GT: Float
-  guiCss_AVERAGE_LENGTH_GTE: Float
-  guiCss_AVERAGE_LENGTH_LT: Float
-  guiCss_AVERAGE_LENGTH_LTE: Float
-  guiCss_LONGEST_LENGTH_EQUAL: Int
-  guiCss_LONGEST_LENGTH_GT: Int
-  guiCss_LONGEST_LENGTH_GTE: Int
-  guiCss_LONGEST_LENGTH_LT: Int
-  guiCss_LONGEST_LENGTH_LTE: Int
-  guiCss_SHORTEST_LENGTH_EQUAL: Int
-  guiCss_SHORTEST_LENGTH_GT: Int
-  guiCss_SHORTEST_LENGTH_GTE: Int
-  guiCss_SHORTEST_LENGTH_LT: Int
-  guiCss_SHORTEST_LENGTH_LTE: Int
   renderForEachPropKey_AVERAGE_LENGTH_EQUAL: Float
   renderForEachPropKey_AVERAGE_LENGTH_GT: Float
   renderForEachPropKey_AVERAGE_LENGTH_GTE: Float
@@ -4181,36 +4151,6 @@ input BaseActionElementNodeAggregationWhereInput {
   childMapperPropKey_SHORTEST_LENGTH_GTE: Int
   childMapperPropKey_SHORTEST_LENGTH_LT: Int
   childMapperPropKey_SHORTEST_LENGTH_LTE: Int
-  customCss_AVERAGE_LENGTH_EQUAL: Float
-  customCss_AVERAGE_LENGTH_GT: Float
-  customCss_AVERAGE_LENGTH_GTE: Float
-  customCss_AVERAGE_LENGTH_LT: Float
-  customCss_AVERAGE_LENGTH_LTE: Float
-  customCss_LONGEST_LENGTH_EQUAL: Int
-  customCss_LONGEST_LENGTH_GT: Int
-  customCss_LONGEST_LENGTH_GTE: Int
-  customCss_LONGEST_LENGTH_LT: Int
-  customCss_LONGEST_LENGTH_LTE: Int
-  customCss_SHORTEST_LENGTH_EQUAL: Int
-  customCss_SHORTEST_LENGTH_GT: Int
-  customCss_SHORTEST_LENGTH_GTE: Int
-  customCss_SHORTEST_LENGTH_LT: Int
-  customCss_SHORTEST_LENGTH_LTE: Int
-  guiCss_AVERAGE_LENGTH_EQUAL: Float
-  guiCss_AVERAGE_LENGTH_GT: Float
-  guiCss_AVERAGE_LENGTH_GTE: Float
-  guiCss_AVERAGE_LENGTH_LT: Float
-  guiCss_AVERAGE_LENGTH_LTE: Float
-  guiCss_LONGEST_LENGTH_EQUAL: Int
-  guiCss_LONGEST_LENGTH_GT: Int
-  guiCss_LONGEST_LENGTH_GTE: Int
-  guiCss_LONGEST_LENGTH_LT: Int
-  guiCss_LONGEST_LENGTH_LTE: Int
-  guiCss_SHORTEST_LENGTH_EQUAL: Int
-  guiCss_SHORTEST_LENGTH_GT: Int
-  guiCss_SHORTEST_LENGTH_GTE: Int
-  guiCss_SHORTEST_LENGTH_LT: Int
-  guiCss_SHORTEST_LENGTH_LTE: Int
   renderForEachPropKey_AVERAGE_LENGTH_EQUAL: Float
   renderForEachPropKey_AVERAGE_LENGTH_GT: Float
   renderForEachPropKey_AVERAGE_LENGTH_GTE: Float
@@ -4801,36 +4741,6 @@ input CodeActionElementNodeAggregationWhereInput {
   childMapperPropKey_SHORTEST_LENGTH_GTE: Int
   childMapperPropKey_SHORTEST_LENGTH_LT: Int
   childMapperPropKey_SHORTEST_LENGTH_LTE: Int
-  customCss_AVERAGE_LENGTH_EQUAL: Float
-  customCss_AVERAGE_LENGTH_GT: Float
-  customCss_AVERAGE_LENGTH_GTE: Float
-  customCss_AVERAGE_LENGTH_LT: Float
-  customCss_AVERAGE_LENGTH_LTE: Float
-  customCss_LONGEST_LENGTH_EQUAL: Int
-  customCss_LONGEST_LENGTH_GT: Int
-  customCss_LONGEST_LENGTH_GTE: Int
-  customCss_LONGEST_LENGTH_LT: Int
-  customCss_LONGEST_LENGTH_LTE: Int
-  customCss_SHORTEST_LENGTH_EQUAL: Int
-  customCss_SHORTEST_LENGTH_GT: Int
-  customCss_SHORTEST_LENGTH_GTE: Int
-  customCss_SHORTEST_LENGTH_LT: Int
-  customCss_SHORTEST_LENGTH_LTE: Int
-  guiCss_AVERAGE_LENGTH_EQUAL: Float
-  guiCss_AVERAGE_LENGTH_GT: Float
-  guiCss_AVERAGE_LENGTH_GTE: Float
-  guiCss_AVERAGE_LENGTH_LT: Float
-  guiCss_AVERAGE_LENGTH_LTE: Float
-  guiCss_LONGEST_LENGTH_EQUAL: Int
-  guiCss_LONGEST_LENGTH_GT: Int
-  guiCss_LONGEST_LENGTH_GTE: Int
-  guiCss_LONGEST_LENGTH_LT: Int
-  guiCss_LONGEST_LENGTH_LTE: Int
-  guiCss_SHORTEST_LENGTH_EQUAL: Int
-  guiCss_SHORTEST_LENGTH_GT: Int
-  guiCss_SHORTEST_LENGTH_GTE: Int
-  guiCss_SHORTEST_LENGTH_LT: Int
-  guiCss_SHORTEST_LENGTH_LTE: Int
   renderForEachPropKey_AVERAGE_LENGTH_EQUAL: Float
   renderForEachPropKey_AVERAGE_LENGTH_GT: Float
   renderForEachPropKey_AVERAGE_LENGTH_GTE: Float
@@ -5542,36 +5452,6 @@ input ComponentChildrenContainerElementNodeAggregationWhereInput {
   childMapperPropKey_SHORTEST_LENGTH_GTE: Int
   childMapperPropKey_SHORTEST_LENGTH_LT: Int
   childMapperPropKey_SHORTEST_LENGTH_LTE: Int
-  customCss_AVERAGE_LENGTH_EQUAL: Float
-  customCss_AVERAGE_LENGTH_GT: Float
-  customCss_AVERAGE_LENGTH_GTE: Float
-  customCss_AVERAGE_LENGTH_LT: Float
-  customCss_AVERAGE_LENGTH_LTE: Float
-  customCss_LONGEST_LENGTH_EQUAL: Int
-  customCss_LONGEST_LENGTH_GT: Int
-  customCss_LONGEST_LENGTH_GTE: Int
-  customCss_LONGEST_LENGTH_LT: Int
-  customCss_LONGEST_LENGTH_LTE: Int
-  customCss_SHORTEST_LENGTH_EQUAL: Int
-  customCss_SHORTEST_LENGTH_GT: Int
-  customCss_SHORTEST_LENGTH_GTE: Int
-  customCss_SHORTEST_LENGTH_LT: Int
-  customCss_SHORTEST_LENGTH_LTE: Int
-  guiCss_AVERAGE_LENGTH_EQUAL: Float
-  guiCss_AVERAGE_LENGTH_GT: Float
-  guiCss_AVERAGE_LENGTH_GTE: Float
-  guiCss_AVERAGE_LENGTH_LT: Float
-  guiCss_AVERAGE_LENGTH_LTE: Float
-  guiCss_LONGEST_LENGTH_EQUAL: Int
-  guiCss_LONGEST_LENGTH_GT: Int
-  guiCss_LONGEST_LENGTH_GTE: Int
-  guiCss_LONGEST_LENGTH_LT: Int
-  guiCss_LONGEST_LENGTH_LTE: Int
-  guiCss_SHORTEST_LENGTH_EQUAL: Int
-  guiCss_SHORTEST_LENGTH_GT: Int
-  guiCss_SHORTEST_LENGTH_GTE: Int
-  guiCss_SHORTEST_LENGTH_LT: Int
-  guiCss_SHORTEST_LENGTH_LTE: Int
   renderForEachPropKey_AVERAGE_LENGTH_EQUAL: Float
   renderForEachPropKey_AVERAGE_LENGTH_GT: Float
   renderForEachPropKey_AVERAGE_LENGTH_GTE: Float
@@ -6041,36 +5921,6 @@ input ComponentRootElementNodeAggregationWhereInput {
   childMapperPropKey_SHORTEST_LENGTH_GTE: Int
   childMapperPropKey_SHORTEST_LENGTH_LT: Int
   childMapperPropKey_SHORTEST_LENGTH_LTE: Int
-  customCss_AVERAGE_LENGTH_EQUAL: Float
-  customCss_AVERAGE_LENGTH_GT: Float
-  customCss_AVERAGE_LENGTH_GTE: Float
-  customCss_AVERAGE_LENGTH_LT: Float
-  customCss_AVERAGE_LENGTH_LTE: Float
-  customCss_LONGEST_LENGTH_EQUAL: Int
-  customCss_LONGEST_LENGTH_GT: Int
-  customCss_LONGEST_LENGTH_GTE: Int
-  customCss_LONGEST_LENGTH_LT: Int
-  customCss_LONGEST_LENGTH_LTE: Int
-  customCss_SHORTEST_LENGTH_EQUAL: Int
-  customCss_SHORTEST_LENGTH_GT: Int
-  customCss_SHORTEST_LENGTH_GTE: Int
-  customCss_SHORTEST_LENGTH_LT: Int
-  customCss_SHORTEST_LENGTH_LTE: Int
-  guiCss_AVERAGE_LENGTH_EQUAL: Float
-  guiCss_AVERAGE_LENGTH_GT: Float
-  guiCss_AVERAGE_LENGTH_GTE: Float
-  guiCss_AVERAGE_LENGTH_LT: Float
-  guiCss_AVERAGE_LENGTH_LTE: Float
-  guiCss_LONGEST_LENGTH_EQUAL: Int
-  guiCss_LONGEST_LENGTH_GT: Int
-  guiCss_LONGEST_LENGTH_GTE: Int
-  guiCss_LONGEST_LENGTH_LT: Int
-  guiCss_LONGEST_LENGTH_LTE: Int
-  guiCss_SHORTEST_LENGTH_EQUAL: Int
-  guiCss_SHORTEST_LENGTH_GT: Int
-  guiCss_SHORTEST_LENGTH_GTE: Int
-  guiCss_SHORTEST_LENGTH_LT: Int
-  guiCss_SHORTEST_LENGTH_LTE: Int
   renderForEachPropKey_AVERAGE_LENGTH_EQUAL: Float
   renderForEachPropKey_AVERAGE_LENGTH_GT: Float
   renderForEachPropKey_AVERAGE_LENGTH_GTE: Float
@@ -6965,6 +6815,7 @@ type Element {
   renderIfExpression: String
   renderType: RenderType
   slug: String!
+  style: String
 }
 
 type ElementAggregateSelection {
@@ -7216,36 +7067,6 @@ input ElementChildMapperPreviousSiblingNodeAggregationWhereInput {
   childMapperPropKey_SHORTEST_LENGTH_GTE: Int
   childMapperPropKey_SHORTEST_LENGTH_LT: Int
   childMapperPropKey_SHORTEST_LENGTH_LTE: Int
-  customCss_AVERAGE_LENGTH_EQUAL: Float
-  customCss_AVERAGE_LENGTH_GT: Float
-  customCss_AVERAGE_LENGTH_GTE: Float
-  customCss_AVERAGE_LENGTH_LT: Float
-  customCss_AVERAGE_LENGTH_LTE: Float
-  customCss_LONGEST_LENGTH_EQUAL: Int
-  customCss_LONGEST_LENGTH_GT: Int
-  customCss_LONGEST_LENGTH_GTE: Int
-  customCss_LONGEST_LENGTH_LT: Int
-  customCss_LONGEST_LENGTH_LTE: Int
-  customCss_SHORTEST_LENGTH_EQUAL: Int
-  customCss_SHORTEST_LENGTH_GT: Int
-  customCss_SHORTEST_LENGTH_GTE: Int
-  customCss_SHORTEST_LENGTH_LT: Int
-  customCss_SHORTEST_LENGTH_LTE: Int
-  guiCss_AVERAGE_LENGTH_EQUAL: Float
-  guiCss_AVERAGE_LENGTH_GT: Float
-  guiCss_AVERAGE_LENGTH_GTE: Float
-  guiCss_AVERAGE_LENGTH_LT: Float
-  guiCss_AVERAGE_LENGTH_LTE: Float
-  guiCss_LONGEST_LENGTH_EQUAL: Int
-  guiCss_LONGEST_LENGTH_GT: Int
-  guiCss_LONGEST_LENGTH_GTE: Int
-  guiCss_LONGEST_LENGTH_LT: Int
-  guiCss_LONGEST_LENGTH_LTE: Int
-  guiCss_SHORTEST_LENGTH_EQUAL: Int
-  guiCss_SHORTEST_LENGTH_GT: Int
-  guiCss_SHORTEST_LENGTH_GTE: Int
-  guiCss_SHORTEST_LENGTH_LT: Int
-  guiCss_SHORTEST_LENGTH_LTE: Int
   renderForEachPropKey_AVERAGE_LENGTH_EQUAL: Float
   renderForEachPropKey_AVERAGE_LENGTH_GT: Float
   renderForEachPropKey_AVERAGE_LENGTH_GTE: Float
@@ -7614,36 +7435,6 @@ input ElementFirstChildNodeAggregationWhereInput {
   childMapperPropKey_SHORTEST_LENGTH_GTE: Int
   childMapperPropKey_SHORTEST_LENGTH_LT: Int
   childMapperPropKey_SHORTEST_LENGTH_LTE: Int
-  customCss_AVERAGE_LENGTH_EQUAL: Float
-  customCss_AVERAGE_LENGTH_GT: Float
-  customCss_AVERAGE_LENGTH_GTE: Float
-  customCss_AVERAGE_LENGTH_LT: Float
-  customCss_AVERAGE_LENGTH_LTE: Float
-  customCss_LONGEST_LENGTH_EQUAL: Int
-  customCss_LONGEST_LENGTH_GT: Int
-  customCss_LONGEST_LENGTH_GTE: Int
-  customCss_LONGEST_LENGTH_LT: Int
-  customCss_LONGEST_LENGTH_LTE: Int
-  customCss_SHORTEST_LENGTH_EQUAL: Int
-  customCss_SHORTEST_LENGTH_GT: Int
-  customCss_SHORTEST_LENGTH_GTE: Int
-  customCss_SHORTEST_LENGTH_LT: Int
-  customCss_SHORTEST_LENGTH_LTE: Int
-  guiCss_AVERAGE_LENGTH_EQUAL: Float
-  guiCss_AVERAGE_LENGTH_GT: Float
-  guiCss_AVERAGE_LENGTH_GTE: Float
-  guiCss_AVERAGE_LENGTH_LT: Float
-  guiCss_AVERAGE_LENGTH_LTE: Float
-  guiCss_LONGEST_LENGTH_EQUAL: Int
-  guiCss_LONGEST_LENGTH_GT: Int
-  guiCss_LONGEST_LENGTH_GTE: Int
-  guiCss_LONGEST_LENGTH_LT: Int
-  guiCss_LONGEST_LENGTH_LTE: Int
-  guiCss_SHORTEST_LENGTH_EQUAL: Int
-  guiCss_SHORTEST_LENGTH_GT: Int
-  guiCss_SHORTEST_LENGTH_GTE: Int
-  guiCss_SHORTEST_LENGTH_LT: Int
-  guiCss_SHORTEST_LENGTH_LTE: Int
   renderForEachPropKey_AVERAGE_LENGTH_EQUAL: Float
   renderForEachPropKey_AVERAGE_LENGTH_GT: Float
   renderForEachPropKey_AVERAGE_LENGTH_GTE: Float
@@ -7812,36 +7603,6 @@ input ElementNextSiblingNodeAggregationWhereInput {
   childMapperPropKey_SHORTEST_LENGTH_GTE: Int
   childMapperPropKey_SHORTEST_LENGTH_LT: Int
   childMapperPropKey_SHORTEST_LENGTH_LTE: Int
-  customCss_AVERAGE_LENGTH_EQUAL: Float
-  customCss_AVERAGE_LENGTH_GT: Float
-  customCss_AVERAGE_LENGTH_GTE: Float
-  customCss_AVERAGE_LENGTH_LT: Float
-  customCss_AVERAGE_LENGTH_LTE: Float
-  customCss_LONGEST_LENGTH_EQUAL: Int
-  customCss_LONGEST_LENGTH_GT: Int
-  customCss_LONGEST_LENGTH_GTE: Int
-  customCss_LONGEST_LENGTH_LT: Int
-  customCss_LONGEST_LENGTH_LTE: Int
-  customCss_SHORTEST_LENGTH_EQUAL: Int
-  customCss_SHORTEST_LENGTH_GT: Int
-  customCss_SHORTEST_LENGTH_GTE: Int
-  customCss_SHORTEST_LENGTH_LT: Int
-  customCss_SHORTEST_LENGTH_LTE: Int
-  guiCss_AVERAGE_LENGTH_EQUAL: Float
-  guiCss_AVERAGE_LENGTH_GT: Float
-  guiCss_AVERAGE_LENGTH_GTE: Float
-  guiCss_AVERAGE_LENGTH_LT: Float
-  guiCss_AVERAGE_LENGTH_LTE: Float
-  guiCss_LONGEST_LENGTH_EQUAL: Int
-  guiCss_LONGEST_LENGTH_GT: Int
-  guiCss_LONGEST_LENGTH_GTE: Int
-  guiCss_LONGEST_LENGTH_LT: Int
-  guiCss_LONGEST_LENGTH_LTE: Int
-  guiCss_SHORTEST_LENGTH_EQUAL: Int
-  guiCss_SHORTEST_LENGTH_GT: Int
-  guiCss_SHORTEST_LENGTH_GTE: Int
-  guiCss_SHORTEST_LENGTH_LT: Int
-  guiCss_SHORTEST_LENGTH_LTE: Int
   renderForEachPropKey_AVERAGE_LENGTH_EQUAL: Float
   renderForEachPropKey_AVERAGE_LENGTH_GT: Float
   renderForEachPropKey_AVERAGE_LENGTH_GTE: Float
@@ -8286,36 +8047,6 @@ input ElementParentNodeAggregationWhereInput {
   childMapperPropKey_SHORTEST_LENGTH_GTE: Int
   childMapperPropKey_SHORTEST_LENGTH_LT: Int
   childMapperPropKey_SHORTEST_LENGTH_LTE: Int
-  customCss_AVERAGE_LENGTH_EQUAL: Float
-  customCss_AVERAGE_LENGTH_GT: Float
-  customCss_AVERAGE_LENGTH_GTE: Float
-  customCss_AVERAGE_LENGTH_LT: Float
-  customCss_AVERAGE_LENGTH_LTE: Float
-  customCss_LONGEST_LENGTH_EQUAL: Int
-  customCss_LONGEST_LENGTH_GT: Int
-  customCss_LONGEST_LENGTH_GTE: Int
-  customCss_LONGEST_LENGTH_LT: Int
-  customCss_LONGEST_LENGTH_LTE: Int
-  customCss_SHORTEST_LENGTH_EQUAL: Int
-  customCss_SHORTEST_LENGTH_GT: Int
-  customCss_SHORTEST_LENGTH_GTE: Int
-  customCss_SHORTEST_LENGTH_LT: Int
-  customCss_SHORTEST_LENGTH_LTE: Int
-  guiCss_AVERAGE_LENGTH_EQUAL: Float
-  guiCss_AVERAGE_LENGTH_GT: Float
-  guiCss_AVERAGE_LENGTH_GTE: Float
-  guiCss_AVERAGE_LENGTH_LT: Float
-  guiCss_AVERAGE_LENGTH_LTE: Float
-  guiCss_LONGEST_LENGTH_EQUAL: Int
-  guiCss_LONGEST_LENGTH_GT: Int
-  guiCss_LONGEST_LENGTH_GTE: Int
-  guiCss_LONGEST_LENGTH_LT: Int
-  guiCss_LONGEST_LENGTH_LTE: Int
-  guiCss_SHORTEST_LENGTH_EQUAL: Int
-  guiCss_SHORTEST_LENGTH_GT: Int
-  guiCss_SHORTEST_LENGTH_GTE: Int
-  guiCss_SHORTEST_LENGTH_LT: Int
-  guiCss_SHORTEST_LENGTH_LTE: Int
   renderForEachPropKey_AVERAGE_LENGTH_EQUAL: Float
   renderForEachPropKey_AVERAGE_LENGTH_GT: Float
   renderForEachPropKey_AVERAGE_LENGTH_GTE: Float
@@ -8602,36 +8333,6 @@ input ElementPrevSiblingNodeAggregationWhereInput {
   childMapperPropKey_SHORTEST_LENGTH_GTE: Int
   childMapperPropKey_SHORTEST_LENGTH_LT: Int
   childMapperPropKey_SHORTEST_LENGTH_LTE: Int
-  customCss_AVERAGE_LENGTH_EQUAL: Float
-  customCss_AVERAGE_LENGTH_GT: Float
-  customCss_AVERAGE_LENGTH_GTE: Float
-  customCss_AVERAGE_LENGTH_LT: Float
-  customCss_AVERAGE_LENGTH_LTE: Float
-  customCss_LONGEST_LENGTH_EQUAL: Int
-  customCss_LONGEST_LENGTH_GT: Int
-  customCss_LONGEST_LENGTH_GTE: Int
-  customCss_LONGEST_LENGTH_LT: Int
-  customCss_LONGEST_LENGTH_LTE: Int
-  customCss_SHORTEST_LENGTH_EQUAL: Int
-  customCss_SHORTEST_LENGTH_GT: Int
-  customCss_SHORTEST_LENGTH_GTE: Int
-  customCss_SHORTEST_LENGTH_LT: Int
-  customCss_SHORTEST_LENGTH_LTE: Int
-  guiCss_AVERAGE_LENGTH_EQUAL: Float
-  guiCss_AVERAGE_LENGTH_GT: Float
-  guiCss_AVERAGE_LENGTH_GTE: Float
-  guiCss_AVERAGE_LENGTH_LT: Float
-  guiCss_AVERAGE_LENGTH_LTE: Float
-  guiCss_LONGEST_LENGTH_EQUAL: Int
-  guiCss_LONGEST_LENGTH_GT: Int
-  guiCss_LONGEST_LENGTH_GTE: Int
-  guiCss_LONGEST_LENGTH_LT: Int
-  guiCss_LONGEST_LENGTH_LTE: Int
-  guiCss_SHORTEST_LENGTH_EQUAL: Int
-  guiCss_SHORTEST_LENGTH_GT: Int
-  guiCss_SHORTEST_LENGTH_GTE: Int
-  guiCss_SHORTEST_LENGTH_LT: Int
-  guiCss_SHORTEST_LENGTH_LTE: Int
   renderForEachPropKey_AVERAGE_LENGTH_EQUAL: Float
   renderForEachPropKey_AVERAGE_LENGTH_GT: Float
   renderForEachPropKey_AVERAGE_LENGTH_GTE: Float
@@ -11482,36 +11183,6 @@ input HookElementNodeAggregationWhereInput {
   childMapperPropKey_SHORTEST_LENGTH_GTE: Int
   childMapperPropKey_SHORTEST_LENGTH_LT: Int
   childMapperPropKey_SHORTEST_LENGTH_LTE: Int
-  customCss_AVERAGE_LENGTH_EQUAL: Float
-  customCss_AVERAGE_LENGTH_GT: Float
-  customCss_AVERAGE_LENGTH_GTE: Float
-  customCss_AVERAGE_LENGTH_LT: Float
-  customCss_AVERAGE_LENGTH_LTE: Float
-  customCss_LONGEST_LENGTH_EQUAL: Int
-  customCss_LONGEST_LENGTH_GT: Int
-  customCss_LONGEST_LENGTH_GTE: Int
-  customCss_LONGEST_LENGTH_LT: Int
-  customCss_LONGEST_LENGTH_LTE: Int
-  customCss_SHORTEST_LENGTH_EQUAL: Int
-  customCss_SHORTEST_LENGTH_GT: Int
-  customCss_SHORTEST_LENGTH_GTE: Int
-  customCss_SHORTEST_LENGTH_LT: Int
-  customCss_SHORTEST_LENGTH_LTE: Int
-  guiCss_AVERAGE_LENGTH_EQUAL: Float
-  guiCss_AVERAGE_LENGTH_GT: Float
-  guiCss_AVERAGE_LENGTH_GTE: Float
-  guiCss_AVERAGE_LENGTH_LT: Float
-  guiCss_AVERAGE_LENGTH_LTE: Float
-  guiCss_LONGEST_LENGTH_EQUAL: Int
-  guiCss_LONGEST_LENGTH_GT: Int
-  guiCss_LONGEST_LENGTH_GTE: Int
-  guiCss_LONGEST_LENGTH_LT: Int
-  guiCss_LONGEST_LENGTH_LTE: Int
-  guiCss_SHORTEST_LENGTH_EQUAL: Int
-  guiCss_SHORTEST_LENGTH_GT: Int
-  guiCss_SHORTEST_LENGTH_GTE: Int
-  guiCss_SHORTEST_LENGTH_LT: Int
-  guiCss_SHORTEST_LENGTH_LTE: Int
   renderForEachPropKey_AVERAGE_LENGTH_EQUAL: Float
   renderForEachPropKey_AVERAGE_LENGTH_GT: Float
   renderForEachPropKey_AVERAGE_LENGTH_GTE: Float
@@ -13932,36 +13603,6 @@ input PagePageContentContainerNodeAggregationWhereInput {
   childMapperPropKey_SHORTEST_LENGTH_GTE: Int
   childMapperPropKey_SHORTEST_LENGTH_LT: Int
   childMapperPropKey_SHORTEST_LENGTH_LTE: Int
-  customCss_AVERAGE_LENGTH_EQUAL: Float
-  customCss_AVERAGE_LENGTH_GT: Float
-  customCss_AVERAGE_LENGTH_GTE: Float
-  customCss_AVERAGE_LENGTH_LT: Float
-  customCss_AVERAGE_LENGTH_LTE: Float
-  customCss_LONGEST_LENGTH_EQUAL: Int
-  customCss_LONGEST_LENGTH_GT: Int
-  customCss_LONGEST_LENGTH_GTE: Int
-  customCss_LONGEST_LENGTH_LT: Int
-  customCss_LONGEST_LENGTH_LTE: Int
-  customCss_SHORTEST_LENGTH_EQUAL: Int
-  customCss_SHORTEST_LENGTH_GT: Int
-  customCss_SHORTEST_LENGTH_GTE: Int
-  customCss_SHORTEST_LENGTH_LT: Int
-  customCss_SHORTEST_LENGTH_LTE: Int
-  guiCss_AVERAGE_LENGTH_EQUAL: Float
-  guiCss_AVERAGE_LENGTH_GT: Float
-  guiCss_AVERAGE_LENGTH_GTE: Float
-  guiCss_AVERAGE_LENGTH_LT: Float
-  guiCss_AVERAGE_LENGTH_LTE: Float
-  guiCss_LONGEST_LENGTH_EQUAL: Int
-  guiCss_LONGEST_LENGTH_GT: Int
-  guiCss_LONGEST_LENGTH_GTE: Int
-  guiCss_LONGEST_LENGTH_LT: Int
-  guiCss_LONGEST_LENGTH_LTE: Int
-  guiCss_SHORTEST_LENGTH_EQUAL: Int
-  guiCss_SHORTEST_LENGTH_GT: Int
-  guiCss_SHORTEST_LENGTH_GTE: Int
-  guiCss_SHORTEST_LENGTH_LT: Int
-  guiCss_SHORTEST_LENGTH_LTE: Int
   renderForEachPropKey_AVERAGE_LENGTH_EQUAL: Float
   renderForEachPropKey_AVERAGE_LENGTH_GT: Float
   renderForEachPropKey_AVERAGE_LENGTH_GTE: Float
@@ -14137,36 +13778,6 @@ input PageRootElementNodeAggregationWhereInput {
   childMapperPropKey_SHORTEST_LENGTH_GTE: Int
   childMapperPropKey_SHORTEST_LENGTH_LT: Int
   childMapperPropKey_SHORTEST_LENGTH_LTE: Int
-  customCss_AVERAGE_LENGTH_EQUAL: Float
-  customCss_AVERAGE_LENGTH_GT: Float
-  customCss_AVERAGE_LENGTH_GTE: Float
-  customCss_AVERAGE_LENGTH_LT: Float
-  customCss_AVERAGE_LENGTH_LTE: Float
-  customCss_LONGEST_LENGTH_EQUAL: Int
-  customCss_LONGEST_LENGTH_GT: Int
-  customCss_LONGEST_LENGTH_GTE: Int
-  customCss_LONGEST_LENGTH_LT: Int
-  customCss_LONGEST_LENGTH_LTE: Int
-  customCss_SHORTEST_LENGTH_EQUAL: Int
-  customCss_SHORTEST_LENGTH_GT: Int
-  customCss_SHORTEST_LENGTH_GTE: Int
-  customCss_SHORTEST_LENGTH_LT: Int
-  customCss_SHORTEST_LENGTH_LTE: Int
-  guiCss_AVERAGE_LENGTH_EQUAL: Float
-  guiCss_AVERAGE_LENGTH_GT: Float
-  guiCss_AVERAGE_LENGTH_GTE: Float
-  guiCss_AVERAGE_LENGTH_LT: Float
-  guiCss_AVERAGE_LENGTH_LTE: Float
-  guiCss_LONGEST_LENGTH_EQUAL: Int
-  guiCss_LONGEST_LENGTH_GT: Int
-  guiCss_LONGEST_LENGTH_GTE: Int
-  guiCss_LONGEST_LENGTH_LT: Int
-  guiCss_LONGEST_LENGTH_LTE: Int
-  guiCss_SHORTEST_LENGTH_EQUAL: Int
-  guiCss_SHORTEST_LENGTH_GT: Int
-  guiCss_SHORTEST_LENGTH_GTE: Int
-  guiCss_SHORTEST_LENGTH_LT: Int
-  guiCss_SHORTEST_LENGTH_LTE: Int
   renderForEachPropKey_AVERAGE_LENGTH_EQUAL: Float
   renderForEachPropKey_AVERAGE_LENGTH_GT: Float
   renderForEachPropKey_AVERAGE_LENGTH_GTE: Float
@@ -19775,36 +19386,6 @@ input UserElementsNodeAggregationWhereInput {
   childMapperPropKey_SHORTEST_LENGTH_GTE: Int
   childMapperPropKey_SHORTEST_LENGTH_LT: Int
   childMapperPropKey_SHORTEST_LENGTH_LTE: Int
-  customCss_AVERAGE_LENGTH_EQUAL: Float
-  customCss_AVERAGE_LENGTH_GT: Float
-  customCss_AVERAGE_LENGTH_GTE: Float
-  customCss_AVERAGE_LENGTH_LT: Float
-  customCss_AVERAGE_LENGTH_LTE: Float
-  customCss_LONGEST_LENGTH_EQUAL: Int
-  customCss_LONGEST_LENGTH_GT: Int
-  customCss_LONGEST_LENGTH_GTE: Int
-  customCss_LONGEST_LENGTH_LT: Int
-  customCss_LONGEST_LENGTH_LTE: Int
-  customCss_SHORTEST_LENGTH_EQUAL: Int
-  customCss_SHORTEST_LENGTH_GT: Int
-  customCss_SHORTEST_LENGTH_GTE: Int
-  customCss_SHORTEST_LENGTH_LT: Int
-  customCss_SHORTEST_LENGTH_LTE: Int
-  guiCss_AVERAGE_LENGTH_EQUAL: Float
-  guiCss_AVERAGE_LENGTH_GT: Float
-  guiCss_AVERAGE_LENGTH_GTE: Float
-  guiCss_AVERAGE_LENGTH_LT: Float
-  guiCss_AVERAGE_LENGTH_LTE: Float
-  guiCss_LONGEST_LENGTH_EQUAL: Int
-  guiCss_LONGEST_LENGTH_GT: Int
-  guiCss_LONGEST_LENGTH_GTE: Int
-  guiCss_LONGEST_LENGTH_LT: Int
-  guiCss_LONGEST_LENGTH_LTE: Int
-  guiCss_SHORTEST_LENGTH_EQUAL: Int
-  guiCss_SHORTEST_LENGTH_GT: Int
-  guiCss_SHORTEST_LENGTH_GTE: Int
-  guiCss_SHORTEST_LENGTH_LT: Int
-  guiCss_SHORTEST_LENGTH_LTE: Int
   renderForEachPropKey_AVERAGE_LENGTH_EQUAL: Float
   renderForEachPropKey_AVERAGE_LENGTH_GT: Float
   renderForEachPropKey_AVERAGE_LENGTH_GTE: Float


### PR DESCRIPTION
## Description

Introduce CSS breakpoints. Styles priority follows a mobile-first approach for now.
All styles that are defined on smaller screen sizes are inherited by bigger sizes (unless overridden).

A new field to display inherited styles and show which are overridden at the current breakpoint is added.

## Video or Image

https://github.com/codelab-app/platform/assets/74900868/f4026aeb-d9c0-4a0d-b8ba-b1a833eb3510

## Related Issue(s)

Fixes #2942 
