### PR TITLE
fix: specify element parent on duplicate

### DIFF
--- a/libs/frontend/domain/element/src/store/element.service.ts
+++ b/libs/frontend/domain/element/src/store/element.service.ts
@@ -714,6 +714,10 @@ export class ElementService
       guiCss: element.guiCss,
       id: v4(),
       name: duplicateName,
+      page: element.page ? { id: element.page.id } : null,
+      parentComponent: element.parentComponent
+        ? { id: element.parentComponent.id }
+        : null,
       props,
       renderForEachPropKey: element.renderForEachPropKey,
       renderIfExpression: element.renderIfExpression,


### PR DESCRIPTION
<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(libs-ui-component): must begin with lowercase` -->

## Description

element parent (page/parentComponent props) is a required property, since unique `_compoundName` is not computed based on it. So we can't omit it anymore and need to specify it during creation.

## Video or Image


https://github.com/codelab-app/platform/assets/74900868/fb933f3f-5c09-4b56-ab65-8e0340529737



## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged -->

Fixes #2995
