### PR TITLE
refactor: use element slug for refs

### DIFF
--- a/apps/platform-e2e/src/e2e/builder/form.cy.ts
+++ b/apps/platform-e2e/src/e2e/builder/form.cy.ts
@@ -232,7 +232,6 @@ describe('Testing the Form atom', () => {
             value: apiPostActionId,
           },
         },
-        refKey: 'formRef',
       },
     ])
 

--- a/apps/platform-e2e/src/support/builder/builder.command.ts
+++ b/apps/platform-e2e/src/support/builder/builder.command.ts
@@ -38,12 +38,6 @@ export const createElementTree = (elements: Array<ElementData>) => {
         value: atom,
       })
 
-      cy.findByTestId('create-element-form').setFormFieldValue({
-        label: 'Register Reference',
-        type: FIELD_TYPE.TOGGLE,
-        value: true,
-      })
-
       if (propsData) {
         cy.findByTestId('create-element-form').setFormFieldValue({
           label: 'Props Data',

--- a/apps/platform-e2e/src/support/builder/builder.command.ts
+++ b/apps/platform-e2e/src/support/builder/builder.command.ts
@@ -6,12 +6,11 @@ export interface ElementData {
   name: string
   parentElement: string
   propsData?: object
-  refKey?: string
 }
 
 export const createElementTree = (elements: Array<ElementData>) => {
   return cy.wrap(elements).each((element: ElementData) => {
-    const { atom, name, parentElement, propsData, refKey } = element
+    const { atom, name, parentElement, propsData } = element
 
     cy.getCuiSidebar('Explorer').getCuiSkeleton().should('not.be.visible')
     cy.getCuiSidebar('Explorer').getToolbarItem('Add Element').first().click()
@@ -39,19 +38,17 @@ export const createElementTree = (elements: Array<ElementData>) => {
         value: atom,
       })
 
+      cy.findByTestId('create-element-form').setFormFieldValue({
+        label: 'Register Reference',
+        type: FIELD_TYPE.TOGGLE,
+        value: true,
+      })
+
       if (propsData) {
         cy.findByTestId('create-element-form').setFormFieldValue({
           label: 'Props Data',
           type: FIELD_TYPE.INPUT,
           value: JSON.stringify(propsData),
-        })
-      }
-
-      if (refKey) {
-        cy.findByTestId('create-element-form').setFormFieldValue({
-          label: 'Ref Key',
-          type: FIELD_TYPE.INPUT,
-          value: refKey,
         })
       }
 

--- a/libs/backend/abstract/codegen/src/ogm-types.gen.ts
+++ b/libs/backend/abstract/codegen/src/ogm-types.gen.ts
@@ -6291,7 +6291,6 @@ export type RenderPropTypeUserOwnerNodeAggregateSelection = {
 export type RenderType = {
   __typename?: 'RenderType'
   id: Scalars['ID']
-  registerReference?: Maybe<Scalars['Boolean']>
   kind: RenderTypeKind
 }
 
@@ -27866,7 +27865,6 @@ export type RenderPropTypeWhere = {
 
 export type RenderTypeCreateInput = {
   id: Scalars['ID']
-  registerReference?: InputMaybe<Scalars['Boolean']>
   kind: RenderTypeKind
 }
 
@@ -27880,13 +27878,11 @@ export type RenderTypeOptions = {
 /** Fields to sort RenderTypes by. The order in which sorts are applied is not guaranteed when specifying many fields in one RenderTypeSort object. */
 export type RenderTypeSort = {
   id?: InputMaybe<SortDirection>
-  registerReference?: InputMaybe<SortDirection>
   kind?: InputMaybe<SortDirection>
 }
 
 export type RenderTypeUpdateInput = {
   id?: InputMaybe<Scalars['ID']>
-  registerReference?: InputMaybe<Scalars['Boolean']>
   kind?: InputMaybe<RenderTypeKind>
 }
 
@@ -27910,9 +27906,6 @@ export type RenderTypeWhere = {
   id_NOT_STARTS_WITH?: InputMaybe<Scalars['ID']>
   /** @deprecated Negation filters will be deprecated, use the NOT operator to achieve the same behavior */
   id_NOT_ENDS_WITH?: InputMaybe<Scalars['ID']>
-  registerReference?: InputMaybe<Scalars['Boolean']>
-  /** @deprecated Negation filters will be deprecated, use the NOT operator to achieve the same behavior */
-  registerReference_NOT?: InputMaybe<Scalars['Boolean']>
   kind?: InputMaybe<RenderTypeKind>
   /** @deprecated Negation filters will be deprecated, use the NOT operator to achieve the same behavior */
   kind_NOT?: InputMaybe<RenderTypeKind>

--- a/libs/backend/abstract/codegen/src/ogm-types.gen.ts
+++ b/libs/backend/abstract/codegen/src/ogm-types.gen.ts
@@ -2294,7 +2294,6 @@ export type ApiActionElementElementNodeAggregateSelection = {
   childMapperPropKey: StringAggregateSelectionNullable
   renderForEachPropKey: StringAggregateSelectionNullable
   renderIfExpression: StringAggregateSelectionNullable
-  _compoundRefKey: StringAggregateSelectionNullable
 }
 
 export type ApiActionErrorActionConnection = {
@@ -3224,7 +3223,6 @@ export type CodeActionElementElementNodeAggregateSelection = {
   childMapperPropKey: StringAggregateSelectionNullable
   renderForEachPropKey: StringAggregateSelectionNullable
   renderIfExpression: StringAggregateSelectionNullable
-  _compoundRefKey: StringAggregateSelectionNullable
 }
 
 export type CodeActionsConnection = {
@@ -3508,7 +3506,6 @@ export type ComponentElementChildrenContainerElementNodeAggregateSelection = {
   childMapperPropKey: StringAggregateSelectionNullable
   renderForEachPropKey: StringAggregateSelectionNullable
   renderIfExpression: StringAggregateSelectionNullable
-  _compoundRefKey: StringAggregateSelectionNullable
 }
 
 export type ComponentElementRootElementAggregationSelection = {
@@ -3526,7 +3523,6 @@ export type ComponentElementRootElementNodeAggregateSelection = {
   childMapperPropKey: StringAggregateSelectionNullable
   renderForEachPropKey: StringAggregateSelectionNullable
   renderIfExpression: StringAggregateSelectionNullable
-  _compoundRefKey: StringAggregateSelectionNullable
 }
 
 export type ComponentInterfaceTypeApiAggregationSelection = {
@@ -3966,12 +3962,10 @@ export type Element = {
   childMapperPropKey?: Maybe<Scalars['String']>
   renderForEachPropKey?: Maybe<Scalars['String']>
   renderIfExpression?: Maybe<Scalars['String']>
-  _compoundRefKey?: Maybe<Scalars['String']>
   renderType?: Maybe<RenderType>
   descendantElements: Array<Element>
   name: Scalars['String']
   slug: Scalars['String']
-  refKey?: Maybe<Scalars['String']>
   nextSibling?: Maybe<Element>
   nextSiblingAggregate?: Maybe<ElementElementNextSiblingAggregationSelection>
   prevSibling?: Maybe<Element>
@@ -4258,7 +4252,6 @@ export type ElementAggregateSelection = {
   childMapperPropKey: StringAggregateSelectionNullable
   renderForEachPropKey: StringAggregateSelectionNullable
   renderIfExpression: StringAggregateSelectionNullable
-  _compoundRefKey: StringAggregateSelectionNullable
 }
 
 export type ElementAtomRenderAtomTypeAggregationSelection = {
@@ -4363,7 +4356,6 @@ export type ElementElementChildMapperPreviousSiblingNodeAggregateSelection = {
   childMapperPropKey: StringAggregateSelectionNullable
   renderForEachPropKey: StringAggregateSelectionNullable
   renderIfExpression: StringAggregateSelectionNullable
-  _compoundRefKey: StringAggregateSelectionNullable
 }
 
 export type ElementElementFirstChildAggregationSelection = {
@@ -4381,7 +4373,6 @@ export type ElementElementFirstChildNodeAggregateSelection = {
   childMapperPropKey: StringAggregateSelectionNullable
   renderForEachPropKey: StringAggregateSelectionNullable
   renderIfExpression: StringAggregateSelectionNullable
-  _compoundRefKey: StringAggregateSelectionNullable
 }
 
 export type ElementElementNextSiblingAggregationSelection = {
@@ -4399,7 +4390,6 @@ export type ElementElementNextSiblingNodeAggregateSelection = {
   childMapperPropKey: StringAggregateSelectionNullable
   renderForEachPropKey: StringAggregateSelectionNullable
   renderIfExpression: StringAggregateSelectionNullable
-  _compoundRefKey: StringAggregateSelectionNullable
 }
 
 export type ElementElementParentAggregationSelection = {
@@ -4417,7 +4407,6 @@ export type ElementElementParentNodeAggregateSelection = {
   childMapperPropKey: StringAggregateSelectionNullable
   renderForEachPropKey: StringAggregateSelectionNullable
   renderIfExpression: StringAggregateSelectionNullable
-  _compoundRefKey: StringAggregateSelectionNullable
 }
 
 export type ElementElementPrevSiblingAggregationSelection = {
@@ -4435,7 +4424,6 @@ export type ElementElementPrevSiblingNodeAggregateSelection = {
   childMapperPropKey: StringAggregateSelectionNullable
   renderForEachPropKey: StringAggregateSelectionNullable
   renderIfExpression: StringAggregateSelectionNullable
-  _compoundRefKey: StringAggregateSelectionNullable
 }
 
 export type ElementFirstChildConnection = {
@@ -5339,7 +5327,6 @@ export type HookElementElementNodeAggregateSelection = {
   childMapperPropKey: StringAggregateSelectionNullable
   renderForEachPropKey: StringAggregateSelectionNullable
   renderIfExpression: StringAggregateSelectionNullable
-  _compoundRefKey: StringAggregateSelectionNullable
 }
 
 export type HookElementRelationship = {
@@ -5844,7 +5831,6 @@ export type PageElementPageContentContainerNodeAggregateSelection = {
   childMapperPropKey: StringAggregateSelectionNullable
   renderForEachPropKey: StringAggregateSelectionNullable
   renderIfExpression: StringAggregateSelectionNullable
-  _compoundRefKey: StringAggregateSelectionNullable
 }
 
 export type PageElementRootElementAggregationSelection = {
@@ -5862,7 +5848,6 @@ export type PageElementRootElementNodeAggregateSelection = {
   childMapperPropKey: StringAggregateSelectionNullable
   renderForEachPropKey: StringAggregateSelectionNullable
   renderIfExpression: StringAggregateSelectionNullable
-  _compoundRefKey: StringAggregateSelectionNullable
 }
 
 /** Pagination information (Relay) */
@@ -6306,6 +6291,7 @@ export type RenderPropTypeUserOwnerNodeAggregateSelection = {
 export type RenderType = {
   __typename?: 'RenderType'
   id: Scalars['ID']
+  registerReference?: Maybe<Scalars['Boolean']>
   kind: RenderTypeKind
 }
 
@@ -7513,7 +7499,6 @@ export type UserElementElementsNodeAggregateSelection = {
   childMapperPropKey: StringAggregateSelectionNullable
   renderForEachPropKey: StringAggregateSelectionNullable
   renderIfExpression: StringAggregateSelectionNullable
-  _compoundRefKey: StringAggregateSelectionNullable
 }
 
 export type UserElementsConnection = {
@@ -8494,61 +8479,6 @@ export type ApiActionElementNodeAggregationWhereInput = {
   renderIfExpression_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars['Float']>
   renderIfExpression_LONGEST_LENGTH_LTE?: InputMaybe<Scalars['Int']>
   renderIfExpression_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars['Int']>
-  /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
-  _compoundRefKey_EQUAL?: InputMaybe<Scalars['String']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  _compoundRefKey_AVERAGE_EQUAL?: InputMaybe<Scalars['Float']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  _compoundRefKey_LONGEST_EQUAL?: InputMaybe<Scalars['Int']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  _compoundRefKey_SHORTEST_EQUAL?: InputMaybe<Scalars['Int']>
-  _compoundRefKey_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars['Float']>
-  _compoundRefKey_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars['Int']>
-  _compoundRefKey_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars['Int']>
-  /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
-  _compoundRefKey_GT?: InputMaybe<Scalars['Int']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  _compoundRefKey_AVERAGE_GT?: InputMaybe<Scalars['Float']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  _compoundRefKey_LONGEST_GT?: InputMaybe<Scalars['Int']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  _compoundRefKey_SHORTEST_GT?: InputMaybe<Scalars['Int']>
-  _compoundRefKey_AVERAGE_LENGTH_GT?: InputMaybe<Scalars['Float']>
-  _compoundRefKey_LONGEST_LENGTH_GT?: InputMaybe<Scalars['Int']>
-  _compoundRefKey_SHORTEST_LENGTH_GT?: InputMaybe<Scalars['Int']>
-  /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
-  _compoundRefKey_GTE?: InputMaybe<Scalars['Int']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  _compoundRefKey_AVERAGE_GTE?: InputMaybe<Scalars['Float']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  _compoundRefKey_LONGEST_GTE?: InputMaybe<Scalars['Int']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  _compoundRefKey_SHORTEST_GTE?: InputMaybe<Scalars['Int']>
-  _compoundRefKey_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars['Float']>
-  _compoundRefKey_LONGEST_LENGTH_GTE?: InputMaybe<Scalars['Int']>
-  _compoundRefKey_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars['Int']>
-  /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
-  _compoundRefKey_LT?: InputMaybe<Scalars['Int']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  _compoundRefKey_AVERAGE_LT?: InputMaybe<Scalars['Float']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  _compoundRefKey_LONGEST_LT?: InputMaybe<Scalars['Int']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  _compoundRefKey_SHORTEST_LT?: InputMaybe<Scalars['Int']>
-  _compoundRefKey_AVERAGE_LENGTH_LT?: InputMaybe<Scalars['Float']>
-  _compoundRefKey_LONGEST_LENGTH_LT?: InputMaybe<Scalars['Int']>
-  _compoundRefKey_SHORTEST_LENGTH_LT?: InputMaybe<Scalars['Int']>
-  /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
-  _compoundRefKey_LTE?: InputMaybe<Scalars['Int']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  _compoundRefKey_AVERAGE_LTE?: InputMaybe<Scalars['Float']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  _compoundRefKey_LONGEST_LTE?: InputMaybe<Scalars['Int']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  _compoundRefKey_SHORTEST_LTE?: InputMaybe<Scalars['Int']>
-  _compoundRefKey_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars['Float']>
-  _compoundRefKey_LONGEST_LENGTH_LTE?: InputMaybe<Scalars['Int']>
-  _compoundRefKey_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars['Int']>
 }
 
 export type ApiActionErrorActionApiActionConnectFieldInput = {
@@ -12828,61 +12758,6 @@ export type BaseActionElementNodeAggregationWhereInput = {
   renderIfExpression_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars['Float']>
   renderIfExpression_LONGEST_LENGTH_LTE?: InputMaybe<Scalars['Int']>
   renderIfExpression_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars['Int']>
-  /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
-  _compoundRefKey_EQUAL?: InputMaybe<Scalars['String']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  _compoundRefKey_AVERAGE_EQUAL?: InputMaybe<Scalars['Float']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  _compoundRefKey_LONGEST_EQUAL?: InputMaybe<Scalars['Int']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  _compoundRefKey_SHORTEST_EQUAL?: InputMaybe<Scalars['Int']>
-  _compoundRefKey_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars['Float']>
-  _compoundRefKey_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars['Int']>
-  _compoundRefKey_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars['Int']>
-  /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
-  _compoundRefKey_GT?: InputMaybe<Scalars['Int']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  _compoundRefKey_AVERAGE_GT?: InputMaybe<Scalars['Float']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  _compoundRefKey_LONGEST_GT?: InputMaybe<Scalars['Int']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  _compoundRefKey_SHORTEST_GT?: InputMaybe<Scalars['Int']>
-  _compoundRefKey_AVERAGE_LENGTH_GT?: InputMaybe<Scalars['Float']>
-  _compoundRefKey_LONGEST_LENGTH_GT?: InputMaybe<Scalars['Int']>
-  _compoundRefKey_SHORTEST_LENGTH_GT?: InputMaybe<Scalars['Int']>
-  /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
-  _compoundRefKey_GTE?: InputMaybe<Scalars['Int']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  _compoundRefKey_AVERAGE_GTE?: InputMaybe<Scalars['Float']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  _compoundRefKey_LONGEST_GTE?: InputMaybe<Scalars['Int']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  _compoundRefKey_SHORTEST_GTE?: InputMaybe<Scalars['Int']>
-  _compoundRefKey_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars['Float']>
-  _compoundRefKey_LONGEST_LENGTH_GTE?: InputMaybe<Scalars['Int']>
-  _compoundRefKey_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars['Int']>
-  /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
-  _compoundRefKey_LT?: InputMaybe<Scalars['Int']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  _compoundRefKey_AVERAGE_LT?: InputMaybe<Scalars['Float']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  _compoundRefKey_LONGEST_LT?: InputMaybe<Scalars['Int']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  _compoundRefKey_SHORTEST_LT?: InputMaybe<Scalars['Int']>
-  _compoundRefKey_AVERAGE_LENGTH_LT?: InputMaybe<Scalars['Float']>
-  _compoundRefKey_LONGEST_LENGTH_LT?: InputMaybe<Scalars['Int']>
-  _compoundRefKey_SHORTEST_LENGTH_LT?: InputMaybe<Scalars['Int']>
-  /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
-  _compoundRefKey_LTE?: InputMaybe<Scalars['Int']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  _compoundRefKey_AVERAGE_LTE?: InputMaybe<Scalars['Float']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  _compoundRefKey_LONGEST_LTE?: InputMaybe<Scalars['Int']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  _compoundRefKey_SHORTEST_LTE?: InputMaybe<Scalars['Int']>
-  _compoundRefKey_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars['Float']>
-  _compoundRefKey_LONGEST_LENGTH_LTE?: InputMaybe<Scalars['Int']>
-  _compoundRefKey_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars['Int']>
 }
 
 export type BaseActionElementUpdateConnectionInput = {
@@ -13823,61 +13698,6 @@ export type CodeActionElementNodeAggregationWhereInput = {
   renderIfExpression_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars['Float']>
   renderIfExpression_LONGEST_LENGTH_LTE?: InputMaybe<Scalars['Int']>
   renderIfExpression_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars['Int']>
-  /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
-  _compoundRefKey_EQUAL?: InputMaybe<Scalars['String']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  _compoundRefKey_AVERAGE_EQUAL?: InputMaybe<Scalars['Float']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  _compoundRefKey_LONGEST_EQUAL?: InputMaybe<Scalars['Int']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  _compoundRefKey_SHORTEST_EQUAL?: InputMaybe<Scalars['Int']>
-  _compoundRefKey_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars['Float']>
-  _compoundRefKey_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars['Int']>
-  _compoundRefKey_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars['Int']>
-  /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
-  _compoundRefKey_GT?: InputMaybe<Scalars['Int']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  _compoundRefKey_AVERAGE_GT?: InputMaybe<Scalars['Float']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  _compoundRefKey_LONGEST_GT?: InputMaybe<Scalars['Int']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  _compoundRefKey_SHORTEST_GT?: InputMaybe<Scalars['Int']>
-  _compoundRefKey_AVERAGE_LENGTH_GT?: InputMaybe<Scalars['Float']>
-  _compoundRefKey_LONGEST_LENGTH_GT?: InputMaybe<Scalars['Int']>
-  _compoundRefKey_SHORTEST_LENGTH_GT?: InputMaybe<Scalars['Int']>
-  /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
-  _compoundRefKey_GTE?: InputMaybe<Scalars['Int']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  _compoundRefKey_AVERAGE_GTE?: InputMaybe<Scalars['Float']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  _compoundRefKey_LONGEST_GTE?: InputMaybe<Scalars['Int']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  _compoundRefKey_SHORTEST_GTE?: InputMaybe<Scalars['Int']>
-  _compoundRefKey_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars['Float']>
-  _compoundRefKey_LONGEST_LENGTH_GTE?: InputMaybe<Scalars['Int']>
-  _compoundRefKey_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars['Int']>
-  /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
-  _compoundRefKey_LT?: InputMaybe<Scalars['Int']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  _compoundRefKey_AVERAGE_LT?: InputMaybe<Scalars['Float']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  _compoundRefKey_LONGEST_LT?: InputMaybe<Scalars['Int']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  _compoundRefKey_SHORTEST_LT?: InputMaybe<Scalars['Int']>
-  _compoundRefKey_AVERAGE_LENGTH_LT?: InputMaybe<Scalars['Float']>
-  _compoundRefKey_LONGEST_LENGTH_LT?: InputMaybe<Scalars['Int']>
-  _compoundRefKey_SHORTEST_LENGTH_LT?: InputMaybe<Scalars['Int']>
-  /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
-  _compoundRefKey_LTE?: InputMaybe<Scalars['Int']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  _compoundRefKey_AVERAGE_LTE?: InputMaybe<Scalars['Float']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  _compoundRefKey_LONGEST_LTE?: InputMaybe<Scalars['Int']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  _compoundRefKey_SHORTEST_LTE?: InputMaybe<Scalars['Int']>
-  _compoundRefKey_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars['Float']>
-  _compoundRefKey_LONGEST_LENGTH_LTE?: InputMaybe<Scalars['Int']>
-  _compoundRefKey_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars['Int']>
 }
 
 export type CodeActionOnCreateInput = {
@@ -14915,61 +14735,6 @@ export type ComponentChildrenContainerElementNodeAggregationWhereInput = {
   renderIfExpression_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars['Float']>
   renderIfExpression_LONGEST_LENGTH_LTE?: InputMaybe<Scalars['Int']>
   renderIfExpression_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars['Int']>
-  /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
-  _compoundRefKey_EQUAL?: InputMaybe<Scalars['String']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  _compoundRefKey_AVERAGE_EQUAL?: InputMaybe<Scalars['Float']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  _compoundRefKey_LONGEST_EQUAL?: InputMaybe<Scalars['Int']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  _compoundRefKey_SHORTEST_EQUAL?: InputMaybe<Scalars['Int']>
-  _compoundRefKey_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars['Float']>
-  _compoundRefKey_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars['Int']>
-  _compoundRefKey_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars['Int']>
-  /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
-  _compoundRefKey_GT?: InputMaybe<Scalars['Int']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  _compoundRefKey_AVERAGE_GT?: InputMaybe<Scalars['Float']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  _compoundRefKey_LONGEST_GT?: InputMaybe<Scalars['Int']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  _compoundRefKey_SHORTEST_GT?: InputMaybe<Scalars['Int']>
-  _compoundRefKey_AVERAGE_LENGTH_GT?: InputMaybe<Scalars['Float']>
-  _compoundRefKey_LONGEST_LENGTH_GT?: InputMaybe<Scalars['Int']>
-  _compoundRefKey_SHORTEST_LENGTH_GT?: InputMaybe<Scalars['Int']>
-  /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
-  _compoundRefKey_GTE?: InputMaybe<Scalars['Int']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  _compoundRefKey_AVERAGE_GTE?: InputMaybe<Scalars['Float']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  _compoundRefKey_LONGEST_GTE?: InputMaybe<Scalars['Int']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  _compoundRefKey_SHORTEST_GTE?: InputMaybe<Scalars['Int']>
-  _compoundRefKey_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars['Float']>
-  _compoundRefKey_LONGEST_LENGTH_GTE?: InputMaybe<Scalars['Int']>
-  _compoundRefKey_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars['Int']>
-  /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
-  _compoundRefKey_LT?: InputMaybe<Scalars['Int']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  _compoundRefKey_AVERAGE_LT?: InputMaybe<Scalars['Float']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  _compoundRefKey_LONGEST_LT?: InputMaybe<Scalars['Int']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  _compoundRefKey_SHORTEST_LT?: InputMaybe<Scalars['Int']>
-  _compoundRefKey_AVERAGE_LENGTH_LT?: InputMaybe<Scalars['Float']>
-  _compoundRefKey_LONGEST_LENGTH_LT?: InputMaybe<Scalars['Int']>
-  _compoundRefKey_SHORTEST_LENGTH_LT?: InputMaybe<Scalars['Int']>
-  /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
-  _compoundRefKey_LTE?: InputMaybe<Scalars['Int']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  _compoundRefKey_AVERAGE_LTE?: InputMaybe<Scalars['Float']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  _compoundRefKey_LONGEST_LTE?: InputMaybe<Scalars['Int']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  _compoundRefKey_SHORTEST_LTE?: InputMaybe<Scalars['Int']>
-  _compoundRefKey_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars['Float']>
-  _compoundRefKey_LONGEST_LENGTH_LTE?: InputMaybe<Scalars['Int']>
-  _compoundRefKey_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars['Int']>
 }
 
 export type ComponentChildrenContainerElementUpdateConnectionInput = {
@@ -15781,61 +15546,6 @@ export type ComponentRootElementNodeAggregationWhereInput = {
   renderIfExpression_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars['Float']>
   renderIfExpression_LONGEST_LENGTH_LTE?: InputMaybe<Scalars['Int']>
   renderIfExpression_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars['Int']>
-  /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
-  _compoundRefKey_EQUAL?: InputMaybe<Scalars['String']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  _compoundRefKey_AVERAGE_EQUAL?: InputMaybe<Scalars['Float']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  _compoundRefKey_LONGEST_EQUAL?: InputMaybe<Scalars['Int']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  _compoundRefKey_SHORTEST_EQUAL?: InputMaybe<Scalars['Int']>
-  _compoundRefKey_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars['Float']>
-  _compoundRefKey_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars['Int']>
-  _compoundRefKey_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars['Int']>
-  /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
-  _compoundRefKey_GT?: InputMaybe<Scalars['Int']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  _compoundRefKey_AVERAGE_GT?: InputMaybe<Scalars['Float']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  _compoundRefKey_LONGEST_GT?: InputMaybe<Scalars['Int']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  _compoundRefKey_SHORTEST_GT?: InputMaybe<Scalars['Int']>
-  _compoundRefKey_AVERAGE_LENGTH_GT?: InputMaybe<Scalars['Float']>
-  _compoundRefKey_LONGEST_LENGTH_GT?: InputMaybe<Scalars['Int']>
-  _compoundRefKey_SHORTEST_LENGTH_GT?: InputMaybe<Scalars['Int']>
-  /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
-  _compoundRefKey_GTE?: InputMaybe<Scalars['Int']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  _compoundRefKey_AVERAGE_GTE?: InputMaybe<Scalars['Float']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  _compoundRefKey_LONGEST_GTE?: InputMaybe<Scalars['Int']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  _compoundRefKey_SHORTEST_GTE?: InputMaybe<Scalars['Int']>
-  _compoundRefKey_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars['Float']>
-  _compoundRefKey_LONGEST_LENGTH_GTE?: InputMaybe<Scalars['Int']>
-  _compoundRefKey_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars['Int']>
-  /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
-  _compoundRefKey_LT?: InputMaybe<Scalars['Int']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  _compoundRefKey_AVERAGE_LT?: InputMaybe<Scalars['Float']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  _compoundRefKey_LONGEST_LT?: InputMaybe<Scalars['Int']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  _compoundRefKey_SHORTEST_LT?: InputMaybe<Scalars['Int']>
-  _compoundRefKey_AVERAGE_LENGTH_LT?: InputMaybe<Scalars['Float']>
-  _compoundRefKey_LONGEST_LENGTH_LT?: InputMaybe<Scalars['Int']>
-  _compoundRefKey_SHORTEST_LENGTH_LT?: InputMaybe<Scalars['Int']>
-  /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
-  _compoundRefKey_LTE?: InputMaybe<Scalars['Int']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  _compoundRefKey_AVERAGE_LTE?: InputMaybe<Scalars['Float']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  _compoundRefKey_LONGEST_LTE?: InputMaybe<Scalars['Int']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  _compoundRefKey_SHORTEST_LTE?: InputMaybe<Scalars['Int']>
-  _compoundRefKey_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars['Float']>
-  _compoundRefKey_LONGEST_LENGTH_LTE?: InputMaybe<Scalars['Int']>
-  _compoundRefKey_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars['Int']>
 }
 
 export type ComponentRootElementUpdateConnectionInput = {
@@ -17007,61 +16717,6 @@ export type ElementChildMapperPreviousSiblingNodeAggregationWhereInput = {
   renderIfExpression_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars['Float']>
   renderIfExpression_LONGEST_LENGTH_LTE?: InputMaybe<Scalars['Int']>
   renderIfExpression_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars['Int']>
-  /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
-  _compoundRefKey_EQUAL?: InputMaybe<Scalars['String']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  _compoundRefKey_AVERAGE_EQUAL?: InputMaybe<Scalars['Float']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  _compoundRefKey_LONGEST_EQUAL?: InputMaybe<Scalars['Int']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  _compoundRefKey_SHORTEST_EQUAL?: InputMaybe<Scalars['Int']>
-  _compoundRefKey_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars['Float']>
-  _compoundRefKey_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars['Int']>
-  _compoundRefKey_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars['Int']>
-  /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
-  _compoundRefKey_GT?: InputMaybe<Scalars['Int']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  _compoundRefKey_AVERAGE_GT?: InputMaybe<Scalars['Float']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  _compoundRefKey_LONGEST_GT?: InputMaybe<Scalars['Int']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  _compoundRefKey_SHORTEST_GT?: InputMaybe<Scalars['Int']>
-  _compoundRefKey_AVERAGE_LENGTH_GT?: InputMaybe<Scalars['Float']>
-  _compoundRefKey_LONGEST_LENGTH_GT?: InputMaybe<Scalars['Int']>
-  _compoundRefKey_SHORTEST_LENGTH_GT?: InputMaybe<Scalars['Int']>
-  /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
-  _compoundRefKey_GTE?: InputMaybe<Scalars['Int']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  _compoundRefKey_AVERAGE_GTE?: InputMaybe<Scalars['Float']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  _compoundRefKey_LONGEST_GTE?: InputMaybe<Scalars['Int']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  _compoundRefKey_SHORTEST_GTE?: InputMaybe<Scalars['Int']>
-  _compoundRefKey_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars['Float']>
-  _compoundRefKey_LONGEST_LENGTH_GTE?: InputMaybe<Scalars['Int']>
-  _compoundRefKey_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars['Int']>
-  /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
-  _compoundRefKey_LT?: InputMaybe<Scalars['Int']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  _compoundRefKey_AVERAGE_LT?: InputMaybe<Scalars['Float']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  _compoundRefKey_LONGEST_LT?: InputMaybe<Scalars['Int']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  _compoundRefKey_SHORTEST_LT?: InputMaybe<Scalars['Int']>
-  _compoundRefKey_AVERAGE_LENGTH_LT?: InputMaybe<Scalars['Float']>
-  _compoundRefKey_LONGEST_LENGTH_LT?: InputMaybe<Scalars['Int']>
-  _compoundRefKey_SHORTEST_LENGTH_LT?: InputMaybe<Scalars['Int']>
-  /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
-  _compoundRefKey_LTE?: InputMaybe<Scalars['Int']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  _compoundRefKey_AVERAGE_LTE?: InputMaybe<Scalars['Float']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  _compoundRefKey_LONGEST_LTE?: InputMaybe<Scalars['Int']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  _compoundRefKey_SHORTEST_LTE?: InputMaybe<Scalars['Int']>
-  _compoundRefKey_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars['Float']>
-  _compoundRefKey_LONGEST_LENGTH_LTE?: InputMaybe<Scalars['Int']>
-  _compoundRefKey_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars['Int']>
 }
 
 export type ElementChildMapperPreviousSiblingUpdateConnectionInput = {
@@ -17124,7 +16779,6 @@ export type ElementCreateInput = {
   childMapperPropKey?: InputMaybe<Scalars['String']>
   renderForEachPropKey?: InputMaybe<Scalars['String']>
   renderIfExpression?: InputMaybe<Scalars['String']>
-  _compoundRefKey?: InputMaybe<Scalars['String']>
   nextSibling?: InputMaybe<ElementNextSiblingFieldInput>
   prevSibling?: InputMaybe<ElementPrevSiblingFieldInput>
   firstChild?: InputMaybe<ElementFirstChildFieldInput>
@@ -17569,61 +17223,6 @@ export type ElementFirstChildNodeAggregationWhereInput = {
   renderIfExpression_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars['Float']>
   renderIfExpression_LONGEST_LENGTH_LTE?: InputMaybe<Scalars['Int']>
   renderIfExpression_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars['Int']>
-  /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
-  _compoundRefKey_EQUAL?: InputMaybe<Scalars['String']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  _compoundRefKey_AVERAGE_EQUAL?: InputMaybe<Scalars['Float']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  _compoundRefKey_LONGEST_EQUAL?: InputMaybe<Scalars['Int']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  _compoundRefKey_SHORTEST_EQUAL?: InputMaybe<Scalars['Int']>
-  _compoundRefKey_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars['Float']>
-  _compoundRefKey_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars['Int']>
-  _compoundRefKey_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars['Int']>
-  /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
-  _compoundRefKey_GT?: InputMaybe<Scalars['Int']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  _compoundRefKey_AVERAGE_GT?: InputMaybe<Scalars['Float']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  _compoundRefKey_LONGEST_GT?: InputMaybe<Scalars['Int']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  _compoundRefKey_SHORTEST_GT?: InputMaybe<Scalars['Int']>
-  _compoundRefKey_AVERAGE_LENGTH_GT?: InputMaybe<Scalars['Float']>
-  _compoundRefKey_LONGEST_LENGTH_GT?: InputMaybe<Scalars['Int']>
-  _compoundRefKey_SHORTEST_LENGTH_GT?: InputMaybe<Scalars['Int']>
-  /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
-  _compoundRefKey_GTE?: InputMaybe<Scalars['Int']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  _compoundRefKey_AVERAGE_GTE?: InputMaybe<Scalars['Float']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  _compoundRefKey_LONGEST_GTE?: InputMaybe<Scalars['Int']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  _compoundRefKey_SHORTEST_GTE?: InputMaybe<Scalars['Int']>
-  _compoundRefKey_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars['Float']>
-  _compoundRefKey_LONGEST_LENGTH_GTE?: InputMaybe<Scalars['Int']>
-  _compoundRefKey_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars['Int']>
-  /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
-  _compoundRefKey_LT?: InputMaybe<Scalars['Int']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  _compoundRefKey_AVERAGE_LT?: InputMaybe<Scalars['Float']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  _compoundRefKey_LONGEST_LT?: InputMaybe<Scalars['Int']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  _compoundRefKey_SHORTEST_LT?: InputMaybe<Scalars['Int']>
-  _compoundRefKey_AVERAGE_LENGTH_LT?: InputMaybe<Scalars['Float']>
-  _compoundRefKey_LONGEST_LENGTH_LT?: InputMaybe<Scalars['Int']>
-  _compoundRefKey_SHORTEST_LENGTH_LT?: InputMaybe<Scalars['Int']>
-  /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
-  _compoundRefKey_LTE?: InputMaybe<Scalars['Int']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  _compoundRefKey_AVERAGE_LTE?: InputMaybe<Scalars['Float']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  _compoundRefKey_LONGEST_LTE?: InputMaybe<Scalars['Int']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  _compoundRefKey_SHORTEST_LTE?: InputMaybe<Scalars['Int']>
-  _compoundRefKey_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars['Float']>
-  _compoundRefKey_LONGEST_LENGTH_LTE?: InputMaybe<Scalars['Int']>
-  _compoundRefKey_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars['Int']>
 }
 
 export type ElementFirstChildUpdateConnectionInput = {
@@ -18037,61 +17636,6 @@ export type ElementNextSiblingNodeAggregationWhereInput = {
   renderIfExpression_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars['Float']>
   renderIfExpression_LONGEST_LENGTH_LTE?: InputMaybe<Scalars['Int']>
   renderIfExpression_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars['Int']>
-  /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
-  _compoundRefKey_EQUAL?: InputMaybe<Scalars['String']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  _compoundRefKey_AVERAGE_EQUAL?: InputMaybe<Scalars['Float']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  _compoundRefKey_LONGEST_EQUAL?: InputMaybe<Scalars['Int']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  _compoundRefKey_SHORTEST_EQUAL?: InputMaybe<Scalars['Int']>
-  _compoundRefKey_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars['Float']>
-  _compoundRefKey_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars['Int']>
-  _compoundRefKey_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars['Int']>
-  /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
-  _compoundRefKey_GT?: InputMaybe<Scalars['Int']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  _compoundRefKey_AVERAGE_GT?: InputMaybe<Scalars['Float']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  _compoundRefKey_LONGEST_GT?: InputMaybe<Scalars['Int']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  _compoundRefKey_SHORTEST_GT?: InputMaybe<Scalars['Int']>
-  _compoundRefKey_AVERAGE_LENGTH_GT?: InputMaybe<Scalars['Float']>
-  _compoundRefKey_LONGEST_LENGTH_GT?: InputMaybe<Scalars['Int']>
-  _compoundRefKey_SHORTEST_LENGTH_GT?: InputMaybe<Scalars['Int']>
-  /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
-  _compoundRefKey_GTE?: InputMaybe<Scalars['Int']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  _compoundRefKey_AVERAGE_GTE?: InputMaybe<Scalars['Float']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  _compoundRefKey_LONGEST_GTE?: InputMaybe<Scalars['Int']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  _compoundRefKey_SHORTEST_GTE?: InputMaybe<Scalars['Int']>
-  _compoundRefKey_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars['Float']>
-  _compoundRefKey_LONGEST_LENGTH_GTE?: InputMaybe<Scalars['Int']>
-  _compoundRefKey_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars['Int']>
-  /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
-  _compoundRefKey_LT?: InputMaybe<Scalars['Int']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  _compoundRefKey_AVERAGE_LT?: InputMaybe<Scalars['Float']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  _compoundRefKey_LONGEST_LT?: InputMaybe<Scalars['Int']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  _compoundRefKey_SHORTEST_LT?: InputMaybe<Scalars['Int']>
-  _compoundRefKey_AVERAGE_LENGTH_LT?: InputMaybe<Scalars['Float']>
-  _compoundRefKey_LONGEST_LENGTH_LT?: InputMaybe<Scalars['Int']>
-  _compoundRefKey_SHORTEST_LENGTH_LT?: InputMaybe<Scalars['Int']>
-  /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
-  _compoundRefKey_LTE?: InputMaybe<Scalars['Int']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  _compoundRefKey_AVERAGE_LTE?: InputMaybe<Scalars['Float']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  _compoundRefKey_LONGEST_LTE?: InputMaybe<Scalars['Int']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  _compoundRefKey_SHORTEST_LTE?: InputMaybe<Scalars['Int']>
-  _compoundRefKey_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars['Float']>
-  _compoundRefKey_LONGEST_LENGTH_LTE?: InputMaybe<Scalars['Int']>
-  _compoundRefKey_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars['Int']>
 }
 
 export type ElementNextSiblingUpdateConnectionInput = {
@@ -18116,7 +17660,6 @@ export type ElementOnCreateInput = {
   childMapperPropKey?: InputMaybe<Scalars['String']>
   renderForEachPropKey?: InputMaybe<Scalars['String']>
   renderIfExpression?: InputMaybe<Scalars['String']>
-  _compoundRefKey?: InputMaybe<Scalars['String']>
 }
 
 export type ElementOptions = {
@@ -18909,61 +18452,6 @@ export type ElementParentNodeAggregationWhereInput = {
   renderIfExpression_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars['Float']>
   renderIfExpression_LONGEST_LENGTH_LTE?: InputMaybe<Scalars['Int']>
   renderIfExpression_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars['Int']>
-  /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
-  _compoundRefKey_EQUAL?: InputMaybe<Scalars['String']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  _compoundRefKey_AVERAGE_EQUAL?: InputMaybe<Scalars['Float']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  _compoundRefKey_LONGEST_EQUAL?: InputMaybe<Scalars['Int']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  _compoundRefKey_SHORTEST_EQUAL?: InputMaybe<Scalars['Int']>
-  _compoundRefKey_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars['Float']>
-  _compoundRefKey_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars['Int']>
-  _compoundRefKey_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars['Int']>
-  /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
-  _compoundRefKey_GT?: InputMaybe<Scalars['Int']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  _compoundRefKey_AVERAGE_GT?: InputMaybe<Scalars['Float']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  _compoundRefKey_LONGEST_GT?: InputMaybe<Scalars['Int']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  _compoundRefKey_SHORTEST_GT?: InputMaybe<Scalars['Int']>
-  _compoundRefKey_AVERAGE_LENGTH_GT?: InputMaybe<Scalars['Float']>
-  _compoundRefKey_LONGEST_LENGTH_GT?: InputMaybe<Scalars['Int']>
-  _compoundRefKey_SHORTEST_LENGTH_GT?: InputMaybe<Scalars['Int']>
-  /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
-  _compoundRefKey_GTE?: InputMaybe<Scalars['Int']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  _compoundRefKey_AVERAGE_GTE?: InputMaybe<Scalars['Float']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  _compoundRefKey_LONGEST_GTE?: InputMaybe<Scalars['Int']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  _compoundRefKey_SHORTEST_GTE?: InputMaybe<Scalars['Int']>
-  _compoundRefKey_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars['Float']>
-  _compoundRefKey_LONGEST_LENGTH_GTE?: InputMaybe<Scalars['Int']>
-  _compoundRefKey_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars['Int']>
-  /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
-  _compoundRefKey_LT?: InputMaybe<Scalars['Int']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  _compoundRefKey_AVERAGE_LT?: InputMaybe<Scalars['Float']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  _compoundRefKey_LONGEST_LT?: InputMaybe<Scalars['Int']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  _compoundRefKey_SHORTEST_LT?: InputMaybe<Scalars['Int']>
-  _compoundRefKey_AVERAGE_LENGTH_LT?: InputMaybe<Scalars['Float']>
-  _compoundRefKey_LONGEST_LENGTH_LT?: InputMaybe<Scalars['Int']>
-  _compoundRefKey_SHORTEST_LENGTH_LT?: InputMaybe<Scalars['Int']>
-  /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
-  _compoundRefKey_LTE?: InputMaybe<Scalars['Int']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  _compoundRefKey_AVERAGE_LTE?: InputMaybe<Scalars['Float']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  _compoundRefKey_LONGEST_LTE?: InputMaybe<Scalars['Int']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  _compoundRefKey_SHORTEST_LTE?: InputMaybe<Scalars['Int']>
-  _compoundRefKey_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars['Float']>
-  _compoundRefKey_LONGEST_LENGTH_LTE?: InputMaybe<Scalars['Int']>
-  _compoundRefKey_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars['Int']>
 }
 
 export type ElementParentUpdateConnectionInput = {
@@ -19477,61 +18965,6 @@ export type ElementPrevSiblingNodeAggregationWhereInput = {
   renderIfExpression_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars['Float']>
   renderIfExpression_LONGEST_LENGTH_LTE?: InputMaybe<Scalars['Int']>
   renderIfExpression_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars['Int']>
-  /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
-  _compoundRefKey_EQUAL?: InputMaybe<Scalars['String']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  _compoundRefKey_AVERAGE_EQUAL?: InputMaybe<Scalars['Float']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  _compoundRefKey_LONGEST_EQUAL?: InputMaybe<Scalars['Int']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  _compoundRefKey_SHORTEST_EQUAL?: InputMaybe<Scalars['Int']>
-  _compoundRefKey_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars['Float']>
-  _compoundRefKey_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars['Int']>
-  _compoundRefKey_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars['Int']>
-  /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
-  _compoundRefKey_GT?: InputMaybe<Scalars['Int']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  _compoundRefKey_AVERAGE_GT?: InputMaybe<Scalars['Float']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  _compoundRefKey_LONGEST_GT?: InputMaybe<Scalars['Int']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  _compoundRefKey_SHORTEST_GT?: InputMaybe<Scalars['Int']>
-  _compoundRefKey_AVERAGE_LENGTH_GT?: InputMaybe<Scalars['Float']>
-  _compoundRefKey_LONGEST_LENGTH_GT?: InputMaybe<Scalars['Int']>
-  _compoundRefKey_SHORTEST_LENGTH_GT?: InputMaybe<Scalars['Int']>
-  /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
-  _compoundRefKey_GTE?: InputMaybe<Scalars['Int']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  _compoundRefKey_AVERAGE_GTE?: InputMaybe<Scalars['Float']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  _compoundRefKey_LONGEST_GTE?: InputMaybe<Scalars['Int']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  _compoundRefKey_SHORTEST_GTE?: InputMaybe<Scalars['Int']>
-  _compoundRefKey_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars['Float']>
-  _compoundRefKey_LONGEST_LENGTH_GTE?: InputMaybe<Scalars['Int']>
-  _compoundRefKey_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars['Int']>
-  /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
-  _compoundRefKey_LT?: InputMaybe<Scalars['Int']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  _compoundRefKey_AVERAGE_LT?: InputMaybe<Scalars['Float']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  _compoundRefKey_LONGEST_LT?: InputMaybe<Scalars['Int']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  _compoundRefKey_SHORTEST_LT?: InputMaybe<Scalars['Int']>
-  _compoundRefKey_AVERAGE_LENGTH_LT?: InputMaybe<Scalars['Float']>
-  _compoundRefKey_LONGEST_LENGTH_LT?: InputMaybe<Scalars['Int']>
-  _compoundRefKey_SHORTEST_LENGTH_LT?: InputMaybe<Scalars['Int']>
-  /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
-  _compoundRefKey_LTE?: InputMaybe<Scalars['Int']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  _compoundRefKey_AVERAGE_LTE?: InputMaybe<Scalars['Float']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  _compoundRefKey_LONGEST_LTE?: InputMaybe<Scalars['Int']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  _compoundRefKey_SHORTEST_LTE?: InputMaybe<Scalars['Int']>
-  _compoundRefKey_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars['Float']>
-  _compoundRefKey_LONGEST_LENGTH_LTE?: InputMaybe<Scalars['Int']>
-  _compoundRefKey_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars['Int']>
 }
 
 export type ElementPrevSiblingUpdateConnectionInput = {
@@ -20259,7 +19692,6 @@ export type ElementSort = {
   childMapperPropKey?: InputMaybe<SortDirection>
   renderForEachPropKey?: InputMaybe<SortDirection>
   renderIfExpression?: InputMaybe<SortDirection>
-  _compoundRefKey?: InputMaybe<SortDirection>
 }
 
 export type ElementTypeConnectInput = {
@@ -20575,7 +20007,6 @@ export type ElementTypeWhere = {
 export type ElementUniqueWhere = {
   id?: InputMaybe<Scalars['ID']>
   _compoundName?: InputMaybe<Scalars['String']>
-  _compoundRefKey?: InputMaybe<Scalars['String']>
 }
 
 export type ElementUpdateInput = {
@@ -20586,7 +20017,6 @@ export type ElementUpdateInput = {
   childMapperPropKey?: InputMaybe<Scalars['String']>
   renderForEachPropKey?: InputMaybe<Scalars['String']>
   renderIfExpression?: InputMaybe<Scalars['String']>
-  _compoundRefKey?: InputMaybe<Scalars['String']>
   nextSibling?: InputMaybe<ElementNextSiblingUpdateFieldInput>
   prevSibling?: InputMaybe<ElementPrevSiblingUpdateFieldInput>
   firstChild?: InputMaybe<ElementFirstChildUpdateFieldInput>
@@ -20718,22 +20148,6 @@ export type ElementWhere = {
   renderIfExpression_NOT_STARTS_WITH?: InputMaybe<Scalars['String']>
   /** @deprecated Negation filters will be deprecated, use the NOT operator to achieve the same behavior */
   renderIfExpression_NOT_ENDS_WITH?: InputMaybe<Scalars['String']>
-  _compoundRefKey?: InputMaybe<Scalars['String']>
-  /** @deprecated Negation filters will be deprecated, use the NOT operator to achieve the same behavior */
-  _compoundRefKey_NOT?: InputMaybe<Scalars['String']>
-  _compoundRefKey_IN?: InputMaybe<Array<InputMaybe<Scalars['String']>>>
-  /** @deprecated Negation filters will be deprecated, use the NOT operator to achieve the same behavior */
-  _compoundRefKey_NOT_IN?: InputMaybe<Array<InputMaybe<Scalars['String']>>>
-  _compoundRefKey_MATCHES?: InputMaybe<Scalars['String']>
-  _compoundRefKey_CONTAINS?: InputMaybe<Scalars['String']>
-  _compoundRefKey_STARTS_WITH?: InputMaybe<Scalars['String']>
-  _compoundRefKey_ENDS_WITH?: InputMaybe<Scalars['String']>
-  /** @deprecated Negation filters will be deprecated, use the NOT operator to achieve the same behavior */
-  _compoundRefKey_NOT_CONTAINS?: InputMaybe<Scalars['String']>
-  /** @deprecated Negation filters will be deprecated, use the NOT operator to achieve the same behavior */
-  _compoundRefKey_NOT_STARTS_WITH?: InputMaybe<Scalars['String']>
-  /** @deprecated Negation filters will be deprecated, use the NOT operator to achieve the same behavior */
-  _compoundRefKey_NOT_ENDS_WITH?: InputMaybe<Scalars['String']>
   nextSibling?: InputMaybe<ElementWhere>
   nextSibling_NOT?: InputMaybe<ElementWhere>
   nextSiblingAggregate?: InputMaybe<ElementNextSiblingAggregateInput>
@@ -23611,61 +23025,6 @@ export type HookElementNodeAggregationWhereInput = {
   renderIfExpression_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars['Float']>
   renderIfExpression_LONGEST_LENGTH_LTE?: InputMaybe<Scalars['Int']>
   renderIfExpression_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars['Int']>
-  /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
-  _compoundRefKey_EQUAL?: InputMaybe<Scalars['String']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  _compoundRefKey_AVERAGE_EQUAL?: InputMaybe<Scalars['Float']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  _compoundRefKey_LONGEST_EQUAL?: InputMaybe<Scalars['Int']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  _compoundRefKey_SHORTEST_EQUAL?: InputMaybe<Scalars['Int']>
-  _compoundRefKey_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars['Float']>
-  _compoundRefKey_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars['Int']>
-  _compoundRefKey_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars['Int']>
-  /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
-  _compoundRefKey_GT?: InputMaybe<Scalars['Int']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  _compoundRefKey_AVERAGE_GT?: InputMaybe<Scalars['Float']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  _compoundRefKey_LONGEST_GT?: InputMaybe<Scalars['Int']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  _compoundRefKey_SHORTEST_GT?: InputMaybe<Scalars['Int']>
-  _compoundRefKey_AVERAGE_LENGTH_GT?: InputMaybe<Scalars['Float']>
-  _compoundRefKey_LONGEST_LENGTH_GT?: InputMaybe<Scalars['Int']>
-  _compoundRefKey_SHORTEST_LENGTH_GT?: InputMaybe<Scalars['Int']>
-  /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
-  _compoundRefKey_GTE?: InputMaybe<Scalars['Int']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  _compoundRefKey_AVERAGE_GTE?: InputMaybe<Scalars['Float']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  _compoundRefKey_LONGEST_GTE?: InputMaybe<Scalars['Int']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  _compoundRefKey_SHORTEST_GTE?: InputMaybe<Scalars['Int']>
-  _compoundRefKey_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars['Float']>
-  _compoundRefKey_LONGEST_LENGTH_GTE?: InputMaybe<Scalars['Int']>
-  _compoundRefKey_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars['Int']>
-  /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
-  _compoundRefKey_LT?: InputMaybe<Scalars['Int']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  _compoundRefKey_AVERAGE_LT?: InputMaybe<Scalars['Float']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  _compoundRefKey_LONGEST_LT?: InputMaybe<Scalars['Int']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  _compoundRefKey_SHORTEST_LT?: InputMaybe<Scalars['Int']>
-  _compoundRefKey_AVERAGE_LENGTH_LT?: InputMaybe<Scalars['Float']>
-  _compoundRefKey_LONGEST_LENGTH_LT?: InputMaybe<Scalars['Int']>
-  _compoundRefKey_SHORTEST_LENGTH_LT?: InputMaybe<Scalars['Int']>
-  /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
-  _compoundRefKey_LTE?: InputMaybe<Scalars['Int']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  _compoundRefKey_AVERAGE_LTE?: InputMaybe<Scalars['Float']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  _compoundRefKey_LONGEST_LTE?: InputMaybe<Scalars['Int']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  _compoundRefKey_SHORTEST_LTE?: InputMaybe<Scalars['Int']>
-  _compoundRefKey_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars['Float']>
-  _compoundRefKey_LONGEST_LENGTH_LTE?: InputMaybe<Scalars['Int']>
-  _compoundRefKey_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars['Int']>
 }
 
 export type HookElementUpdateConnectionInput = {
@@ -26530,61 +25889,6 @@ export type PagePageContentContainerNodeAggregationWhereInput = {
   renderIfExpression_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars['Float']>
   renderIfExpression_LONGEST_LENGTH_LTE?: InputMaybe<Scalars['Int']>
   renderIfExpression_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars['Int']>
-  /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
-  _compoundRefKey_EQUAL?: InputMaybe<Scalars['String']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  _compoundRefKey_AVERAGE_EQUAL?: InputMaybe<Scalars['Float']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  _compoundRefKey_LONGEST_EQUAL?: InputMaybe<Scalars['Int']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  _compoundRefKey_SHORTEST_EQUAL?: InputMaybe<Scalars['Int']>
-  _compoundRefKey_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars['Float']>
-  _compoundRefKey_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars['Int']>
-  _compoundRefKey_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars['Int']>
-  /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
-  _compoundRefKey_GT?: InputMaybe<Scalars['Int']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  _compoundRefKey_AVERAGE_GT?: InputMaybe<Scalars['Float']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  _compoundRefKey_LONGEST_GT?: InputMaybe<Scalars['Int']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  _compoundRefKey_SHORTEST_GT?: InputMaybe<Scalars['Int']>
-  _compoundRefKey_AVERAGE_LENGTH_GT?: InputMaybe<Scalars['Float']>
-  _compoundRefKey_LONGEST_LENGTH_GT?: InputMaybe<Scalars['Int']>
-  _compoundRefKey_SHORTEST_LENGTH_GT?: InputMaybe<Scalars['Int']>
-  /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
-  _compoundRefKey_GTE?: InputMaybe<Scalars['Int']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  _compoundRefKey_AVERAGE_GTE?: InputMaybe<Scalars['Float']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  _compoundRefKey_LONGEST_GTE?: InputMaybe<Scalars['Int']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  _compoundRefKey_SHORTEST_GTE?: InputMaybe<Scalars['Int']>
-  _compoundRefKey_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars['Float']>
-  _compoundRefKey_LONGEST_LENGTH_GTE?: InputMaybe<Scalars['Int']>
-  _compoundRefKey_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars['Int']>
-  /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
-  _compoundRefKey_LT?: InputMaybe<Scalars['Int']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  _compoundRefKey_AVERAGE_LT?: InputMaybe<Scalars['Float']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  _compoundRefKey_LONGEST_LT?: InputMaybe<Scalars['Int']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  _compoundRefKey_SHORTEST_LT?: InputMaybe<Scalars['Int']>
-  _compoundRefKey_AVERAGE_LENGTH_LT?: InputMaybe<Scalars['Float']>
-  _compoundRefKey_LONGEST_LENGTH_LT?: InputMaybe<Scalars['Int']>
-  _compoundRefKey_SHORTEST_LENGTH_LT?: InputMaybe<Scalars['Int']>
-  /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
-  _compoundRefKey_LTE?: InputMaybe<Scalars['Int']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  _compoundRefKey_AVERAGE_LTE?: InputMaybe<Scalars['Float']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  _compoundRefKey_LONGEST_LTE?: InputMaybe<Scalars['Int']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  _compoundRefKey_SHORTEST_LTE?: InputMaybe<Scalars['Int']>
-  _compoundRefKey_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars['Float']>
-  _compoundRefKey_LONGEST_LENGTH_LTE?: InputMaybe<Scalars['Int']>
-  _compoundRefKey_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars['Int']>
 }
 
 export type PagePageContentContainerUpdateConnectionInput = {
@@ -27005,61 +26309,6 @@ export type PageRootElementNodeAggregationWhereInput = {
   renderIfExpression_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars['Float']>
   renderIfExpression_LONGEST_LENGTH_LTE?: InputMaybe<Scalars['Int']>
   renderIfExpression_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars['Int']>
-  /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
-  _compoundRefKey_EQUAL?: InputMaybe<Scalars['String']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  _compoundRefKey_AVERAGE_EQUAL?: InputMaybe<Scalars['Float']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  _compoundRefKey_LONGEST_EQUAL?: InputMaybe<Scalars['Int']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  _compoundRefKey_SHORTEST_EQUAL?: InputMaybe<Scalars['Int']>
-  _compoundRefKey_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars['Float']>
-  _compoundRefKey_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars['Int']>
-  _compoundRefKey_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars['Int']>
-  /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
-  _compoundRefKey_GT?: InputMaybe<Scalars['Int']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  _compoundRefKey_AVERAGE_GT?: InputMaybe<Scalars['Float']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  _compoundRefKey_LONGEST_GT?: InputMaybe<Scalars['Int']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  _compoundRefKey_SHORTEST_GT?: InputMaybe<Scalars['Int']>
-  _compoundRefKey_AVERAGE_LENGTH_GT?: InputMaybe<Scalars['Float']>
-  _compoundRefKey_LONGEST_LENGTH_GT?: InputMaybe<Scalars['Int']>
-  _compoundRefKey_SHORTEST_LENGTH_GT?: InputMaybe<Scalars['Int']>
-  /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
-  _compoundRefKey_GTE?: InputMaybe<Scalars['Int']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  _compoundRefKey_AVERAGE_GTE?: InputMaybe<Scalars['Float']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  _compoundRefKey_LONGEST_GTE?: InputMaybe<Scalars['Int']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  _compoundRefKey_SHORTEST_GTE?: InputMaybe<Scalars['Int']>
-  _compoundRefKey_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars['Float']>
-  _compoundRefKey_LONGEST_LENGTH_GTE?: InputMaybe<Scalars['Int']>
-  _compoundRefKey_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars['Int']>
-  /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
-  _compoundRefKey_LT?: InputMaybe<Scalars['Int']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  _compoundRefKey_AVERAGE_LT?: InputMaybe<Scalars['Float']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  _compoundRefKey_LONGEST_LT?: InputMaybe<Scalars['Int']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  _compoundRefKey_SHORTEST_LT?: InputMaybe<Scalars['Int']>
-  _compoundRefKey_AVERAGE_LENGTH_LT?: InputMaybe<Scalars['Float']>
-  _compoundRefKey_LONGEST_LENGTH_LT?: InputMaybe<Scalars['Int']>
-  _compoundRefKey_SHORTEST_LENGTH_LT?: InputMaybe<Scalars['Int']>
-  /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
-  _compoundRefKey_LTE?: InputMaybe<Scalars['Int']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  _compoundRefKey_AVERAGE_LTE?: InputMaybe<Scalars['Float']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  _compoundRefKey_LONGEST_LTE?: InputMaybe<Scalars['Int']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  _compoundRefKey_SHORTEST_LTE?: InputMaybe<Scalars['Int']>
-  _compoundRefKey_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars['Float']>
-  _compoundRefKey_LONGEST_LENGTH_LTE?: InputMaybe<Scalars['Int']>
-  _compoundRefKey_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars['Int']>
 }
 
 export type PageRootElementUpdateConnectionInput = {
@@ -28617,6 +27866,7 @@ export type RenderPropTypeWhere = {
 
 export type RenderTypeCreateInput = {
   id: Scalars['ID']
+  registerReference?: InputMaybe<Scalars['Boolean']>
   kind: RenderTypeKind
 }
 
@@ -28630,11 +27880,13 @@ export type RenderTypeOptions = {
 /** Fields to sort RenderTypes by. The order in which sorts are applied is not guaranteed when specifying many fields in one RenderTypeSort object. */
 export type RenderTypeSort = {
   id?: InputMaybe<SortDirection>
+  registerReference?: InputMaybe<SortDirection>
   kind?: InputMaybe<SortDirection>
 }
 
 export type RenderTypeUpdateInput = {
   id?: InputMaybe<Scalars['ID']>
+  registerReference?: InputMaybe<Scalars['Boolean']>
   kind?: InputMaybe<RenderTypeKind>
 }
 
@@ -28658,6 +27910,9 @@ export type RenderTypeWhere = {
   id_NOT_STARTS_WITH?: InputMaybe<Scalars['ID']>
   /** @deprecated Negation filters will be deprecated, use the NOT operator to achieve the same behavior */
   id_NOT_ENDS_WITH?: InputMaybe<Scalars['ID']>
+  registerReference?: InputMaybe<Scalars['Boolean']>
+  /** @deprecated Negation filters will be deprecated, use the NOT operator to achieve the same behavior */
+  registerReference_NOT?: InputMaybe<Scalars['Boolean']>
   kind?: InputMaybe<RenderTypeKind>
   /** @deprecated Negation filters will be deprecated, use the NOT operator to achieve the same behavior */
   kind_NOT?: InputMaybe<RenderTypeKind>
@@ -33776,61 +33031,6 @@ export type UserElementsNodeAggregationWhereInput = {
   renderIfExpression_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars['Float']>
   renderIfExpression_LONGEST_LENGTH_LTE?: InputMaybe<Scalars['Int']>
   renderIfExpression_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars['Int']>
-  /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
-  _compoundRefKey_EQUAL?: InputMaybe<Scalars['String']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  _compoundRefKey_AVERAGE_EQUAL?: InputMaybe<Scalars['Float']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  _compoundRefKey_LONGEST_EQUAL?: InputMaybe<Scalars['Int']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  _compoundRefKey_SHORTEST_EQUAL?: InputMaybe<Scalars['Int']>
-  _compoundRefKey_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars['Float']>
-  _compoundRefKey_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars['Int']>
-  _compoundRefKey_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars['Int']>
-  /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
-  _compoundRefKey_GT?: InputMaybe<Scalars['Int']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  _compoundRefKey_AVERAGE_GT?: InputMaybe<Scalars['Float']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  _compoundRefKey_LONGEST_GT?: InputMaybe<Scalars['Int']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  _compoundRefKey_SHORTEST_GT?: InputMaybe<Scalars['Int']>
-  _compoundRefKey_AVERAGE_LENGTH_GT?: InputMaybe<Scalars['Float']>
-  _compoundRefKey_LONGEST_LENGTH_GT?: InputMaybe<Scalars['Int']>
-  _compoundRefKey_SHORTEST_LENGTH_GT?: InputMaybe<Scalars['Int']>
-  /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
-  _compoundRefKey_GTE?: InputMaybe<Scalars['Int']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  _compoundRefKey_AVERAGE_GTE?: InputMaybe<Scalars['Float']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  _compoundRefKey_LONGEST_GTE?: InputMaybe<Scalars['Int']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  _compoundRefKey_SHORTEST_GTE?: InputMaybe<Scalars['Int']>
-  _compoundRefKey_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars['Float']>
-  _compoundRefKey_LONGEST_LENGTH_GTE?: InputMaybe<Scalars['Int']>
-  _compoundRefKey_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars['Int']>
-  /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
-  _compoundRefKey_LT?: InputMaybe<Scalars['Int']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  _compoundRefKey_AVERAGE_LT?: InputMaybe<Scalars['Float']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  _compoundRefKey_LONGEST_LT?: InputMaybe<Scalars['Int']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  _compoundRefKey_SHORTEST_LT?: InputMaybe<Scalars['Int']>
-  _compoundRefKey_AVERAGE_LENGTH_LT?: InputMaybe<Scalars['Float']>
-  _compoundRefKey_LONGEST_LENGTH_LT?: InputMaybe<Scalars['Int']>
-  _compoundRefKey_SHORTEST_LENGTH_LT?: InputMaybe<Scalars['Int']>
-  /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
-  _compoundRefKey_LTE?: InputMaybe<Scalars['Int']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  _compoundRefKey_AVERAGE_LTE?: InputMaybe<Scalars['Float']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  _compoundRefKey_LONGEST_LTE?: InputMaybe<Scalars['Int']>
-  /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
-  _compoundRefKey_SHORTEST_LTE?: InputMaybe<Scalars['Int']>
-  _compoundRefKey_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars['Float']>
-  _compoundRefKey_LONGEST_LENGTH_LTE?: InputMaybe<Scalars['Int']>
-  _compoundRefKey_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars['Int']>
 }
 
 export type UserElementsUpdateConnectionInput = {
@@ -36183,7 +35383,6 @@ export interface ElementAggregateSelectionInput {
   childMapperPropKey?: StringAggregateInputNullable
   renderForEachPropKey?: StringAggregateInputNullable
   renderIfExpression?: StringAggregateInputNullable
-  _compoundRefKey?: StringAggregateInputNullable
 }
 
 export declare class ElementModel {

--- a/libs/backend/domain/element/src/model/element.model.ts
+++ b/libs/backend/domain/element/src/model/element.model.ts
@@ -40,8 +40,6 @@ export class Element implements IElementDTO {
 
   renderType?: Nullable<RenderType> | undefined
 
-  refKey?: Nullable<string> | undefined
-
   constructor({ id, name, props }: IElementDTO) {
     this.id = id
     this.name = name

--- a/libs/backend/infra/adapter/neo4j/src/resolver/pure-resolver/element/element.resolver.ts
+++ b/libs/backend/infra/adapter/neo4j/src/resolver/pure-resolver/element/element.resolver.ts
@@ -1,13 +1,11 @@
 import type { IResolvers } from '@graphql-tools/utils'
 import { name } from './field/element-name'
 import { slug } from './field/element-slug'
-import { refKey } from './field/ref-key'
 import { renderType } from './field/render-type'
 
 export const elementResolver: IResolvers = {
   Element: {
     name,
-    refKey,
     renderType,
     slug,
   },

--- a/libs/backend/infra/adapter/neo4j/src/resolver/pure-resolver/element/field/ref-key.ts
+++ b/libs/backend/infra/adapter/neo4j/src/resolver/pure-resolver/element/field/ref-key.ts
@@ -1,8 +1,0 @@
-import type { Element } from '@codelab/shared/abstract/codegen'
-import { uuidRegex } from '@codelab/shared/utils'
-
-export const refKey = (element: Element) => {
-  const reg = new RegExp(`${uuidRegex.source}-`, 'gi')
-
-  return element._compoundRefKey?.replace(reg, '')
-}

--- a/libs/backend/infra/adapter/neo4j/src/schema/model/element.schema.ts
+++ b/libs/backend/infra/adapter/neo4j/src/schema/model/element.schema.ts
@@ -53,9 +53,6 @@ export const elementSchema = gql`
     renderComponentType: Component
       @relationship(type: "RENDER_COMPONENT_TYPE", direction: OUT)
 
-    _compoundRefKey: String @unique
-    refKey: String @customResolver(requires: ["id", "_compoundRefKey"])
-
     renderAtomType: Atom @relationship(type: "RENDER_ATOM_TYPE", direction: OUT)
     renderType: RenderType
 

--- a/libs/backend/infra/adapter/neo4j/src/selectionSet/element-selection-set.ts
+++ b/libs/backend/infra/adapter/neo4j/src/selectionSet/element-selection-set.ts
@@ -51,8 +51,6 @@ const baseElementSelectionSet = `
     id
     type
   }
-  _compoundRefKey
-  refKey
 `
 
 export const elementSelectionSet = `{

--- a/libs/frontend/abstract/core/src/domain/element/element.dto.interface.ts
+++ b/libs/frontend/abstract/core/src/domain/element/element.dto.interface.ts
@@ -14,7 +14,6 @@ export interface ICreateElementData {
   /**
    * We should connect to `atom` or `component` in future
    */
-  refKey?: Nullable<string>
   renderType?: Nullable<RenderType>
 }
 
@@ -25,7 +24,6 @@ export type IUpdateElementData = Pick<
   | 'name'
   | 'postRenderAction'
   | 'preRenderAction'
-  | 'refKey'
   | 'renderType'
 > &
   Pick<ICreateElementData, 'id'> & {
@@ -48,7 +46,6 @@ export type IUpdateBaseElementData = Pick<
   | 'name'
   | 'postRenderAction'
   | 'preRenderAction'
-  | 'refKey'
   | 'renderForEachPropKey'
   | 'renderIfExpression'
   | 'renderType'

--- a/libs/frontend/abstract/core/src/domain/element/element.fragment.graphql
+++ b/libs/frontend/abstract/core/src/domain/element/element.fragment.graphql
@@ -2,7 +2,6 @@ fragment Element on Element {
   __typename
   id
   name
-  slug
   customCss
   guiCss
   page {
@@ -15,7 +14,6 @@ fragment Element on Element {
     ...Atom
     # ...RenderAtom
   }
-  refKey
   renderType {
     id
     kind
@@ -62,7 +60,6 @@ fragment ProductionElement on Element {
   __typename
   id
   name
-  slug
   customCss
   guiCss
   page {

--- a/libs/frontend/abstract/core/src/domain/element/element.fragment.graphql.gen.ts
+++ b/libs/frontend/abstract/core/src/domain/element/element.fragment.graphql.gen.ts
@@ -17,17 +17,19 @@ export type ElementFragment = {
   __typename: 'Element'
   id: string
   name: string
-  slug: string
   customCss?: string | null
   guiCss?: string | null
-  refKey?: string | null
   childMapperPropKey?: string | null
   renderForEachPropKey?: string | null
   renderIfExpression?: string | null
   page?: { id: string } | null
   renderComponentType?: { id: string } | null
   renderAtomType?: AtomFragment | null
-  renderType?: { id: string; kind: Types.RenderTypeKind } | null
+  renderType?: {
+    id: string
+    kind: Types.RenderTypeKind
+    registerReference?: boolean | null
+  } | null
   prevSibling?: { id: string } | null
   nextSibling?: { id: string } | null
   parentComponent?: { id: string } | null
@@ -50,7 +52,6 @@ export type ProductionElementFragment = {
   __typename: 'Element'
   id: string
   name: string
-  slug: string
   customCss?: string | null
   guiCss?: string | null
   childMapperPropKey?: string | null
@@ -59,7 +60,11 @@ export type ProductionElementFragment = {
   page?: { id: string } | null
   renderComponentType?: { id: string } | null
   renderAtomType?: ProductionAtomFragment | null
-  renderType?: { id: string; kind: Types.RenderTypeKind } | null
+  renderType?: {
+    id: string
+    kind: Types.RenderTypeKind
+    registerReference?: boolean | null
+  } | null
   prevSibling?: { id: string } | null
   nextSibling?: { id: string } | null
   parentComponent?: { id: string } | null
@@ -83,7 +88,6 @@ export const ElementFragmentDoc = gql`
     __typename
     id
     name
-    slug
     customCss
     guiCss
     page {
@@ -95,10 +99,10 @@ export const ElementFragmentDoc = gql`
     renderAtomType {
       ...Atom
     }
-    refKey
     renderType {
       id
       kind
+      registerReference
     }
     prevSibling {
       id
@@ -145,7 +149,6 @@ export const ProductionElementFragmentDoc = gql`
     __typename
     id
     name
-    slug
     customCss
     guiCss
     page {
@@ -160,6 +163,7 @@ export const ProductionElementFragmentDoc = gql`
     renderType {
       id
       kind
+      registerReference
     }
     prevSibling {
       id

--- a/libs/frontend/abstract/core/src/domain/element/element.fragment.graphql.gen.ts
+++ b/libs/frontend/abstract/core/src/domain/element/element.fragment.graphql.gen.ts
@@ -25,11 +25,7 @@ export type ElementFragment = {
   page?: { id: string } | null
   renderComponentType?: { id: string } | null
   renderAtomType?: AtomFragment | null
-  renderType?: {
-    id: string
-    kind: Types.RenderTypeKind
-    registerReference?: boolean | null
-  } | null
+  renderType?: { id: string; kind: Types.RenderTypeKind } | null
   prevSibling?: { id: string } | null
   nextSibling?: { id: string } | null
   parentComponent?: { id: string } | null
@@ -60,11 +56,7 @@ export type ProductionElementFragment = {
   page?: { id: string } | null
   renderComponentType?: { id: string } | null
   renderAtomType?: ProductionAtomFragment | null
-  renderType?: {
-    id: string
-    kind: Types.RenderTypeKind
-    registerReference?: boolean | null
-  } | null
+  renderType?: { id: string; kind: Types.RenderTypeKind } | null
   prevSibling?: { id: string } | null
   nextSibling?: { id: string } | null
   parentComponent?: { id: string } | null
@@ -102,7 +94,6 @@ export const ElementFragmentDoc = gql`
     renderType {
       id
       kind
-      registerReference
     }
     prevSibling {
       id
@@ -163,7 +154,6 @@ export const ProductionElementFragmentDoc = gql`
     renderType {
       id
       kind
-      registerReference
     }
     prevSibling {
       id

--- a/libs/frontend/abstract/core/src/domain/element/element.model.interface.ts
+++ b/libs/frontend/abstract/core/src/domain/element/element.model.interface.ts
@@ -102,7 +102,6 @@ export interface IElement
   propsHaveErrors: boolean | null
   // store attached to the provider page
   providerStore?: Ref<IStore>
-  refKey: Nullish<string>
   renderForEachPropKey: Nullable<string>
   renderIfExpression: Nullable<string>
   renderType: IElementRenderType | null
@@ -110,7 +109,7 @@ export interface IElement
   // renderComponentType: Nullable<Ref<IComponent>>
   renderingMetadata: Nullable<RenderingMetadata>
   runtimeProp: Maybe<IElementRuntimeProp>
-
+  slug: string
   /**
    * to render a component we create a duplicate for each element
    * keeps track of source element in case this is a duplicate

--- a/libs/frontend/domain/element/src/store/element.model.ts
+++ b/libs/frontend/domain/element/src/store/element.model.ts
@@ -51,6 +51,7 @@ import {
 import {
   compoundCaseToTitleCase,
   createUniqueName,
+  slugify,
 } from '@codelab/shared/utils'
 import { computed } from 'mobx'
 import {
@@ -81,7 +82,6 @@ const create = ({
   preRenderAction,
   prevSibling,
   props,
-  refKey,
   renderForEachPropKey,
   renderIfExpression,
   renderType,
@@ -115,7 +115,6 @@ const create = ({
       : undefined,
     prevSibling: prevSibling?.id ? elementRef(prevSibling.id) : undefined,
     props: propRef(props.id),
-    refKey,
     renderForEachPropKey,
     renderIfExpression,
     renderingMetadata: null,
@@ -152,7 +151,6 @@ export class Element
     preRenderAction: prop<Nullable<Ref<IAction>>>(null).withSetter(),
     prevSibling: prop<Nullable<Ref<IElement>>>(null).withSetter(),
     props: prop<Ref<IProp>>().withSetter(),
-    refKey: prop<Nullable<string>>(null),
     renderForEachPropKey: prop<Nullable<string>>(null).withSetter(),
     renderIfExpression: prop<Nullable<string>>(null).withSetter(),
     renderingMetadata: prop<Nullable<RenderingMetadata>>(null),
@@ -326,6 +324,11 @@ export class Element
     }
   }
 
+  @computed
+  get slug(): string {
+    return slugify(this.name)
+  }
+
   @modelAction
   appendToGuiCss(css: CssMap) {
     const curGuiCss = JSON.parse(this.guiCss || '{}')
@@ -431,7 +434,7 @@ export class Element
       secondary:
         this.renderType?.maybeCurrent?.name ||
         (isAtomInstance(this.renderType)
-          ? compoundCaseToTitleCase((this.renderType.current as IAtom).type)
+          ? compoundCaseToTitleCase(this.renderType.current.type)
           : undefined),
     }
   }
@@ -757,7 +760,6 @@ export class Element
     preRenderAction,
     prevSibling,
     props,
-    refKey,
     renderForEachPropKey,
     renderIfExpression,
     renderType,
@@ -797,8 +799,6 @@ export class Element
     this.childMapperPreviousSibling = childMapperPreviousSibling
       ? elementRef(childMapperPreviousSibling.id)
       : null
-
-    this.refKey = refKey ?? null
 
     return this
   }

--- a/libs/frontend/domain/element/src/use-cases/element/create-element/create-element.schema.ts
+++ b/libs/frontend/domain/element/src/use-cases/element/create-element/create-element.schema.ts
@@ -95,11 +95,6 @@ export const createElementSchema: JSONSchemaType<
       required: ['id', 'kind'],
       type: 'object',
     },
-    refKey: {
-      label: 'Ref Key',
-      nullable: true,
-      type: 'string',
-    },
   },
   required: ['name', 'id'],
   title: 'Create Element Input',

--- a/libs/frontend/domain/element/src/use-cases/element/update-element/UpdateElementForm.tsx
+++ b/libs/frontend/domain/element/src/use-cases/element/update-element/UpdateElementForm.tsx
@@ -50,10 +50,6 @@ export const UpdateElementForm = observer<UpdateElementFormProps>(
       expandedFields.push('renderCondition')
     }
 
-    if (model.refKey) {
-      expandedFields.push('reference')
-    }
-
     if (
       model.childMapperPropKey ??
       model.childMapperPreviousSibling ??
@@ -89,7 +85,6 @@ export const UpdateElementForm = observer<UpdateElementFormProps>(
             'postRenderAction',
             'renderType',
             'name',
-            'refKey',
           ]}
         />
         <Collapse defaultActiveKey={expandedFields}>
@@ -113,9 +108,6 @@ export const UpdateElementForm = observer<UpdateElementFormProps>(
           </Collapse.Panel>
           <Collapse.Panel header="Child Mapper" key="childMapper">
             <ChildMapperCompositeField element={element} />
-          </Collapse.Panel>
-          <Collapse.Panel header="Reference" key="reference">
-            <AutoField name="refKey" />
           </Collapse.Panel>
         </Collapse>
       </Form>

--- a/libs/frontend/domain/element/src/use-cases/element/update-element/update-element.schema.ts
+++ b/libs/frontend/domain/element/src/use-cases/element/update-element/update-element.schema.ts
@@ -94,11 +94,6 @@ export const updateElementSchema: JSONSchemaType<IUpdateBaseElementData> = {
       required: ['id', 'kind'],
       type: 'object',
     },
-    refKey: {
-      label: 'Ref Key',
-      nullable: true,
-      type: 'string',
-    },
   },
   required: [],
   title: 'Update Element Input',

--- a/libs/frontend/domain/element/src/utils/get-element-model.ts
+++ b/libs/frontend/domain/element/src/utils/get-element-model.ts
@@ -39,7 +39,6 @@ export const getElementModel = (element: IElement) => {
     preRenderAction: element.preRenderAction
       ? { id: element.preRenderAction.current.id }
       : null,
-    refKey: element.refKey,
     renderForEachPropKey: element.renderForEachPropKey,
     renderIfExpression: element.renderIfExpression,
     renderType,

--- a/libs/frontend/domain/renderer/src/element-runtime-props.model.ts
+++ b/libs/frontend/domain/renderer/src/element-runtime-props.model.ts
@@ -28,7 +28,7 @@ export class ElementRuntimeProps
   @computed
   get props() {
     // memorize values or else it will be lost inside callback
-    const refKey = this.node.refKey
+    const slug = this.node.slug
     const store = this.node.store.current
 
     return {
@@ -40,9 +40,8 @@ export class ElementRuntimeProps
        * Internal system props for meta data, use double underline for system-defined identifiers.
        */
       [DATA_ELEMENT_ID]: this.node.id,
-      forwardedRef: refKey
-        ? (node: HTMLElement) => store.registerRef(refKey, node)
-        : undefined,
+      // FIXME: add condition to attach ref
+      forwardedRef: (node: HTMLElement) => store.registerRef(slug, node),
       key: this.node.id,
     }
   }

--- a/libs/frontend/domain/renderer/src/element-runtime-props.model.ts
+++ b/libs/frontend/domain/renderer/src/element-runtime-props.model.ts
@@ -2,7 +2,10 @@ import type {
   IElement,
   IElementRuntimeProp,
 } from '@codelab/frontend/abstract/core'
-import { DATA_ELEMENT_ID } from '@codelab/frontend/abstract/core'
+import {
+  DATA_ELEMENT_ID,
+  isAtomInstance,
+} from '@codelab/frontend/abstract/core'
 import {
   evaluateExpression,
   evaluateObject,
@@ -28,6 +31,7 @@ export class ElementRuntimeProps
   @computed
   get props() {
     // memorize values or else it will be lost inside callback
+    const registerReference = isAtomInstance(this.node.renderType)
     const slug = this.node.slug
     const store = this.node.store.current
 
@@ -40,9 +44,10 @@ export class ElementRuntimeProps
        * Internal system props for meta data, use double underline for system-defined identifiers.
        */
       [DATA_ELEMENT_ID]: this.node.id,
-      // FIXME: add condition to attach ref
-      forwardedRef: (node: HTMLElement) => store.registerRef(slug, node),
       key: this.node.id,
+      ref: registerReference
+        ? (node: HTMLElement) => store.registerRef(slug, node)
+        : undefined,
     }
   }
 

--- a/libs/frontend/domain/renderer/src/test/renderer.spec.ts
+++ b/libs/frontend/domain/renderer/src/test/renderer.spec.ts
@@ -26,7 +26,10 @@ describe('Renderer', () => {
     const rootElement = clonedComponent?.rootElement.current
     const rootElementProps = rootElement?.runtimeProp?.evaluatedProps || {}
 
-    expect(props).toMatchObject(rootElementProps)
+    expect(props).toMatchObject({
+      ...rootElementProps,
+      ref: expect.any(Function),
+    })
 
     const componentAtomType =
       rootElement && isAtomInstance(rootElement.renderType)
@@ -53,6 +56,7 @@ describe('Renderer', () => {
       ...rootElementProps,
       [DATA_COMPONENT_ID]: clonedComponent?.id,
       expressionProp: 'expression value - component instance prop',
+      ref: expect.any(Function),
     })
   })
 })

--- a/libs/frontend/domain/store/src/store/models/store.model.ts
+++ b/libs/frontend/domain/store/src/store/models/store.model.ts
@@ -11,6 +11,7 @@ import {
   componentRef,
   getRenderService,
   getRunnerId,
+  isAtomInstance,
   pageRef,
   typeRef,
 } from '@codelab/frontend/abstract/core'
@@ -101,7 +102,7 @@ export class Store
     const elements = elementTree?.elements || []
 
     return elements
-      .filter((element) => Boolean(element.renderType?.registerReference))
+      .filter((element) => isAtomInstance(element.renderType))
       .map(({ slug }) => slug)
   }
 

--- a/libs/frontend/domain/store/src/store/models/store.model.ts
+++ b/libs/frontend/domain/store/src/store/models/store.model.ts
@@ -101,8 +101,8 @@ export class Store
     const elements = elementTree?.elements || []
 
     return elements
-      .filter((element) => Boolean(element.refKey))
-      .map(({ refKey }) => refKey as string)
+      .filter((element) => Boolean(element.renderType?.registerReference))
+      .map(({ slug }) => slug)
   }
 
   @computed

--- a/libs/frontend/domain/type/src/interface-form/ui-properties/primative-ui-properties.ts
+++ b/libs/frontend/domain/type/src/interface-form/ui-properties/primative-ui-properties.ts
@@ -15,8 +15,6 @@ export const primitiveTypeUiProperties: UiPropertiesFn<IPrimitiveType> = (
     ? createAutoCompleteOptions(context.autocomplete)
     : undefined
 
-  console.log(autocomplete)
-
   if (type.primitiveKind === IPrimitiveTypeKind.String) {
     return {
       uniforms: {

--- a/libs/frontend/shared/utils/src/dynamic-loader.ts
+++ b/libs/frontend/shared/utils/src/dynamic-loader.ts
@@ -1,6 +1,5 @@
 import type { LoaderComponent } from 'next/dynamic'
 import dynamic from 'next/dynamic'
-import type { RefObject } from 'react'
 import React from 'react'
 
 /**
@@ -8,16 +7,23 @@ import React from 'react'
  */
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export const dynamicLoader = (loadingFn: () => LoaderComponent<any>) =>
-  dynamic(
+export const dynamicLoader = (loadingFn: () => LoaderComponent<any>) => {
+  const LoadedComponent = dynamic(
     async () => {
       const result = await loadingFn()
       const Component = 'default' in result ? result.default : result
 
-      return React.forwardRef(
-        (props: unknown & { forwardedRef: RefObject<unknown> }, ref) =>
-          React.createElement(Component, { ...props, ref: props.forwardedRef }),
-      )
+      return ({
+        forwarded,
+        ...rest
+      }: object & { forwarded: React.ForwardedRef<unknown> }) =>
+        React.createElement(Component, { ...rest, ref: forwarded })
     },
     { ssr: false },
   )
+
+  // a workaround for: https://github.com/cookpete/react-player/issues/1455
+  return React.forwardRef((props: object, forwarded) =>
+    React.createElement(LoadedComponent, { ...props, forwarded }),
+  )
+}

--- a/libs/shared/abstract/codegen/src/types.api.graphql.gen.ts
+++ b/libs/shared/abstract/codegen/src/types.api.graphql.gen.ts
@@ -614,7 +614,6 @@ export type ApiActionElementElementAggregationSelection = {
 export type ApiActionElementElementNodeAggregateSelection = {
   __typename?: 'ApiActionElementElementNodeAggregateSelection'
   _compoundName: StringAggregateSelectionNonNullable
-  _compoundRefKey: StringAggregateSelectionNullable
   childMapperPropKey: StringAggregateSelectionNullable
   customCss: StringAggregateSelectionNullable
   guiCss: StringAggregateSelectionNullable
@@ -642,21 +641,6 @@ export type ApiActionElementNodeAggregationWhereInput = {
   _compoundName_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars['Int']['input']>
   _compoundName_SHORTEST_LENGTH_LT?: InputMaybe<Scalars['Int']['input']>
   _compoundName_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars['Int']['input']>
-  _compoundRefKey_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars['Float']['input']>
-  _compoundRefKey_AVERAGE_LENGTH_GT?: InputMaybe<Scalars['Float']['input']>
-  _compoundRefKey_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars['Float']['input']>
-  _compoundRefKey_AVERAGE_LENGTH_LT?: InputMaybe<Scalars['Float']['input']>
-  _compoundRefKey_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars['Float']['input']>
-  _compoundRefKey_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars['Int']['input']>
-  _compoundRefKey_LONGEST_LENGTH_GT?: InputMaybe<Scalars['Int']['input']>
-  _compoundRefKey_LONGEST_LENGTH_GTE?: InputMaybe<Scalars['Int']['input']>
-  _compoundRefKey_LONGEST_LENGTH_LT?: InputMaybe<Scalars['Int']['input']>
-  _compoundRefKey_LONGEST_LENGTH_LTE?: InputMaybe<Scalars['Int']['input']>
-  _compoundRefKey_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars['Int']['input']>
-  _compoundRefKey_SHORTEST_LENGTH_GT?: InputMaybe<Scalars['Int']['input']>
-  _compoundRefKey_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars['Int']['input']>
-  _compoundRefKey_SHORTEST_LENGTH_LT?: InputMaybe<Scalars['Int']['input']>
-  _compoundRefKey_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars['Int']['input']>
   childMapperPropKey_AVERAGE_LENGTH_EQUAL?: InputMaybe<
     Scalars['Float']['input']
   >
@@ -4278,21 +4262,6 @@ export type BaseActionElementNodeAggregationWhereInput = {
   _compoundName_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars['Int']['input']>
   _compoundName_SHORTEST_LENGTH_LT?: InputMaybe<Scalars['Int']['input']>
   _compoundName_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars['Int']['input']>
-  _compoundRefKey_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars['Float']['input']>
-  _compoundRefKey_AVERAGE_LENGTH_GT?: InputMaybe<Scalars['Float']['input']>
-  _compoundRefKey_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars['Float']['input']>
-  _compoundRefKey_AVERAGE_LENGTH_LT?: InputMaybe<Scalars['Float']['input']>
-  _compoundRefKey_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars['Float']['input']>
-  _compoundRefKey_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars['Int']['input']>
-  _compoundRefKey_LONGEST_LENGTH_GT?: InputMaybe<Scalars['Int']['input']>
-  _compoundRefKey_LONGEST_LENGTH_GTE?: InputMaybe<Scalars['Int']['input']>
-  _compoundRefKey_LONGEST_LENGTH_LT?: InputMaybe<Scalars['Int']['input']>
-  _compoundRefKey_LONGEST_LENGTH_LTE?: InputMaybe<Scalars['Int']['input']>
-  _compoundRefKey_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars['Int']['input']>
-  _compoundRefKey_SHORTEST_LENGTH_GT?: InputMaybe<Scalars['Int']['input']>
-  _compoundRefKey_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars['Int']['input']>
-  _compoundRefKey_SHORTEST_LENGTH_LT?: InputMaybe<Scalars['Int']['input']>
-  _compoundRefKey_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars['Int']['input']>
   childMapperPropKey_AVERAGE_LENGTH_EQUAL?: InputMaybe<
     Scalars['Float']['input']
   >
@@ -4904,7 +4873,6 @@ export type CodeActionElementElementAggregationSelection = {
 export type CodeActionElementElementNodeAggregateSelection = {
   __typename?: 'CodeActionElementElementNodeAggregateSelection'
   _compoundName: StringAggregateSelectionNonNullable
-  _compoundRefKey: StringAggregateSelectionNullable
   childMapperPropKey: StringAggregateSelectionNullable
   customCss: StringAggregateSelectionNullable
   guiCss: StringAggregateSelectionNullable
@@ -4932,21 +4900,6 @@ export type CodeActionElementNodeAggregationWhereInput = {
   _compoundName_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars['Int']['input']>
   _compoundName_SHORTEST_LENGTH_LT?: InputMaybe<Scalars['Int']['input']>
   _compoundName_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars['Int']['input']>
-  _compoundRefKey_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars['Float']['input']>
-  _compoundRefKey_AVERAGE_LENGTH_GT?: InputMaybe<Scalars['Float']['input']>
-  _compoundRefKey_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars['Float']['input']>
-  _compoundRefKey_AVERAGE_LENGTH_LT?: InputMaybe<Scalars['Float']['input']>
-  _compoundRefKey_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars['Float']['input']>
-  _compoundRefKey_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars['Int']['input']>
-  _compoundRefKey_LONGEST_LENGTH_GT?: InputMaybe<Scalars['Int']['input']>
-  _compoundRefKey_LONGEST_LENGTH_GTE?: InputMaybe<Scalars['Int']['input']>
-  _compoundRefKey_LONGEST_LENGTH_LT?: InputMaybe<Scalars['Int']['input']>
-  _compoundRefKey_LONGEST_LENGTH_LTE?: InputMaybe<Scalars['Int']['input']>
-  _compoundRefKey_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars['Int']['input']>
-  _compoundRefKey_SHORTEST_LENGTH_GT?: InputMaybe<Scalars['Int']['input']>
-  _compoundRefKey_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars['Int']['input']>
-  _compoundRefKey_SHORTEST_LENGTH_LT?: InputMaybe<Scalars['Int']['input']>
-  _compoundRefKey_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars['Int']['input']>
   childMapperPropKey_AVERAGE_LENGTH_EQUAL?: InputMaybe<
     Scalars['Float']['input']
   >
@@ -5745,21 +5698,6 @@ export type ComponentChildrenContainerElementNodeAggregationWhereInput = {
   _compoundName_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars['Int']['input']>
   _compoundName_SHORTEST_LENGTH_LT?: InputMaybe<Scalars['Int']['input']>
   _compoundName_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars['Int']['input']>
-  _compoundRefKey_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars['Float']['input']>
-  _compoundRefKey_AVERAGE_LENGTH_GT?: InputMaybe<Scalars['Float']['input']>
-  _compoundRefKey_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars['Float']['input']>
-  _compoundRefKey_AVERAGE_LENGTH_LT?: InputMaybe<Scalars['Float']['input']>
-  _compoundRefKey_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars['Float']['input']>
-  _compoundRefKey_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars['Int']['input']>
-  _compoundRefKey_LONGEST_LENGTH_GT?: InputMaybe<Scalars['Int']['input']>
-  _compoundRefKey_LONGEST_LENGTH_GTE?: InputMaybe<Scalars['Int']['input']>
-  _compoundRefKey_LONGEST_LENGTH_LT?: InputMaybe<Scalars['Int']['input']>
-  _compoundRefKey_LONGEST_LENGTH_LTE?: InputMaybe<Scalars['Int']['input']>
-  _compoundRefKey_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars['Int']['input']>
-  _compoundRefKey_SHORTEST_LENGTH_GT?: InputMaybe<Scalars['Int']['input']>
-  _compoundRefKey_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars['Int']['input']>
-  _compoundRefKey_SHORTEST_LENGTH_LT?: InputMaybe<Scalars['Int']['input']>
-  _compoundRefKey_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars['Int']['input']>
   childMapperPropKey_AVERAGE_LENGTH_EQUAL?: InputMaybe<
     Scalars['Float']['input']
   >
@@ -5942,7 +5880,6 @@ export type ComponentElementChildrenContainerElementAggregationSelection = {
 export type ComponentElementChildrenContainerElementNodeAggregateSelection = {
   __typename?: 'ComponentElementChildrenContainerElementNodeAggregateSelection'
   _compoundName: StringAggregateSelectionNonNullable
-  _compoundRefKey: StringAggregateSelectionNullable
   childMapperPropKey: StringAggregateSelectionNullable
   customCss: StringAggregateSelectionNullable
   guiCss: StringAggregateSelectionNullable
@@ -5960,7 +5897,6 @@ export type ComponentElementRootElementAggregationSelection = {
 export type ComponentElementRootElementNodeAggregateSelection = {
   __typename?: 'ComponentElementRootElementNodeAggregateSelection'
   _compoundName: StringAggregateSelectionNonNullable
-  _compoundRefKey: StringAggregateSelectionNullable
   childMapperPropKey: StringAggregateSelectionNullable
   customCss: StringAggregateSelectionNullable
   guiCss: StringAggregateSelectionNullable
@@ -6267,21 +6203,6 @@ export type ComponentRootElementNodeAggregationWhereInput = {
   _compoundName_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars['Int']['input']>
   _compoundName_SHORTEST_LENGTH_LT?: InputMaybe<Scalars['Int']['input']>
   _compoundName_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars['Int']['input']>
-  _compoundRefKey_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars['Float']['input']>
-  _compoundRefKey_AVERAGE_LENGTH_GT?: InputMaybe<Scalars['Float']['input']>
-  _compoundRefKey_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars['Float']['input']>
-  _compoundRefKey_AVERAGE_LENGTH_LT?: InputMaybe<Scalars['Float']['input']>
-  _compoundRefKey_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars['Float']['input']>
-  _compoundRefKey_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars['Int']['input']>
-  _compoundRefKey_LONGEST_LENGTH_GT?: InputMaybe<Scalars['Int']['input']>
-  _compoundRefKey_LONGEST_LENGTH_GTE?: InputMaybe<Scalars['Int']['input']>
-  _compoundRefKey_LONGEST_LENGTH_LT?: InputMaybe<Scalars['Int']['input']>
-  _compoundRefKey_LONGEST_LENGTH_LTE?: InputMaybe<Scalars['Int']['input']>
-  _compoundRefKey_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars['Int']['input']>
-  _compoundRefKey_SHORTEST_LENGTH_GT?: InputMaybe<Scalars['Int']['input']>
-  _compoundRefKey_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars['Int']['input']>
-  _compoundRefKey_SHORTEST_LENGTH_LT?: InputMaybe<Scalars['Int']['input']>
-  _compoundRefKey_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars['Int']['input']>
   childMapperPropKey_AVERAGE_LENGTH_EQUAL?: InputMaybe<
     Scalars['Float']['input']
   >
@@ -7067,7 +6988,6 @@ export type DomainsConnection = {
 export type Element = {
   __typename?: 'Element'
   _compoundName: Scalars['String']['output']
-  _compoundRefKey?: Maybe<Scalars['String']['output']>
   childMapperComponent?: Maybe<Component>
   childMapperComponentAggregate?: Maybe<ElementComponentChildMapperComponentAggregationSelection>
   childMapperComponentConnection: ElementChildMapperComponentConnection
@@ -7105,7 +7025,6 @@ export type Element = {
   props: Prop
   propsAggregate?: Maybe<ElementPropPropsAggregationSelection>
   propsConnection: ElementPropsConnection
-  refKey?: Maybe<Scalars['String']['output']>
   renderAtomType?: Maybe<Atom>
   renderAtomTypeAggregate?: Maybe<ElementAtomRenderAtomTypeAggregationSelection>
   renderAtomTypeConnection: ElementRenderAtomTypeConnection
@@ -7358,7 +7277,6 @@ export type ElementRenderComponentTypeConnectionArgs = {
 export type ElementAggregateSelection = {
   __typename?: 'ElementAggregateSelection'
   _compoundName: StringAggregateSelectionNonNullable
-  _compoundRefKey: StringAggregateSelectionNullable
   childMapperPropKey: StringAggregateSelectionNullable
   count: Scalars['Int']['output']
   customCss: StringAggregateSelectionNullable
@@ -7596,21 +7514,6 @@ export type ElementChildMapperPreviousSiblingNodeAggregationWhereInput = {
   _compoundName_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars['Int']['input']>
   _compoundName_SHORTEST_LENGTH_LT?: InputMaybe<Scalars['Int']['input']>
   _compoundName_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars['Int']['input']>
-  _compoundRefKey_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars['Float']['input']>
-  _compoundRefKey_AVERAGE_LENGTH_GT?: InputMaybe<Scalars['Float']['input']>
-  _compoundRefKey_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars['Float']['input']>
-  _compoundRefKey_AVERAGE_LENGTH_LT?: InputMaybe<Scalars['Float']['input']>
-  _compoundRefKey_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars['Float']['input']>
-  _compoundRefKey_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars['Int']['input']>
-  _compoundRefKey_LONGEST_LENGTH_GT?: InputMaybe<Scalars['Int']['input']>
-  _compoundRefKey_LONGEST_LENGTH_GTE?: InputMaybe<Scalars['Int']['input']>
-  _compoundRefKey_LONGEST_LENGTH_LT?: InputMaybe<Scalars['Int']['input']>
-  _compoundRefKey_LONGEST_LENGTH_LTE?: InputMaybe<Scalars['Int']['input']>
-  _compoundRefKey_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars['Int']['input']>
-  _compoundRefKey_SHORTEST_LENGTH_GT?: InputMaybe<Scalars['Int']['input']>
-  _compoundRefKey_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars['Int']['input']>
-  _compoundRefKey_SHORTEST_LENGTH_LT?: InputMaybe<Scalars['Int']['input']>
-  _compoundRefKey_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars['Int']['input']>
   childMapperPropKey_AVERAGE_LENGTH_EQUAL?: InputMaybe<
     Scalars['Float']['input']
   >
@@ -7801,7 +7704,6 @@ export type ElementConnectWhere = {
 
 export type ElementCreateInput = {
   _compoundName: Scalars['String']['input']
-  _compoundRefKey?: InputMaybe<Scalars['String']['input']>
   childMapperComponent?: InputMaybe<ElementChildMapperComponentFieldInput>
   childMapperPreviousSibling?: InputMaybe<ElementChildMapperPreviousSiblingFieldInput>
   childMapperPropKey?: InputMaybe<Scalars['String']['input']>
@@ -7870,7 +7772,6 @@ export type ElementElementChildMapperPreviousSiblingAggregationSelection = {
 export type ElementElementChildMapperPreviousSiblingNodeAggregateSelection = {
   __typename?: 'ElementElementChildMapperPreviousSiblingNodeAggregateSelection'
   _compoundName: StringAggregateSelectionNonNullable
-  _compoundRefKey: StringAggregateSelectionNullable
   childMapperPropKey: StringAggregateSelectionNullable
   customCss: StringAggregateSelectionNullable
   guiCss: StringAggregateSelectionNullable
@@ -7888,7 +7789,6 @@ export type ElementElementFirstChildAggregationSelection = {
 export type ElementElementFirstChildNodeAggregateSelection = {
   __typename?: 'ElementElementFirstChildNodeAggregateSelection'
   _compoundName: StringAggregateSelectionNonNullable
-  _compoundRefKey: StringAggregateSelectionNullable
   childMapperPropKey: StringAggregateSelectionNullable
   customCss: StringAggregateSelectionNullable
   guiCss: StringAggregateSelectionNullable
@@ -7906,7 +7806,6 @@ export type ElementElementNextSiblingAggregationSelection = {
 export type ElementElementNextSiblingNodeAggregateSelection = {
   __typename?: 'ElementElementNextSiblingNodeAggregateSelection'
   _compoundName: StringAggregateSelectionNonNullable
-  _compoundRefKey: StringAggregateSelectionNullable
   childMapperPropKey: StringAggregateSelectionNullable
   customCss: StringAggregateSelectionNullable
   guiCss: StringAggregateSelectionNullable
@@ -7924,7 +7823,6 @@ export type ElementElementParentAggregationSelection = {
 export type ElementElementParentNodeAggregateSelection = {
   __typename?: 'ElementElementParentNodeAggregateSelection'
   _compoundName: StringAggregateSelectionNonNullable
-  _compoundRefKey: StringAggregateSelectionNullable
   childMapperPropKey: StringAggregateSelectionNullable
   customCss: StringAggregateSelectionNullable
   guiCss: StringAggregateSelectionNullable
@@ -7942,7 +7840,6 @@ export type ElementElementPrevSiblingAggregationSelection = {
 export type ElementElementPrevSiblingNodeAggregateSelection = {
   __typename?: 'ElementElementPrevSiblingNodeAggregateSelection'
   _compoundName: StringAggregateSelectionNonNullable
-  _compoundRefKey: StringAggregateSelectionNullable
   childMapperPropKey: StringAggregateSelectionNullable
   customCss: StringAggregateSelectionNullable
   guiCss: StringAggregateSelectionNullable
@@ -8036,21 +7933,6 @@ export type ElementFirstChildNodeAggregationWhereInput = {
   _compoundName_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars['Int']['input']>
   _compoundName_SHORTEST_LENGTH_LT?: InputMaybe<Scalars['Int']['input']>
   _compoundName_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars['Int']['input']>
-  _compoundRefKey_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars['Float']['input']>
-  _compoundRefKey_AVERAGE_LENGTH_GT?: InputMaybe<Scalars['Float']['input']>
-  _compoundRefKey_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars['Float']['input']>
-  _compoundRefKey_AVERAGE_LENGTH_LT?: InputMaybe<Scalars['Float']['input']>
-  _compoundRefKey_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars['Float']['input']>
-  _compoundRefKey_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars['Int']['input']>
-  _compoundRefKey_LONGEST_LENGTH_GT?: InputMaybe<Scalars['Int']['input']>
-  _compoundRefKey_LONGEST_LENGTH_GTE?: InputMaybe<Scalars['Int']['input']>
-  _compoundRefKey_LONGEST_LENGTH_LT?: InputMaybe<Scalars['Int']['input']>
-  _compoundRefKey_LONGEST_LENGTH_LTE?: InputMaybe<Scalars['Int']['input']>
-  _compoundRefKey_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars['Int']['input']>
-  _compoundRefKey_SHORTEST_LENGTH_GT?: InputMaybe<Scalars['Int']['input']>
-  _compoundRefKey_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars['Int']['input']>
-  _compoundRefKey_SHORTEST_LENGTH_LT?: InputMaybe<Scalars['Int']['input']>
-  _compoundRefKey_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars['Int']['input']>
   childMapperPropKey_AVERAGE_LENGTH_EQUAL?: InputMaybe<
     Scalars['Float']['input']
   >
@@ -8247,21 +8129,6 @@ export type ElementNextSiblingNodeAggregationWhereInput = {
   _compoundName_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars['Int']['input']>
   _compoundName_SHORTEST_LENGTH_LT?: InputMaybe<Scalars['Int']['input']>
   _compoundName_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars['Int']['input']>
-  _compoundRefKey_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars['Float']['input']>
-  _compoundRefKey_AVERAGE_LENGTH_GT?: InputMaybe<Scalars['Float']['input']>
-  _compoundRefKey_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars['Float']['input']>
-  _compoundRefKey_AVERAGE_LENGTH_LT?: InputMaybe<Scalars['Float']['input']>
-  _compoundRefKey_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars['Float']['input']>
-  _compoundRefKey_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars['Int']['input']>
-  _compoundRefKey_LONGEST_LENGTH_GT?: InputMaybe<Scalars['Int']['input']>
-  _compoundRefKey_LONGEST_LENGTH_GTE?: InputMaybe<Scalars['Int']['input']>
-  _compoundRefKey_LONGEST_LENGTH_LT?: InputMaybe<Scalars['Int']['input']>
-  _compoundRefKey_LONGEST_LENGTH_LTE?: InputMaybe<Scalars['Int']['input']>
-  _compoundRefKey_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars['Int']['input']>
-  _compoundRefKey_SHORTEST_LENGTH_GT?: InputMaybe<Scalars['Int']['input']>
-  _compoundRefKey_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars['Int']['input']>
-  _compoundRefKey_SHORTEST_LENGTH_LT?: InputMaybe<Scalars['Int']['input']>
-  _compoundRefKey_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars['Int']['input']>
   childMapperPropKey_AVERAGE_LENGTH_EQUAL?: InputMaybe<
     Scalars['Float']['input']
   >
@@ -8375,7 +8242,6 @@ export type ElementNextSiblingUpdateFieldInput = {
 
 export type ElementOnCreateInput = {
   _compoundName: Scalars['String']['input']
-  _compoundRefKey?: InputMaybe<Scalars['String']['input']>
   childMapperPropKey?: InputMaybe<Scalars['String']['input']>
   customCss?: InputMaybe<Scalars['String']['input']>
   guiCss?: InputMaybe<Scalars['String']['input']>
@@ -8733,21 +8599,6 @@ export type ElementParentNodeAggregationWhereInput = {
   _compoundName_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars['Int']['input']>
   _compoundName_SHORTEST_LENGTH_LT?: InputMaybe<Scalars['Int']['input']>
   _compoundName_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars['Int']['input']>
-  _compoundRefKey_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars['Float']['input']>
-  _compoundRefKey_AVERAGE_LENGTH_GT?: InputMaybe<Scalars['Float']['input']>
-  _compoundRefKey_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars['Float']['input']>
-  _compoundRefKey_AVERAGE_LENGTH_LT?: InputMaybe<Scalars['Float']['input']>
-  _compoundRefKey_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars['Float']['input']>
-  _compoundRefKey_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars['Int']['input']>
-  _compoundRefKey_LONGEST_LENGTH_GT?: InputMaybe<Scalars['Int']['input']>
-  _compoundRefKey_LONGEST_LENGTH_GTE?: InputMaybe<Scalars['Int']['input']>
-  _compoundRefKey_LONGEST_LENGTH_LT?: InputMaybe<Scalars['Int']['input']>
-  _compoundRefKey_LONGEST_LENGTH_LTE?: InputMaybe<Scalars['Int']['input']>
-  _compoundRefKey_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars['Int']['input']>
-  _compoundRefKey_SHORTEST_LENGTH_GT?: InputMaybe<Scalars['Int']['input']>
-  _compoundRefKey_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars['Int']['input']>
-  _compoundRefKey_SHORTEST_LENGTH_LT?: InputMaybe<Scalars['Int']['input']>
-  _compoundRefKey_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars['Int']['input']>
   childMapperPropKey_AVERAGE_LENGTH_EQUAL?: InputMaybe<
     Scalars['Float']['input']
   >
@@ -9066,21 +8917,6 @@ export type ElementPrevSiblingNodeAggregationWhereInput = {
   _compoundName_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars['Int']['input']>
   _compoundName_SHORTEST_LENGTH_LT?: InputMaybe<Scalars['Int']['input']>
   _compoundName_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars['Int']['input']>
-  _compoundRefKey_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars['Float']['input']>
-  _compoundRefKey_AVERAGE_LENGTH_GT?: InputMaybe<Scalars['Float']['input']>
-  _compoundRefKey_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars['Float']['input']>
-  _compoundRefKey_AVERAGE_LENGTH_LT?: InputMaybe<Scalars['Float']['input']>
-  _compoundRefKey_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars['Float']['input']>
-  _compoundRefKey_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars['Int']['input']>
-  _compoundRefKey_LONGEST_LENGTH_GT?: InputMaybe<Scalars['Int']['input']>
-  _compoundRefKey_LONGEST_LENGTH_GTE?: InputMaybe<Scalars['Int']['input']>
-  _compoundRefKey_LONGEST_LENGTH_LT?: InputMaybe<Scalars['Int']['input']>
-  _compoundRefKey_LONGEST_LENGTH_LTE?: InputMaybe<Scalars['Int']['input']>
-  _compoundRefKey_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars['Int']['input']>
-  _compoundRefKey_SHORTEST_LENGTH_GT?: InputMaybe<Scalars['Int']['input']>
-  _compoundRefKey_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars['Int']['input']>
-  _compoundRefKey_SHORTEST_LENGTH_LT?: InputMaybe<Scalars['Int']['input']>
-  _compoundRefKey_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars['Int']['input']>
   childMapperPropKey_AVERAGE_LENGTH_EQUAL?: InputMaybe<
     Scalars['Float']['input']
   >
@@ -9618,7 +9454,6 @@ export type ElementRenderComponentTypeUpdateFieldInput = {
 /** Fields to sort Elements by. The order in which sorts are applied is not guaranteed when specifying many fields in one ElementSort object. */
 export type ElementSort = {
   _compoundName?: InputMaybe<SortDirection>
-  _compoundRefKey?: InputMaybe<SortDirection>
   childMapperPropKey?: InputMaybe<SortDirection>
   customCss?: InputMaybe<SortDirection>
   guiCss?: InputMaybe<SortDirection>
@@ -9900,13 +9735,11 @@ export type ElementTypesConnection = {
 
 export type ElementUniqueWhere = {
   _compoundName?: InputMaybe<Scalars['String']['input']>
-  _compoundRefKey?: InputMaybe<Scalars['String']['input']>
   id?: InputMaybe<Scalars['ID']['input']>
 }
 
 export type ElementUpdateInput = {
   _compoundName?: InputMaybe<Scalars['String']['input']>
-  _compoundRefKey?: InputMaybe<Scalars['String']['input']>
   childMapperComponent?: InputMaybe<ElementChildMapperComponentUpdateFieldInput>
   childMapperPreviousSibling?: InputMaybe<ElementChildMapperPreviousSiblingUpdateFieldInput>
   childMapperPropKey?: InputMaybe<Scalars['String']['input']>
@@ -9938,12 +9771,6 @@ export type ElementWhere = {
   _compoundName_IN?: InputMaybe<Array<Scalars['String']['input']>>
   _compoundName_MATCHES?: InputMaybe<Scalars['String']['input']>
   _compoundName_STARTS_WITH?: InputMaybe<Scalars['String']['input']>
-  _compoundRefKey?: InputMaybe<Scalars['String']['input']>
-  _compoundRefKey_CONTAINS?: InputMaybe<Scalars['String']['input']>
-  _compoundRefKey_ENDS_WITH?: InputMaybe<Scalars['String']['input']>
-  _compoundRefKey_IN?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>
-  _compoundRefKey_MATCHES?: InputMaybe<Scalars['String']['input']>
-  _compoundRefKey_STARTS_WITH?: InputMaybe<Scalars['String']['input']>
   childMapperComponent?: InputMaybe<ComponentWhere>
   childMapperComponentAggregate?: InputMaybe<ElementChildMapperComponentAggregateInput>
   childMapperComponentConnection?: InputMaybe<ElementChildMapperComponentConnectionWhere>
@@ -12060,7 +11887,6 @@ export type HookElementElementAggregationSelection = {
 export type HookElementElementNodeAggregateSelection = {
   __typename?: 'HookElementElementNodeAggregateSelection'
   _compoundName: StringAggregateSelectionNonNullable
-  _compoundRefKey: StringAggregateSelectionNullable
   childMapperPropKey: StringAggregateSelectionNullable
   customCss: StringAggregateSelectionNullable
   guiCss: StringAggregateSelectionNullable
@@ -12094,21 +11920,6 @@ export type HookElementNodeAggregationWhereInput = {
   _compoundName_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars['Int']['input']>
   _compoundName_SHORTEST_LENGTH_LT?: InputMaybe<Scalars['Int']['input']>
   _compoundName_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars['Int']['input']>
-  _compoundRefKey_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars['Float']['input']>
-  _compoundRefKey_AVERAGE_LENGTH_GT?: InputMaybe<Scalars['Float']['input']>
-  _compoundRefKey_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars['Float']['input']>
-  _compoundRefKey_AVERAGE_LENGTH_LT?: InputMaybe<Scalars['Float']['input']>
-  _compoundRefKey_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars['Float']['input']>
-  _compoundRefKey_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars['Int']['input']>
-  _compoundRefKey_LONGEST_LENGTH_GT?: InputMaybe<Scalars['Int']['input']>
-  _compoundRefKey_LONGEST_LENGTH_GTE?: InputMaybe<Scalars['Int']['input']>
-  _compoundRefKey_LONGEST_LENGTH_LT?: InputMaybe<Scalars['Int']['input']>
-  _compoundRefKey_LONGEST_LENGTH_LTE?: InputMaybe<Scalars['Int']['input']>
-  _compoundRefKey_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars['Int']['input']>
-  _compoundRefKey_SHORTEST_LENGTH_GT?: InputMaybe<Scalars['Int']['input']>
-  _compoundRefKey_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars['Int']['input']>
-  _compoundRefKey_SHORTEST_LENGTH_LT?: InputMaybe<Scalars['Int']['input']>
-  _compoundRefKey_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars['Int']['input']>
   childMapperPropKey_AVERAGE_LENGTH_EQUAL?: InputMaybe<
     Scalars['Float']['input']
   >
@@ -14692,7 +14503,6 @@ export type PageElementPageContentContainerAggregationSelection = {
 export type PageElementPageContentContainerNodeAggregateSelection = {
   __typename?: 'PageElementPageContentContainerNodeAggregateSelection'
   _compoundName: StringAggregateSelectionNonNullable
-  _compoundRefKey: StringAggregateSelectionNullable
   childMapperPropKey: StringAggregateSelectionNullable
   customCss: StringAggregateSelectionNullable
   guiCss: StringAggregateSelectionNullable
@@ -14710,7 +14520,6 @@ export type PageElementRootElementAggregationSelection = {
 export type PageElementRootElementNodeAggregateSelection = {
   __typename?: 'PageElementRootElementNodeAggregateSelection'
   _compoundName: StringAggregateSelectionNonNullable
-  _compoundRefKey: StringAggregateSelectionNullable
   childMapperPropKey: StringAggregateSelectionNullable
   customCss: StringAggregateSelectionNullable
   guiCss: StringAggregateSelectionNullable
@@ -14834,21 +14643,6 @@ export type PagePageContentContainerNodeAggregationWhereInput = {
   _compoundName_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars['Int']['input']>
   _compoundName_SHORTEST_LENGTH_LT?: InputMaybe<Scalars['Int']['input']>
   _compoundName_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars['Int']['input']>
-  _compoundRefKey_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars['Float']['input']>
-  _compoundRefKey_AVERAGE_LENGTH_GT?: InputMaybe<Scalars['Float']['input']>
-  _compoundRefKey_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars['Float']['input']>
-  _compoundRefKey_AVERAGE_LENGTH_LT?: InputMaybe<Scalars['Float']['input']>
-  _compoundRefKey_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars['Float']['input']>
-  _compoundRefKey_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars['Int']['input']>
-  _compoundRefKey_LONGEST_LENGTH_GT?: InputMaybe<Scalars['Int']['input']>
-  _compoundRefKey_LONGEST_LENGTH_GTE?: InputMaybe<Scalars['Int']['input']>
-  _compoundRefKey_LONGEST_LENGTH_LT?: InputMaybe<Scalars['Int']['input']>
-  _compoundRefKey_LONGEST_LENGTH_LTE?: InputMaybe<Scalars['Int']['input']>
-  _compoundRefKey_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars['Int']['input']>
-  _compoundRefKey_SHORTEST_LENGTH_GT?: InputMaybe<Scalars['Int']['input']>
-  _compoundRefKey_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars['Int']['input']>
-  _compoundRefKey_SHORTEST_LENGTH_LT?: InputMaybe<Scalars['Int']['input']>
-  _compoundRefKey_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars['Int']['input']>
   childMapperPropKey_AVERAGE_LENGTH_EQUAL?: InputMaybe<
     Scalars['Float']['input']
   >
@@ -15052,21 +14846,6 @@ export type PageRootElementNodeAggregationWhereInput = {
   _compoundName_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars['Int']['input']>
   _compoundName_SHORTEST_LENGTH_LT?: InputMaybe<Scalars['Int']['input']>
   _compoundName_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars['Int']['input']>
-  _compoundRefKey_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars['Float']['input']>
-  _compoundRefKey_AVERAGE_LENGTH_GT?: InputMaybe<Scalars['Float']['input']>
-  _compoundRefKey_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars['Float']['input']>
-  _compoundRefKey_AVERAGE_LENGTH_LT?: InputMaybe<Scalars['Float']['input']>
-  _compoundRefKey_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars['Float']['input']>
-  _compoundRefKey_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars['Int']['input']>
-  _compoundRefKey_LONGEST_LENGTH_GT?: InputMaybe<Scalars['Int']['input']>
-  _compoundRefKey_LONGEST_LENGTH_GTE?: InputMaybe<Scalars['Int']['input']>
-  _compoundRefKey_LONGEST_LENGTH_LT?: InputMaybe<Scalars['Int']['input']>
-  _compoundRefKey_LONGEST_LENGTH_LTE?: InputMaybe<Scalars['Int']['input']>
-  _compoundRefKey_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars['Int']['input']>
-  _compoundRefKey_SHORTEST_LENGTH_GT?: InputMaybe<Scalars['Int']['input']>
-  _compoundRefKey_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars['Int']['input']>
-  _compoundRefKey_SHORTEST_LENGTH_LT?: InputMaybe<Scalars['Int']['input']>
-  _compoundRefKey_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars['Int']['input']>
   childMapperPropKey_AVERAGE_LENGTH_EQUAL?: InputMaybe<
     Scalars['Float']['input']
   >
@@ -17055,6 +16834,7 @@ export type RenderType = {
   __typename?: 'RenderType'
   id: Scalars['ID']['output']
   kind: RenderTypeKind
+  registerReference?: Maybe<Scalars['Boolean']['output']>
 }
 
 export enum RenderTypeKind {
@@ -21482,7 +21262,6 @@ export type UserElementElementsAggregationSelection = {
 export type UserElementElementsNodeAggregateSelection = {
   __typename?: 'UserElementElementsNodeAggregateSelection'
   _compoundName: StringAggregateSelectionNonNullable
-  _compoundRefKey: StringAggregateSelectionNullable
   childMapperPropKey: StringAggregateSelectionNullable
   customCss: StringAggregateSelectionNullable
   guiCss: StringAggregateSelectionNullable
@@ -21576,21 +21355,6 @@ export type UserElementsNodeAggregationWhereInput = {
   _compoundName_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars['Int']['input']>
   _compoundName_SHORTEST_LENGTH_LT?: InputMaybe<Scalars['Int']['input']>
   _compoundName_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars['Int']['input']>
-  _compoundRefKey_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars['Float']['input']>
-  _compoundRefKey_AVERAGE_LENGTH_GT?: InputMaybe<Scalars['Float']['input']>
-  _compoundRefKey_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars['Float']['input']>
-  _compoundRefKey_AVERAGE_LENGTH_LT?: InputMaybe<Scalars['Float']['input']>
-  _compoundRefKey_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars['Float']['input']>
-  _compoundRefKey_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars['Int']['input']>
-  _compoundRefKey_LONGEST_LENGTH_GT?: InputMaybe<Scalars['Int']['input']>
-  _compoundRefKey_LONGEST_LENGTH_GTE?: InputMaybe<Scalars['Int']['input']>
-  _compoundRefKey_LONGEST_LENGTH_LT?: InputMaybe<Scalars['Int']['input']>
-  _compoundRefKey_LONGEST_LENGTH_LTE?: InputMaybe<Scalars['Int']['input']>
-  _compoundRefKey_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars['Int']['input']>
-  _compoundRefKey_SHORTEST_LENGTH_GT?: InputMaybe<Scalars['Int']['input']>
-  _compoundRefKey_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars['Int']['input']>
-  _compoundRefKey_SHORTEST_LENGTH_LT?: InputMaybe<Scalars['Int']['input']>
-  _compoundRefKey_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars['Int']['input']>
   childMapperPropKey_AVERAGE_LENGTH_EQUAL?: InputMaybe<
     Scalars['Float']['input']
   >
@@ -22398,10 +22162,8 @@ export type ElementFragment = {
   __typename: 'Element'
   id: string
   name: string
-  slug: string
   customCss?: string | null
   guiCss?: string | null
-  refKey?: string | null
   childMapperPropKey?: string | null
   renderForEachPropKey?: string | null
   renderIfExpression?: string | null
@@ -22412,6 +22174,7 @@ export type ElementFragment = {
     __typename?: 'RenderType'
     id: string
     kind: RenderTypeKind
+    registerReference?: boolean | null
   } | null
   prevSibling?: { __typename?: 'Element'; id: string } | null
   nextSibling?: { __typename?: 'Element'; id: string } | null
@@ -22439,7 +22202,6 @@ export type ProductionElementFragment = {
   __typename: 'Element'
   id: string
   name: string
-  slug: string
   customCss?: string | null
   guiCss?: string | null
   childMapperPropKey?: string | null
@@ -22452,6 +22214,7 @@ export type ProductionElementFragment = {
     __typename?: 'RenderType'
     id: string
     kind: RenderTypeKind
+    registerReference?: boolean | null
   } | null
   prevSibling?: { __typename?: 'Element'; id: string } | null
   nextSibling?: { __typename?: 'Element'; id: string } | null

--- a/libs/shared/abstract/codegen/src/types.api.graphql.gen.ts
+++ b/libs/shared/abstract/codegen/src/types.api.graphql.gen.ts
@@ -16834,7 +16834,6 @@ export type RenderType = {
   __typename?: 'RenderType'
   id: Scalars['ID']['output']
   kind: RenderTypeKind
-  registerReference?: Maybe<Scalars['Boolean']['output']>
 }
 
 export enum RenderTypeKind {
@@ -22174,7 +22173,6 @@ export type ElementFragment = {
     __typename?: 'RenderType'
     id: string
     kind: RenderTypeKind
-    registerReference?: boolean | null
   } | null
   prevSibling?: { __typename?: 'Element'; id: string } | null
   nextSibling?: { __typename?: 'Element'; id: string } | null
@@ -22214,7 +22212,6 @@ export type ProductionElementFragment = {
     __typename?: 'RenderType'
     id: string
     kind: RenderTypeKind
-    registerReference?: boolean | null
   } | null
   prevSibling?: { __typename?: 'Element'; id: string } | null
   nextSibling?: { __typename?: 'Element'; id: string } | null

--- a/libs/shared/abstract/core/src/element.dto.interface.ts
+++ b/libs/shared/abstract/core/src/element.dto.interface.ts
@@ -21,7 +21,6 @@ export interface IElementDTO {
   preRenderAction?: Nullable<IEntity>
   prevSibling?: Nullable<IEntity>
   props: IEntity
-  refKey?: Nullable<string>
   renderForEachPropKey?: Nullable<string>
   renderIfExpression?: Nullable<string>
   renderType?: Nullable<RenderType>

--- a/schema.graphql
+++ b/schema.graphql
@@ -547,7 +547,6 @@ type ApiActionElementElementAggregationSelection {
 
 type ApiActionElementElementNodeAggregateSelection {
   _compoundName: StringAggregateSelectionNonNullable!
-  _compoundRefKey: StringAggregateSelectionNullable!
   childMapperPropKey: StringAggregateSelectionNullable!
   customCss: StringAggregateSelectionNullable!
   guiCss: StringAggregateSelectionNullable!
@@ -575,21 +574,6 @@ input ApiActionElementNodeAggregationWhereInput {
   _compoundName_SHORTEST_LENGTH_GTE: Int
   _compoundName_SHORTEST_LENGTH_LT: Int
   _compoundName_SHORTEST_LENGTH_LTE: Int
-  _compoundRefKey_AVERAGE_LENGTH_EQUAL: Float
-  _compoundRefKey_AVERAGE_LENGTH_GT: Float
-  _compoundRefKey_AVERAGE_LENGTH_GTE: Float
-  _compoundRefKey_AVERAGE_LENGTH_LT: Float
-  _compoundRefKey_AVERAGE_LENGTH_LTE: Float
-  _compoundRefKey_LONGEST_LENGTH_EQUAL: Int
-  _compoundRefKey_LONGEST_LENGTH_GT: Int
-  _compoundRefKey_LONGEST_LENGTH_GTE: Int
-  _compoundRefKey_LONGEST_LENGTH_LT: Int
-  _compoundRefKey_LONGEST_LENGTH_LTE: Int
-  _compoundRefKey_SHORTEST_LENGTH_EQUAL: Int
-  _compoundRefKey_SHORTEST_LENGTH_GT: Int
-  _compoundRefKey_SHORTEST_LENGTH_GTE: Int
-  _compoundRefKey_SHORTEST_LENGTH_LT: Int
-  _compoundRefKey_SHORTEST_LENGTH_LTE: Int
   childMapperPropKey_AVERAGE_LENGTH_EQUAL: Float
   childMapperPropKey_AVERAGE_LENGTH_GT: Float
   childMapperPropKey_AVERAGE_LENGTH_GTE: Float
@@ -4168,21 +4152,6 @@ input BaseActionElementNodeAggregationWhereInput {
   _compoundName_SHORTEST_LENGTH_GTE: Int
   _compoundName_SHORTEST_LENGTH_LT: Int
   _compoundName_SHORTEST_LENGTH_LTE: Int
-  _compoundRefKey_AVERAGE_LENGTH_EQUAL: Float
-  _compoundRefKey_AVERAGE_LENGTH_GT: Float
-  _compoundRefKey_AVERAGE_LENGTH_GTE: Float
-  _compoundRefKey_AVERAGE_LENGTH_LT: Float
-  _compoundRefKey_AVERAGE_LENGTH_LTE: Float
-  _compoundRefKey_LONGEST_LENGTH_EQUAL: Int
-  _compoundRefKey_LONGEST_LENGTH_GT: Int
-  _compoundRefKey_LONGEST_LENGTH_GTE: Int
-  _compoundRefKey_LONGEST_LENGTH_LT: Int
-  _compoundRefKey_LONGEST_LENGTH_LTE: Int
-  _compoundRefKey_SHORTEST_LENGTH_EQUAL: Int
-  _compoundRefKey_SHORTEST_LENGTH_GT: Int
-  _compoundRefKey_SHORTEST_LENGTH_GTE: Int
-  _compoundRefKey_SHORTEST_LENGTH_LT: Int
-  _compoundRefKey_SHORTEST_LENGTH_LTE: Int
   childMapperPropKey_AVERAGE_LENGTH_EQUAL: Float
   childMapperPropKey_AVERAGE_LENGTH_GT: Float
   childMapperPropKey_AVERAGE_LENGTH_GTE: Float
@@ -4762,7 +4731,6 @@ type CodeActionElementElementAggregationSelection {
 
 type CodeActionElementElementNodeAggregateSelection {
   _compoundName: StringAggregateSelectionNonNullable!
-  _compoundRefKey: StringAggregateSelectionNullable!
   childMapperPropKey: StringAggregateSelectionNullable!
   customCss: StringAggregateSelectionNullable!
   guiCss: StringAggregateSelectionNullable!
@@ -4790,21 +4758,6 @@ input CodeActionElementNodeAggregationWhereInput {
   _compoundName_SHORTEST_LENGTH_GTE: Int
   _compoundName_SHORTEST_LENGTH_LT: Int
   _compoundName_SHORTEST_LENGTH_LTE: Int
-  _compoundRefKey_AVERAGE_LENGTH_EQUAL: Float
-  _compoundRefKey_AVERAGE_LENGTH_GT: Float
-  _compoundRefKey_AVERAGE_LENGTH_GTE: Float
-  _compoundRefKey_AVERAGE_LENGTH_LT: Float
-  _compoundRefKey_AVERAGE_LENGTH_LTE: Float
-  _compoundRefKey_LONGEST_LENGTH_EQUAL: Int
-  _compoundRefKey_LONGEST_LENGTH_GT: Int
-  _compoundRefKey_LONGEST_LENGTH_GTE: Int
-  _compoundRefKey_LONGEST_LENGTH_LT: Int
-  _compoundRefKey_LONGEST_LENGTH_LTE: Int
-  _compoundRefKey_SHORTEST_LENGTH_EQUAL: Int
-  _compoundRefKey_SHORTEST_LENGTH_GT: Int
-  _compoundRefKey_SHORTEST_LENGTH_GTE: Int
-  _compoundRefKey_SHORTEST_LENGTH_LT: Int
-  _compoundRefKey_SHORTEST_LENGTH_LTE: Int
   childMapperPropKey_AVERAGE_LENGTH_EQUAL: Float
   childMapperPropKey_AVERAGE_LENGTH_GT: Float
   childMapperPropKey_AVERAGE_LENGTH_GTE: Float
@@ -5531,21 +5484,6 @@ input ComponentChildrenContainerElementNodeAggregationWhereInput {
   _compoundName_SHORTEST_LENGTH_GTE: Int
   _compoundName_SHORTEST_LENGTH_LT: Int
   _compoundName_SHORTEST_LENGTH_LTE: Int
-  _compoundRefKey_AVERAGE_LENGTH_EQUAL: Float
-  _compoundRefKey_AVERAGE_LENGTH_GT: Float
-  _compoundRefKey_AVERAGE_LENGTH_GTE: Float
-  _compoundRefKey_AVERAGE_LENGTH_LT: Float
-  _compoundRefKey_AVERAGE_LENGTH_LTE: Float
-  _compoundRefKey_LONGEST_LENGTH_EQUAL: Int
-  _compoundRefKey_LONGEST_LENGTH_GT: Int
-  _compoundRefKey_LONGEST_LENGTH_GTE: Int
-  _compoundRefKey_LONGEST_LENGTH_LT: Int
-  _compoundRefKey_LONGEST_LENGTH_LTE: Int
-  _compoundRefKey_SHORTEST_LENGTH_EQUAL: Int
-  _compoundRefKey_SHORTEST_LENGTH_GT: Int
-  _compoundRefKey_SHORTEST_LENGTH_GTE: Int
-  _compoundRefKey_SHORTEST_LENGTH_LT: Int
-  _compoundRefKey_SHORTEST_LENGTH_LTE: Int
   childMapperPropKey_AVERAGE_LENGTH_EQUAL: Float
   childMapperPropKey_AVERAGE_LENGTH_GT: Float
   childMapperPropKey_AVERAGE_LENGTH_GTE: Float
@@ -5710,7 +5648,6 @@ type ComponentElementChildrenContainerElementAggregationSelection {
 
 type ComponentElementChildrenContainerElementNodeAggregateSelection {
   _compoundName: StringAggregateSelectionNonNullable!
-  _compoundRefKey: StringAggregateSelectionNullable!
   childMapperPropKey: StringAggregateSelectionNullable!
   customCss: StringAggregateSelectionNullable!
   guiCss: StringAggregateSelectionNullable!
@@ -5726,7 +5663,6 @@ type ComponentElementRootElementAggregationSelection {
 
 type ComponentElementRootElementNodeAggregateSelection {
   _compoundName: StringAggregateSelectionNonNullable!
-  _compoundRefKey: StringAggregateSelectionNullable!
   childMapperPropKey: StringAggregateSelectionNullable!
   customCss: StringAggregateSelectionNullable!
   guiCss: StringAggregateSelectionNullable!
@@ -6034,21 +5970,6 @@ input ComponentRootElementNodeAggregationWhereInput {
   _compoundName_SHORTEST_LENGTH_GTE: Int
   _compoundName_SHORTEST_LENGTH_LT: Int
   _compoundName_SHORTEST_LENGTH_LTE: Int
-  _compoundRefKey_AVERAGE_LENGTH_EQUAL: Float
-  _compoundRefKey_AVERAGE_LENGTH_GT: Float
-  _compoundRefKey_AVERAGE_LENGTH_GTE: Float
-  _compoundRefKey_AVERAGE_LENGTH_LT: Float
-  _compoundRefKey_AVERAGE_LENGTH_LTE: Float
-  _compoundRefKey_LONGEST_LENGTH_EQUAL: Int
-  _compoundRefKey_LONGEST_LENGTH_GT: Int
-  _compoundRefKey_LONGEST_LENGTH_GTE: Int
-  _compoundRefKey_LONGEST_LENGTH_LT: Int
-  _compoundRefKey_LONGEST_LENGTH_LTE: Int
-  _compoundRefKey_SHORTEST_LENGTH_EQUAL: Int
-  _compoundRefKey_SHORTEST_LENGTH_GT: Int
-  _compoundRefKey_SHORTEST_LENGTH_GTE: Int
-  _compoundRefKey_SHORTEST_LENGTH_LT: Int
-  _compoundRefKey_SHORTEST_LENGTH_LTE: Int
   childMapperPropKey_AVERAGE_LENGTH_EQUAL: Float
   childMapperPropKey_AVERAGE_LENGTH_GT: Float
   childMapperPropKey_AVERAGE_LENGTH_GTE: Float
@@ -6773,7 +6694,6 @@ type DomainsConnection {
 
 type Element {
   _compoundName: String!
-  _compoundRefKey: String
   childMapperComponent(
     directed: Boolean = true
     options: ComponentOptions
@@ -6940,7 +6860,6 @@ type Element {
     sort: [ElementPropsConnectionSort!]
     where: ElementPropsConnectionWhere
   ): ElementPropsConnection!
-  refKey: String
   renderAtomType(
     directed: Boolean = true
     options: AtomOptions
@@ -6981,7 +6900,6 @@ type Element {
 
 type ElementAggregateSelection {
   _compoundName: StringAggregateSelectionNonNullable!
-  _compoundRefKey: StringAggregateSelectionNullable!
   childMapperPropKey: StringAggregateSelectionNullable!
   count: Int!
   customCss: StringAggregateSelectionNullable!
@@ -7215,21 +7133,6 @@ input ElementChildMapperPreviousSiblingNodeAggregationWhereInput {
   _compoundName_SHORTEST_LENGTH_GTE: Int
   _compoundName_SHORTEST_LENGTH_LT: Int
   _compoundName_SHORTEST_LENGTH_LTE: Int
-  _compoundRefKey_AVERAGE_LENGTH_EQUAL: Float
-  _compoundRefKey_AVERAGE_LENGTH_GT: Float
-  _compoundRefKey_AVERAGE_LENGTH_GTE: Float
-  _compoundRefKey_AVERAGE_LENGTH_LT: Float
-  _compoundRefKey_AVERAGE_LENGTH_LTE: Float
-  _compoundRefKey_LONGEST_LENGTH_EQUAL: Int
-  _compoundRefKey_LONGEST_LENGTH_GT: Int
-  _compoundRefKey_LONGEST_LENGTH_GTE: Int
-  _compoundRefKey_LONGEST_LENGTH_LT: Int
-  _compoundRefKey_LONGEST_LENGTH_LTE: Int
-  _compoundRefKey_SHORTEST_LENGTH_EQUAL: Int
-  _compoundRefKey_SHORTEST_LENGTH_GT: Int
-  _compoundRefKey_SHORTEST_LENGTH_GTE: Int
-  _compoundRefKey_SHORTEST_LENGTH_LT: Int
-  _compoundRefKey_SHORTEST_LENGTH_LTE: Int
   childMapperPropKey_AVERAGE_LENGTH_EQUAL: Float
   childMapperPropKey_AVERAGE_LENGTH_GT: Float
   childMapperPropKey_AVERAGE_LENGTH_GTE: Float
@@ -7399,7 +7302,6 @@ input ElementConnectWhere {
 
 input ElementCreateInput {
   _compoundName: String!
-  _compoundRefKey: String
   childMapperComponent: ElementChildMapperComponentFieldInput
   childMapperPreviousSibling: ElementChildMapperPreviousSiblingFieldInput
   childMapperPropKey: String
@@ -7465,7 +7367,6 @@ type ElementElementChildMapperPreviousSiblingAggregationSelection {
 
 type ElementElementChildMapperPreviousSiblingNodeAggregateSelection {
   _compoundName: StringAggregateSelectionNonNullable!
-  _compoundRefKey: StringAggregateSelectionNullable!
   childMapperPropKey: StringAggregateSelectionNullable!
   customCss: StringAggregateSelectionNullable!
   guiCss: StringAggregateSelectionNullable!
@@ -7481,7 +7382,6 @@ type ElementElementFirstChildAggregationSelection {
 
 type ElementElementFirstChildNodeAggregateSelection {
   _compoundName: StringAggregateSelectionNonNullable!
-  _compoundRefKey: StringAggregateSelectionNullable!
   childMapperPropKey: StringAggregateSelectionNullable!
   customCss: StringAggregateSelectionNullable!
   guiCss: StringAggregateSelectionNullable!
@@ -7497,7 +7397,6 @@ type ElementElementNextSiblingAggregationSelection {
 
 type ElementElementNextSiblingNodeAggregateSelection {
   _compoundName: StringAggregateSelectionNonNullable!
-  _compoundRefKey: StringAggregateSelectionNullable!
   childMapperPropKey: StringAggregateSelectionNullable!
   customCss: StringAggregateSelectionNullable!
   guiCss: StringAggregateSelectionNullable!
@@ -7513,7 +7412,6 @@ type ElementElementParentAggregationSelection {
 
 type ElementElementParentNodeAggregateSelection {
   _compoundName: StringAggregateSelectionNonNullable!
-  _compoundRefKey: StringAggregateSelectionNullable!
   childMapperPropKey: StringAggregateSelectionNullable!
   customCss: StringAggregateSelectionNullable!
   guiCss: StringAggregateSelectionNullable!
@@ -7529,7 +7427,6 @@ type ElementElementPrevSiblingAggregationSelection {
 
 type ElementElementPrevSiblingNodeAggregateSelection {
   _compoundName: StringAggregateSelectionNonNullable!
-  _compoundRefKey: StringAggregateSelectionNullable!
   childMapperPropKey: StringAggregateSelectionNullable!
   customCss: StringAggregateSelectionNullable!
   guiCss: StringAggregateSelectionNullable!
@@ -7625,21 +7522,6 @@ input ElementFirstChildNodeAggregationWhereInput {
   _compoundName_SHORTEST_LENGTH_GTE: Int
   _compoundName_SHORTEST_LENGTH_LT: Int
   _compoundName_SHORTEST_LENGTH_LTE: Int
-  _compoundRefKey_AVERAGE_LENGTH_EQUAL: Float
-  _compoundRefKey_AVERAGE_LENGTH_GT: Float
-  _compoundRefKey_AVERAGE_LENGTH_GTE: Float
-  _compoundRefKey_AVERAGE_LENGTH_LT: Float
-  _compoundRefKey_AVERAGE_LENGTH_LTE: Float
-  _compoundRefKey_LONGEST_LENGTH_EQUAL: Int
-  _compoundRefKey_LONGEST_LENGTH_GT: Int
-  _compoundRefKey_LONGEST_LENGTH_GTE: Int
-  _compoundRefKey_LONGEST_LENGTH_LT: Int
-  _compoundRefKey_LONGEST_LENGTH_LTE: Int
-  _compoundRefKey_SHORTEST_LENGTH_EQUAL: Int
-  _compoundRefKey_SHORTEST_LENGTH_GT: Int
-  _compoundRefKey_SHORTEST_LENGTH_GTE: Int
-  _compoundRefKey_SHORTEST_LENGTH_LT: Int
-  _compoundRefKey_SHORTEST_LENGTH_LTE: Int
   childMapperPropKey_AVERAGE_LENGTH_EQUAL: Float
   childMapperPropKey_AVERAGE_LENGTH_GT: Float
   childMapperPropKey_AVERAGE_LENGTH_GTE: Float
@@ -7823,21 +7705,6 @@ input ElementNextSiblingNodeAggregationWhereInput {
   _compoundName_SHORTEST_LENGTH_GTE: Int
   _compoundName_SHORTEST_LENGTH_LT: Int
   _compoundName_SHORTEST_LENGTH_LTE: Int
-  _compoundRefKey_AVERAGE_LENGTH_EQUAL: Float
-  _compoundRefKey_AVERAGE_LENGTH_GT: Float
-  _compoundRefKey_AVERAGE_LENGTH_GTE: Float
-  _compoundRefKey_AVERAGE_LENGTH_LT: Float
-  _compoundRefKey_AVERAGE_LENGTH_LTE: Float
-  _compoundRefKey_LONGEST_LENGTH_EQUAL: Int
-  _compoundRefKey_LONGEST_LENGTH_GT: Int
-  _compoundRefKey_LONGEST_LENGTH_GTE: Int
-  _compoundRefKey_LONGEST_LENGTH_LT: Int
-  _compoundRefKey_LONGEST_LENGTH_LTE: Int
-  _compoundRefKey_SHORTEST_LENGTH_EQUAL: Int
-  _compoundRefKey_SHORTEST_LENGTH_GT: Int
-  _compoundRefKey_SHORTEST_LENGTH_GTE: Int
-  _compoundRefKey_SHORTEST_LENGTH_LT: Int
-  _compoundRefKey_SHORTEST_LENGTH_LTE: Int
   childMapperPropKey_AVERAGE_LENGTH_EQUAL: Float
   childMapperPropKey_AVERAGE_LENGTH_GT: Float
   childMapperPropKey_AVERAGE_LENGTH_GTE: Float
@@ -7936,7 +7803,6 @@ input ElementNextSiblingUpdateFieldInput {
 
 input ElementOnCreateInput {
   _compoundName: String!
-  _compoundRefKey: String
   childMapperPropKey: String
   customCss: String
   guiCss: String
@@ -8299,21 +8165,6 @@ input ElementParentNodeAggregationWhereInput {
   _compoundName_SHORTEST_LENGTH_GTE: Int
   _compoundName_SHORTEST_LENGTH_LT: Int
   _compoundName_SHORTEST_LENGTH_LTE: Int
-  _compoundRefKey_AVERAGE_LENGTH_EQUAL: Float
-  _compoundRefKey_AVERAGE_LENGTH_GT: Float
-  _compoundRefKey_AVERAGE_LENGTH_GTE: Float
-  _compoundRefKey_AVERAGE_LENGTH_LT: Float
-  _compoundRefKey_AVERAGE_LENGTH_LTE: Float
-  _compoundRefKey_LONGEST_LENGTH_EQUAL: Int
-  _compoundRefKey_LONGEST_LENGTH_GT: Int
-  _compoundRefKey_LONGEST_LENGTH_GTE: Int
-  _compoundRefKey_LONGEST_LENGTH_LT: Int
-  _compoundRefKey_LONGEST_LENGTH_LTE: Int
-  _compoundRefKey_SHORTEST_LENGTH_EQUAL: Int
-  _compoundRefKey_SHORTEST_LENGTH_GT: Int
-  _compoundRefKey_SHORTEST_LENGTH_GTE: Int
-  _compoundRefKey_SHORTEST_LENGTH_LT: Int
-  _compoundRefKey_SHORTEST_LENGTH_LTE: Int
   childMapperPropKey_AVERAGE_LENGTH_EQUAL: Float
   childMapperPropKey_AVERAGE_LENGTH_GT: Float
   childMapperPropKey_AVERAGE_LENGTH_GTE: Float
@@ -8615,21 +8466,6 @@ input ElementPrevSiblingNodeAggregationWhereInput {
   _compoundName_SHORTEST_LENGTH_GTE: Int
   _compoundName_SHORTEST_LENGTH_LT: Int
   _compoundName_SHORTEST_LENGTH_LTE: Int
-  _compoundRefKey_AVERAGE_LENGTH_EQUAL: Float
-  _compoundRefKey_AVERAGE_LENGTH_GT: Float
-  _compoundRefKey_AVERAGE_LENGTH_GTE: Float
-  _compoundRefKey_AVERAGE_LENGTH_LT: Float
-  _compoundRefKey_AVERAGE_LENGTH_LTE: Float
-  _compoundRefKey_LONGEST_LENGTH_EQUAL: Int
-  _compoundRefKey_LONGEST_LENGTH_GT: Int
-  _compoundRefKey_LONGEST_LENGTH_GTE: Int
-  _compoundRefKey_LONGEST_LENGTH_LT: Int
-  _compoundRefKey_LONGEST_LENGTH_LTE: Int
-  _compoundRefKey_SHORTEST_LENGTH_EQUAL: Int
-  _compoundRefKey_SHORTEST_LENGTH_GT: Int
-  _compoundRefKey_SHORTEST_LENGTH_GTE: Int
-  _compoundRefKey_SHORTEST_LENGTH_LT: Int
-  _compoundRefKey_SHORTEST_LENGTH_LTE: Int
   childMapperPropKey_AVERAGE_LENGTH_EQUAL: Float
   childMapperPropKey_AVERAGE_LENGTH_GT: Float
   childMapperPropKey_AVERAGE_LENGTH_GTE: Float
@@ -9152,7 +8988,6 @@ Fields to sort Elements by. The order in which sorts are applied is not guarante
 """
 input ElementSort {
   _compoundName: SortDirection
-  _compoundRefKey: SortDirection
   childMapperPropKey: SortDirection
   customCss: SortDirection
   guiCss: SortDirection
@@ -9395,13 +9230,11 @@ type ElementTypesConnection {
 
 input ElementUniqueWhere {
   _compoundName: String
-  _compoundRefKey: String
   id: ID
 }
 
 input ElementUpdateInput {
   _compoundName: String
-  _compoundRefKey: String
   childMapperComponent: ElementChildMapperComponentUpdateFieldInput
   childMapperPreviousSibling: ElementChildMapperPreviousSiblingUpdateFieldInput
   childMapperPropKey: String
@@ -9433,12 +9266,6 @@ input ElementWhere {
   _compoundName_IN: [String!]
   _compoundName_MATCHES: String
   _compoundName_STARTS_WITH: String
-  _compoundRefKey: String
-  _compoundRefKey_CONTAINS: String
-  _compoundRefKey_ENDS_WITH: String
-  _compoundRefKey_IN: [String]
-  _compoundRefKey_MATCHES: String
-  _compoundRefKey_STARTS_WITH: String
   childMapperComponent: ComponentWhere
   childMapperComponentAggregate: ElementChildMapperComponentAggregateInput
   childMapperComponentConnection: ElementChildMapperComponentConnectionWhere
@@ -11480,7 +11307,6 @@ type HookElementElementAggregationSelection {
 
 type HookElementElementNodeAggregateSelection {
   _compoundName: StringAggregateSelectionNonNullable!
-  _compoundRefKey: StringAggregateSelectionNullable!
   childMapperPropKey: StringAggregateSelectionNullable!
   customCss: StringAggregateSelectionNullable!
   guiCss: StringAggregateSelectionNullable!
@@ -11514,21 +11340,6 @@ input HookElementNodeAggregationWhereInput {
   _compoundName_SHORTEST_LENGTH_GTE: Int
   _compoundName_SHORTEST_LENGTH_LT: Int
   _compoundName_SHORTEST_LENGTH_LTE: Int
-  _compoundRefKey_AVERAGE_LENGTH_EQUAL: Float
-  _compoundRefKey_AVERAGE_LENGTH_GT: Float
-  _compoundRefKey_AVERAGE_LENGTH_GTE: Float
-  _compoundRefKey_AVERAGE_LENGTH_LT: Float
-  _compoundRefKey_AVERAGE_LENGTH_LTE: Float
-  _compoundRefKey_LONGEST_LENGTH_EQUAL: Int
-  _compoundRefKey_LONGEST_LENGTH_GT: Int
-  _compoundRefKey_LONGEST_LENGTH_GTE: Int
-  _compoundRefKey_LONGEST_LENGTH_LT: Int
-  _compoundRefKey_LONGEST_LENGTH_LTE: Int
-  _compoundRefKey_SHORTEST_LENGTH_EQUAL: Int
-  _compoundRefKey_SHORTEST_LENGTH_GT: Int
-  _compoundRefKey_SHORTEST_LENGTH_GTE: Int
-  _compoundRefKey_SHORTEST_LENGTH_LT: Int
-  _compoundRefKey_SHORTEST_LENGTH_LTE: Int
   childMapperPropKey_AVERAGE_LENGTH_EQUAL: Float
   childMapperPropKey_AVERAGE_LENGTH_GT: Float
   childMapperPropKey_AVERAGE_LENGTH_GTE: Float
@@ -13822,7 +13633,6 @@ type PageElementPageContentContainerAggregationSelection {
 
 type PageElementPageContentContainerNodeAggregateSelection {
   _compoundName: StringAggregateSelectionNonNullable!
-  _compoundRefKey: StringAggregateSelectionNullable!
   childMapperPropKey: StringAggregateSelectionNullable!
   customCss: StringAggregateSelectionNullable!
   guiCss: StringAggregateSelectionNullable!
@@ -13838,7 +13648,6 @@ type PageElementRootElementAggregationSelection {
 
 type PageElementRootElementNodeAggregateSelection {
   _compoundName: StringAggregateSelectionNonNullable!
-  _compoundRefKey: StringAggregateSelectionNullable!
   childMapperPropKey: StringAggregateSelectionNullable!
   customCss: StringAggregateSelectionNullable!
   guiCss: StringAggregateSelectionNullable!
@@ -13968,21 +13777,6 @@ input PagePageContentContainerNodeAggregationWhereInput {
   _compoundName_SHORTEST_LENGTH_GTE: Int
   _compoundName_SHORTEST_LENGTH_LT: Int
   _compoundName_SHORTEST_LENGTH_LTE: Int
-  _compoundRefKey_AVERAGE_LENGTH_EQUAL: Float
-  _compoundRefKey_AVERAGE_LENGTH_GT: Float
-  _compoundRefKey_AVERAGE_LENGTH_GTE: Float
-  _compoundRefKey_AVERAGE_LENGTH_LT: Float
-  _compoundRefKey_AVERAGE_LENGTH_LTE: Float
-  _compoundRefKey_LONGEST_LENGTH_EQUAL: Int
-  _compoundRefKey_LONGEST_LENGTH_GT: Int
-  _compoundRefKey_LONGEST_LENGTH_GTE: Int
-  _compoundRefKey_LONGEST_LENGTH_LT: Int
-  _compoundRefKey_LONGEST_LENGTH_LTE: Int
-  _compoundRefKey_SHORTEST_LENGTH_EQUAL: Int
-  _compoundRefKey_SHORTEST_LENGTH_GT: Int
-  _compoundRefKey_SHORTEST_LENGTH_GTE: Int
-  _compoundRefKey_SHORTEST_LENGTH_LT: Int
-  _compoundRefKey_SHORTEST_LENGTH_LTE: Int
   childMapperPropKey_AVERAGE_LENGTH_EQUAL: Float
   childMapperPropKey_AVERAGE_LENGTH_GT: Float
   childMapperPropKey_AVERAGE_LENGTH_GTE: Float
@@ -14173,21 +13967,6 @@ input PageRootElementNodeAggregationWhereInput {
   _compoundName_SHORTEST_LENGTH_GTE: Int
   _compoundName_SHORTEST_LENGTH_LT: Int
   _compoundName_SHORTEST_LENGTH_LTE: Int
-  _compoundRefKey_AVERAGE_LENGTH_EQUAL: Float
-  _compoundRefKey_AVERAGE_LENGTH_GT: Float
-  _compoundRefKey_AVERAGE_LENGTH_GTE: Float
-  _compoundRefKey_AVERAGE_LENGTH_LT: Float
-  _compoundRefKey_AVERAGE_LENGTH_LTE: Float
-  _compoundRefKey_LONGEST_LENGTH_EQUAL: Int
-  _compoundRefKey_LONGEST_LENGTH_GT: Int
-  _compoundRefKey_LONGEST_LENGTH_GTE: Int
-  _compoundRefKey_LONGEST_LENGTH_LT: Int
-  _compoundRefKey_LONGEST_LENGTH_LTE: Int
-  _compoundRefKey_SHORTEST_LENGTH_EQUAL: Int
-  _compoundRefKey_SHORTEST_LENGTH_GT: Int
-  _compoundRefKey_SHORTEST_LENGTH_GTE: Int
-  _compoundRefKey_SHORTEST_LENGTH_LT: Int
-  _compoundRefKey_SHORTEST_LENGTH_LTE: Int
   childMapperPropKey_AVERAGE_LENGTH_EQUAL: Float
   childMapperPropKey_AVERAGE_LENGTH_GT: Float
   childMapperPropKey_AVERAGE_LENGTH_GTE: Float
@@ -15753,6 +15532,7 @@ type RenderPropTypesConnection {
 type RenderType {
   id: ID!
   kind: RenderTypeKind!
+  registerReference: Boolean
 }
 
 enum RenderTypeKind {
@@ -19717,7 +19497,6 @@ type UserElementElementsAggregationSelection {
 
 type UserElementElementsNodeAggregateSelection {
   _compoundName: StringAggregateSelectionNonNullable!
-  _compoundRefKey: StringAggregateSelectionNullable!
   childMapperPropKey: StringAggregateSelectionNullable!
   customCss: StringAggregateSelectionNullable!
   guiCss: StringAggregateSelectionNullable!
@@ -19813,21 +19592,6 @@ input UserElementsNodeAggregationWhereInput {
   _compoundName_SHORTEST_LENGTH_GTE: Int
   _compoundName_SHORTEST_LENGTH_LT: Int
   _compoundName_SHORTEST_LENGTH_LTE: Int
-  _compoundRefKey_AVERAGE_LENGTH_EQUAL: Float
-  _compoundRefKey_AVERAGE_LENGTH_GT: Float
-  _compoundRefKey_AVERAGE_LENGTH_GTE: Float
-  _compoundRefKey_AVERAGE_LENGTH_LT: Float
-  _compoundRefKey_AVERAGE_LENGTH_LTE: Float
-  _compoundRefKey_LONGEST_LENGTH_EQUAL: Int
-  _compoundRefKey_LONGEST_LENGTH_GT: Int
-  _compoundRefKey_LONGEST_LENGTH_GTE: Int
-  _compoundRefKey_LONGEST_LENGTH_LT: Int
-  _compoundRefKey_LONGEST_LENGTH_LTE: Int
-  _compoundRefKey_SHORTEST_LENGTH_EQUAL: Int
-  _compoundRefKey_SHORTEST_LENGTH_GT: Int
-  _compoundRefKey_SHORTEST_LENGTH_GTE: Int
-  _compoundRefKey_SHORTEST_LENGTH_LT: Int
-  _compoundRefKey_SHORTEST_LENGTH_LTE: Int
   childMapperPropKey_AVERAGE_LENGTH_EQUAL: Float
   childMapperPropKey_AVERAGE_LENGTH_GT: Float
   childMapperPropKey_AVERAGE_LENGTH_GTE: Float

--- a/schema.graphql
+++ b/schema.graphql
@@ -15532,7 +15532,6 @@ type RenderPropTypesConnection {
 type RenderType {
   id: ID!
   kind: RenderTypeKind!
-  registerReference: Boolean
 }
 
 enum RenderTypeKind {


### PR DESCRIPTION
<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(libs-ui-component): must begin with lowercase` -->

## Description

<!-- This is a short description on the Pull Request -->
- Remove `element.refKey` and use `element.slug` instead
## Video or Image

<!-- Add video or image showing how the new feature works -->

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged -->

Fixes #2968 
