### PR TITLE
fix: CI issue about tools-workspace in dist

### DIFF
--- a/.nxignore
+++ b/.nxignore
@@ -1,0 +1,1 @@
+/dist/libs/tools/workspace/


### PR DESCRIPTION
<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(libs-ui-component): must begin with lowercase` -->

## Description
Looks like ignoring the `tools-workspaces` in dist fixes the issue since nx will not see the `tools-workspaces` having a duplicate project name.

Just tried the [.nxignore](https://nx.dev/reference/nxignore) and it works.

There will be expected failing e2e tests, but we can merge this now and properly fix the e2e tests on another PRs. This should now somehow prevent more failing e2e tests to get to master

<!-- This is a short description on the Pull Request -->

## Video or Image

<!-- Add video or image showing how the new feature works -->

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged -->

Fixes #2983 
