### PR TITLE
fix: build app for production does not work

### DIFF
--- a/libs/frontend/domain/domain/src/static-regeneration.ts
+++ b/libs/frontend/domain/domain/src/static-regeneration.ts
@@ -6,8 +6,9 @@ import { getEnv } from '@codelab/shared/config'
 export const regeneratePages = (pages: Array<string>, domain: string) => {
   const baseUrl = getEnv().endpoint.nextPublicPlatformHost
   const pagesParam = pages.join(',')
+  const protocol = baseUrl.startsWith('http') ? '' : 'https://'
 
   return fetch(
-    `https://${baseUrl}/api/regenerate?domain=${domain}&pages=${pagesParam}`,
+    `${protocol}${baseUrl}/api/regenerate?domain=${domain}&pages=${pagesParam}`,
   )
 }

--- a/libs/frontend/domain/page/src/use-cases/get-pages/PageTreeItem.tsx
+++ b/libs/frontend/domain/page/src/use-cases/get-pages/PageTreeItem.tsx
@@ -39,7 +39,7 @@ export const PageTreeItem = observer(
       primaryTitle,
     },
   }: PageTreeItemProps) => {
-    const { pageService, userService } = useStore()
+    const { domainService, pageService, userService } = useStore()
     const { popover } = useCui()
     const [rebuildButtonLoading, setRebuildButtonLoading] = useState(false)
     const router = useRouter()
@@ -75,15 +75,23 @@ export const PageTreeItem = observer(
         icon: rebuildButtonLoading ? <LoadingOutlined /> : <ToolOutlined />,
         key: 'build',
         onClick: async () => {
-          const pageDomain = domains.find(
+          let pageDomains = domains.filter(
             (domain) => domain.app.id === page.app.id,
           )
 
-          if (pageDomain?.name) {
-            setRebuildButtonLoading(true)
-            await regeneratePages([page.url], pageDomain.name)
-            setRebuildButtonLoading(false)
+          if (!pageDomains.length) {
+            pageDomains = await domainService.getAll({
+              app: { id: page.app.id },
+            })
           }
+
+          setRebuildButtonLoading(true)
+
+          for (const pageDomain of pageDomains) {
+            await regeneratePages([page.url], pageDomain.name)
+          }
+
+          setRebuildButtonLoading(false)
         },
         title: 'Build',
       },


### PR DESCRIPTION
<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(libs-ui-component): must begin with lowercase` -->

## Description

After `app` requests were optimized some time ago - app domains are not always loaded (loaded only on `/apps` page), so need to request domains in case they are not loaded yet before trying to build page for production

## Video or Image

https://github.com/codelab-app/platform/assets/74900868/cf6bdd6b-4776-4814-a41a-6286bb4ca6ff


## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged -->

Fixes #2944 
