### PR TITLE
fix: css string values converted to kebab-case

### DIFF
--- a/libs/frontend/domain/renderer/src/element/get-styled-components.ts
+++ b/libs/frontend/domain/renderer/src/element/get-styled-components.ts
@@ -1,10 +1,10 @@
 import type { IComponentType, IPropData } from '@codelab/frontend/abstract/core'
-import { camelCaseToKebabCase } from '@codelab/shared/utils'
+import { camelCaseToKebabCaseOnlyKeys } from '@codelab/shared/utils'
 import React from 'react'
 import styled from 'styled-components'
 
 const ReusableStyledComponent = styled('placeholder')`
-  ${(props: IPropData) => camelCaseToKebabCase(props['css'])}
+  ${(props: IPropData) => camelCaseToKebabCaseOnlyKeys(props['css'])}
 `
 
 /**

--- a/libs/shared/utils/src/transform/strings.ts
+++ b/libs/shared/utils/src/transform/strings.ts
@@ -46,3 +46,13 @@ export const getNameFromSlug = (slug?: string) => {
 export const camelCaseToKebabCase = (input?: string) => {
   return input?.replace(/([A-Z])/g, '-$1').toLowerCase()
 }
+
+/**
+ * Convert camelCase to kebab-case, but only for keys, not values
+ * Example: "fontFamily: 'Gloria Hallelujah'" => "font-family: 'Gloria Hallelujah'"
+ * @param input
+ */
+export const camelCaseToKebabCaseOnlyKeys = (input?: string) =>
+  input?.replace(/(\w+)(?=:)/g, (match) =>
+    match.replace(/[A-Z]/g, (char) => `-${char.toLowerCase()}`),
+  )

--- a/libs/shared/utils/src/transform/strings.ts
+++ b/libs/shared/utils/src/transform/strings.ts
@@ -53,6 +53,6 @@ export const camelCaseToKebabCase = (input?: string) => {
  * @param input
  */
 export const camelCaseToKebabCaseOnlyKeys = (input?: string) =>
-  input?.replace(/(\w+)(?=:)/g, (match) =>
+  input?.replace(/(\w+)(\s*)(?=:)/g, (match) =>
     match.replace(/[A-Z]/g, (char) => `-${char.toLowerCase()}`),
   )


### PR DESCRIPTION
<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(libs-ui-component): must begin with lowercase` -->

## Description
We had to convert camelCase in `css` string to kebab-case to be correctly applied. This conversion was done for both keys and values, which caused some of the styles i.e. font-family to not work if the name is two words. 

So now we only convert the keys to kebab-case. 

<!-- This is a short description on the Pull Request -->

## Video or Image

<!-- Add video or image showing how the new feature works -->

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged -->

Fixes #2991
