### PR TITLE
fix: allow state caching for preview and production only

### DIFF
--- a/libs/frontend/domain/store/src/store/models/store.model.ts
+++ b/libs/frontend/domain/store/src/store/models/store.model.ts
@@ -13,6 +13,7 @@ import {
   getRunnerId,
   isAtomInstance,
   pageRef,
+  RendererType,
   typeRef,
 } from '@codelab/frontend/abstract/core'
 import type {
@@ -139,7 +140,7 @@ export class Store
     Object.keys(actionRunners).forEach((actionName) => {
       actionRunners[actionName] = actionRunners[actionName].bind({
         actions: actionRunners,
-        state: this.cachedState,
+        state: this.state,
       })
     })
 
@@ -148,7 +149,13 @@ export class Store
 
   @computed
   get state() {
-    if (this.cachedState) {
+    const { rendererType } = this.renderService.activeRenderer?.current ?? {}
+
+    const isPreviewOrProduction =
+      rendererType === RendererType.Preview ||
+      rendererType === RendererType.Production
+
+    if (isPreviewOrProduction && this.cachedState) {
       return this.cachedState
     }
 


### PR DESCRIPTION
<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(libs-ui-component): must begin with lowercase` -->

## Description

State should be cached (should not be reset during page navigations, etc.) only for preview and production, while in page/component builder - state should be reset each time it is altered (new prop added/removed, etc), to make sure no outdated information is shown

## Video or Image

<!-- Add video or image showing how the new feature works -->


https://github.com/codelab-app/platform/assets/74900868/0344eb27-4c47-4646-87ce-19c9b1df270c


## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged -->

Fixes #2979 
