### PR TITLE
fix: hide forms and popovers on navigation

### DIFF
--- a/libs/frontend/presentation/codelab-ui/src/layout/CuiSidebarPopover/store/cui-popover.store.ts
+++ b/libs/frontend/presentation/codelab-ui/src/layout/CuiSidebarPopover/store/cui-popover.store.ts
@@ -8,18 +8,22 @@ export class CuiPopoverStore implements IPopoverStore {
 
   constructor() {
     makeAutoObservable(this)
-
-    Router.events.on('routeChangeStart', () => this.close())
   }
+
+  private closeOnRouteChange = () => this.close()
 
   @action
   open(id: string) {
     this.openPopoverId = id
+
+    Router.events.on('routeChangeStart', this.closeOnRouteChange)
   }
 
   @action
   close() {
     this.openPopoverId = undefined
+
+    Router.events.off('routeChangeStart', this.closeOnRouteChange)
   }
 
   @computed

--- a/libs/frontend/presentation/codelab-ui/src/layout/CuiSidebarPopover/store/cui-popover.store.ts
+++ b/libs/frontend/presentation/codelab-ui/src/layout/CuiSidebarPopover/store/cui-popover.store.ts
@@ -1,4 +1,5 @@
 import { action, computed, makeAutoObservable, observable } from 'mobx'
+import { Router } from 'next/router'
 import type { IPopoverStore } from './cui-popover.store.interface'
 
 export class CuiPopoverStore implements IPopoverStore {
@@ -7,6 +8,8 @@ export class CuiPopoverStore implements IPopoverStore {
 
   constructor() {
     makeAutoObservable(this)
+
+    Router.events.on('routeChangeStart', () => this.close())
   }
 
   @action

--- a/libs/frontend/presentation/codelab-ui/src/views/CuiPopoverToolbar/CuiPopoverToolbarItem.tsx
+++ b/libs/frontend/presentation/codelab-ui/src/views/CuiPopoverToolbar/CuiPopoverToolbarItem.tsx
@@ -9,7 +9,6 @@ type CuiPopoverToolbarItemProps = Omit<ToolbarItem, 'icon'> & {
 
 export const CuiPopoverToolbarItem = ({
   icon,
-  key,
   label,
   onClick,
   title,
@@ -24,7 +23,7 @@ export const CuiPopoverToolbarItem = ({
       data-cy={`codelabui-toolbar-item-${title}`}
       onClick={onClick}
     >
-      <Tooltip key={key} title={title}>
+      <Tooltip title={title}>
         <div
           className={`
           flex

--- a/libs/frontend/shared/utils/src/inline-form.service.ts
+++ b/libs/frontend/shared/utils/src/inline-form.service.ts
@@ -16,15 +16,7 @@ export class InlineFormService<
   }))<TMetadata>
   implements IModalService<TMetadata>
 {
-  onAttachedToRootStore() {
-    const closeModalOnRouteChange = () => this.close()
-
-    Router.events.on('routeChangeStart', closeModalOnRouteChange)
-
-    return () => {
-      Router.events.off('routeChangeStart', closeModalOnRouteChange)
-    }
-  }
+  private closeOnRouteChange = () => this.close()
 
   @modelAction
   open(...args: TMetadata extends undefined ? [] : [TMetadata]) {
@@ -33,11 +25,15 @@ export class InlineFormService<
     if (args.length > 0) {
       this.metadata = args[0] ?? null
     }
+
+    Router.events.on('routeChangeStart', this.closeOnRouteChange)
   }
 
   @modelAction
   close() {
     this.isOpen = false
     this.metadata = null
+
+    Router.events.off('routeChangeStart', this.closeOnRouteChange)
   }
 }

--- a/libs/frontend/shared/utils/src/inline-form.service.ts
+++ b/libs/frontend/shared/utils/src/inline-form.service.ts
@@ -1,5 +1,6 @@
 import type { IModalService } from '@codelab/frontend/abstract/core'
 import { Model, model, modelAction, prop } from 'mobx-keystone'
+import { Router } from 'next/router'
 
 @model('@codelab/InlineFormService')
 export class InlineFormService<
@@ -15,6 +16,16 @@ export class InlineFormService<
   }))<TMetadata>
   implements IModalService<TMetadata>
 {
+  onAttachedToRootStore() {
+    const closeModalOnRouteChange = () => this.close()
+
+    Router.events.on('routeChangeStart', closeModalOnRouteChange)
+
+    return () => {
+      Router.events.off('routeChangeStart', closeModalOnRouteChange)
+    }
+  }
+
   @modelAction
   open(...args: TMetadata extends undefined ? [] : [TMetadata]) {
     this.isOpen = true

--- a/libs/frontend/shared/utils/src/modal.service.ts
+++ b/libs/frontend/shared/utils/src/modal.service.ts
@@ -1,5 +1,6 @@
 import type { IModalService } from '@codelab/frontend/abstract/core'
 import { Model, model, modelAction, prop } from 'mobx-keystone'
+import { Router } from 'next/router'
 
 @model('@codelab/ModalService')
 export class ModalService<
@@ -15,6 +16,16 @@ export class ModalService<
   }))<TMetadata>
   implements IModalService<TMetadata>
 {
+  onAttachedToRootStore() {
+    const closeModalOnRouteChange = () => this.close()
+
+    Router.events.on('routeChangeStart', closeModalOnRouteChange)
+
+    return () => {
+      Router.events.off('routeChangeStart', closeModalOnRouteChange)
+    }
+  }
+
   @modelAction
   open(...args: TMetadata extends undefined ? [] : [TMetadata]) {
     this.isOpen = true

--- a/libs/frontend/shared/utils/src/modal.service.ts
+++ b/libs/frontend/shared/utils/src/modal.service.ts
@@ -16,15 +16,7 @@ export class ModalService<
   }))<TMetadata>
   implements IModalService<TMetadata>
 {
-  onAttachedToRootStore() {
-    const closeModalOnRouteChange = () => this.close()
-
-    Router.events.on('routeChangeStart', closeModalOnRouteChange)
-
-    return () => {
-      Router.events.off('routeChangeStart', closeModalOnRouteChange)
-    }
-  }
+  private closeOnRouteChange = () => this.close()
 
   @modelAction
   open(...args: TMetadata extends undefined ? [] : [TMetadata]) {
@@ -33,11 +25,15 @@ export class ModalService<
     if (args.length > 0) {
       this.metadata = args[0] ?? null
     }
+
+    Router.events.on('routeChangeStart', this.closeOnRouteChange)
   }
 
   @modelAction
   close() {
     this.isOpen = false
     this.metadata = null
+
+    Router.events.off('routeChangeStart', this.closeOnRouteChange)
   }
 }


### PR DESCRIPTION
<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(libs-ui-component): must begin with lowercase` -->

## Description

When the user opens an inline form/popover and navigates to another page - the popover and form remain opened and show invalid data.
As a fix, implemented a mechanism to close any forms and popovers when navigation to different pages occurs.

## Video or Image

https://github.com/codelab-app/platform/assets/74900868/4b12b0e6-a5ed-4526-8795-c27b34eb1bbf

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged -->

Fixes #2976
