### PR TITLE
fix: exclude parent actions from select box

### DIFF
--- a/libs/frontend/domain/store/src/use-cases/actions/update-action/UpdateActionForm.tsx
+++ b/libs/frontend/domain/store/src/use-cases/actions/update-action/UpdateActionForm.tsx
@@ -103,9 +103,16 @@ export const UpdateActionForm = observer(
               name="resourceId"
               resourceService={resourceService}
             />
-            {/** TODO: Exclude current action */}
-            <AutoField component={SelectAction} name="successActionId" />
-            <AutoField component={SelectAction} name="errorActionId" />
+            <AutoField
+              component={SelectAction}
+              name="successActionId"
+              updatedAction={{ id: actionToUpdate.id }}
+            />
+            <AutoField
+              component={SelectAction}
+              name="errorActionId"
+              updatedAction={{ id: actionToUpdate.id }}
+            />
 
             {/** GraphQL Config Form */}
             <DisplayIfField<IUpdateActionData>

--- a/libs/frontend/domain/store/src/use-cases/actions/update-action/UpdateActionModal.tsx
+++ b/libs/frontend/domain/store/src/use-cases/actions/update-action/UpdateActionModal.tsx
@@ -84,9 +84,16 @@ export const UpdateActionModal = observer(() => {
               name="resourceId"
               resourceService={resourceService}
             />
-            {/** TODO: Exclude current action */}
-            <AutoField component={SelectAction} name="successActionId" />
-            <AutoField component={SelectAction} name="errorActionId" />
+            <AutoField
+              component={SelectAction}
+              name="successActionId"
+              updatedAction={{ id: actionToUpdate.id }}
+            />
+            <AutoField
+              component={SelectAction}
+              name="errorActionId"
+              updatedAction={{ id: actionToUpdate.id }}
+            />
 
             {/** GraphQL Config Form */}
             <DisplayIfField<IUpdateActionData>

--- a/libs/frontend/domain/type/src/interface-form/fields/select-action/SelectAction.tsx
+++ b/libs/frontend/domain/type/src/interface-form/fields/select-action/SelectAction.tsx
@@ -1,7 +1,13 @@
 /* eslint-disable react/jsx-props-no-spreading */
+import type { IAction } from '@codelab/frontend/abstract/core'
 import { isElementPageNodeRef } from '@codelab/frontend/abstract/core'
 import { useStore } from '@codelab/frontend/presentation/container'
-import type { UniformSelectFieldProps } from '@codelab/shared/abstract/types'
+import { IActionKind } from '@codelab/shared/abstract/core'
+import type {
+  IEntity,
+  UniformSelectFieldProps,
+} from '@codelab/shared/abstract/types'
+import uniq from 'lodash/uniq'
 import React from 'react'
 import { SelectField } from 'uniforms-antd'
 
@@ -9,25 +15,60 @@ export type SelectActionProps = Pick<
   UniformSelectFieldProps,
   'error' | 'label' | 'name' | 'required' | 'value'
 > & {
-  onChange(value: unknown): void
+  updatedAction?: IEntity
+}
+
+const getParentActions = (
+  actions: Array<IAction>,
+  action: IAction,
+): Array<string> => {
+  const parents = actions.filter(
+    (parent) =>
+      parent.type === IActionKind.ApiAction &&
+      (parent.successAction?.id === action.id ||
+        parent.errorAction?.id === action.id),
+  )
+
+  return (
+    parents
+      .map((parent) => parent.id)
+      // get parents of parents
+      .concat(
+        uniq(parents.flatMap((parent) => getParentActions(actions, parent))),
+      )
+  )
 }
 
 export const SelectAction = (fieldProps: SelectActionProps) => {
   const { actionService, builderService } = useStore()
   const selectedNode = builderService.selectedNode
+
+  const updatedAction = fieldProps.updatedAction
+    ? actionService.action(fieldProps.updatedAction.id)
+    : null
+
   const store = selectedNode?.current.store.current
 
   const providerStore = isElementPageNodeRef(selectedNode)
     ? selectedNode.current.providerStore?.current
     : undefined
 
-  const actions = store
-    ? actionService.actionsList.filter((action) => {
-        return (
-          action.store.id === store.id || action.store.id === providerStore?.id
-        )
-      })
-    : actionService.actionsList
+  const parentActions = updatedAction
+    ? getParentActions(actionService.actionsList, updatedAction)
+    : []
+
+  const actions = actionService.actionsList.filter((action) => {
+    const belongsToStore =
+      action.store.id === store?.id || action.store.id === providerStore?.id
+
+    // when selecting success,error actions for an apiAction
+    // it should not appear in selection
+    const actionBeingUpdated = action.id === updatedAction?.id
+    // calling parent actions will cause infinite loop
+    const parentAction = parentActions.includes(action.id)
+
+    return belongsToStore && !actionBeingUpdated && !parentAction
+  })
 
   const options = actions.map((action) => ({
     label: action.name,

--- a/libs/frontend/domain/type/src/interface-form/fields/select-action/SelectAction.tsx
+++ b/libs/frontend/domain/type/src/interface-form/fields/select-action/SelectAction.tsx
@@ -15,6 +15,7 @@ export type SelectActionProps = Pick<
   UniformSelectFieldProps,
   'error' | 'label' | 'name' | 'required' | 'value'
 > & {
+  onChange(value: unknown): void
   updatedAction?: IEntity
 }
 


### PR DESCRIPTION
<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(libs-ui-component): must begin with lowercase` -->

## Description

<!-- This is a short description on the Pull Request -->

## Video or Image

<!-- Add video or image showing how the new feature works -->
- Prevent creating action loop in api actions by allowing only actions that are not already parents for the updated action
- Code actions are not considered because they could involve in loops but still finite using stopping conditions.

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged -->

Fixes #2953 
