### PR TITLE
fix: ClickOverlay is not aligned with target element when css is updated

### DIFF
--- a/libs/frontend/domain/builder/src/sections/overlay-toolbar/BuilderClickOverlay.tsx
+++ b/libs/frontend/domain/builder/src/sections/overlay-toolbar/BuilderClickOverlay.tsx
@@ -79,6 +79,11 @@ export const BuilderClickOverlay = observer<{
   return createPortal(
     <ClickOverlay
       content={content}
+      dependencies={[
+        selectedNode.current.guiCss,
+        selectedNode.current.customCss,
+        selectedNode.current.props.current.values,
+      ]}
       element={element}
       renderContainer={renderContainerRef.current}
     />,

--- a/libs/frontend/presentation/view/components/hoverOverlay/ClickOverlay.tsx
+++ b/libs/frontend/presentation/view/components/hoverOverlay/ClickOverlay.tsx
@@ -1,4 +1,5 @@
 import { useScroll, useScrollIntoView } from '@codelab/frontend/shared/utils'
+import { useDebouncedEffect } from '@react-hookz/web'
 import type { CSSProperties } from 'react'
 import React, { useEffect, useState } from 'react'
 import useResizeObserver from 'use-resize-observer/polyfilled'
@@ -6,6 +7,7 @@ import type { OverlayProps } from './overlay.interface'
 
 export const ClickOverlay = ({
   content,
+  dependencies,
   element,
   renderContainer,
 }: OverlayProps) => {
@@ -13,6 +15,9 @@ export const ClickOverlay = ({
   // - element is resized
   // - the page is resized
   // - the content is scrolled
+  // - element css is updated, especially height, width, margin, padding
+  // - element props is updated (some props may affect size and position when using 'auto')
+
   useResizeObserver({ ref: element })
   useResizeObserver({ ref: renderContainer })
   useScrollIntoView(element, renderContainer)
@@ -27,7 +32,16 @@ export const ClickOverlay = ({
   useEffect(() => {
     setRect(element.getBoundingClientRect())
     setContainerRect(renderContainer.getBoundingClientRect())
-  }, [element, renderContainer])
+  }, [element, renderContainer, ...dependencies])
+
+  useDebouncedEffect(
+    () => {
+      setRect(element.getBoundingClientRect())
+      setContainerRect(renderContainer.getBoundingClientRect())
+    },
+    dependencies,
+    180,
+  )
 
   const style: CSSProperties = {
     border: '1px solid rgb(7, 62, 78)',

--- a/libs/frontend/presentation/view/components/hoverOverlay/overlay.interface.ts
+++ b/libs/frontend/presentation/view/components/hoverOverlay/overlay.interface.ts
@@ -2,6 +2,7 @@ import type React from 'react'
 
 export interface OverlayProps {
   content?: React.ReactNode
+  dependencies: Array<unknown>
   element: HTMLElement
   renderContainer: HTMLElement
 }


### PR DESCRIPTION
<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(libs-ui-component): must begin with lowercase` -->

## Description

For the past two days, I've been grappling with an elusive bug related to element selection. As of now, I'm still not entirely sure about the best way to resolve it.

As most of you are aware, when we select an element in the tree view, a corresponding black square (referred to as `clickOverlay` in the code) appears around the element in the builder view. However, when we modify the CSS properties related to an element's size or margins, the `clickOverlay` doesn't update accordingly. This leads to a situation where the `clickOverlay` no longer aligns correctly with the element. This issue seems to arise because we're not adequately tracking changes to the element's size. But, this is not bug I've been struggling with.


https://github.com/codelab-app/platform/assets/32300655/61d4cc1e-922a-45bb-a220-4d295a990f8e

So, I've made some modifications to the code to track any changes in the CSS, ensuring that the `clickOverlay` updates each time the CSS is updated. Initial tests showed that it worked as expected. However, when I tested it with the `AntDesignButton`, the issue resurfaced. This is the specific bug that has been giving me trouble. You will see in the following video that the bug only happened in `AntDesignButton`.



https://github.com/codelab-app/platform/assets/32300655/046ccba3-6188-4c8d-87f6-9b3fd39b5918



So, what exactly is happening here? To properly align the clickOverlay with the element, we obtain the element's DOMRect values using `getBoundingClientRect` and then apply those values to the `clickOverlay`. In the case of `AntDesignButton`, the issue arises because we are fetching these values before the browser has finished rendering the button. As a result, we end up with outdated values. To confirm this, I added a 200ms delay before retrieving the values, and doing so produced the correct values. You can see it the following video.



https://github.com/codelab-app/platform/assets/32300655/90cbcf97-1131-46fc-bab2-fc35b4011718


For now, adding a delay somewhat solves the bug. However, I can't help but feel that this isn't the right solution and that introducing a delay makes things fragile. So far, I've only observed this bug in `AntDesignButton`, but it could potentially occur in more complex Atoms as well. I could use your advice here, @webberwang.

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged -->

Fixes [#2955](https://github.com/codelab-app/platform/issues/2955)
