### PR TITLE
fix: use lightweight text viewer for preview and production

### DIFF
--- a/libs/frontend/domain/renderer/src/element/text-editor/TextRenderer.tsx
+++ b/libs/frontend/domain/renderer/src/element/text-editor/TextRenderer.tsx
@@ -1,0 +1,14 @@
+import Output from 'editorjs-react-renderer'
+import React, { memo, useMemo } from 'react'
+
+interface Props {
+  data?: string
+}
+
+const TextRenderer = ({ data }: Props) => {
+  const parsedData = useMemo(() => JSON.parse(data || '{}'), [data])
+
+  return <Output data={parsedData} />
+}
+
+export default memo(TextRenderer)

--- a/libs/frontend/domain/renderer/src/element/wrapper.utils.ts
+++ b/libs/frontend/domain/renderer/src/element/wrapper.utils.ts
@@ -16,6 +16,10 @@ const TextEditor = dynamic(() => import('./text-editor/TextEditor'), {
   ssr: false,
 })
 
+const TextRenderer = dynamic(() => import('./text-editor/TextRenderer'), {
+  ssr: false,
+})
+
 /**
  * Fragments can only have the `key` prop
  *
@@ -62,6 +66,9 @@ export const createTextEditor = (
     readOnly,
   })
 }
+
+export const createTextRenderer = (customText: string) =>
+  React.createElement(TextRenderer, { data: customText })
 
 export const noWrapper = () => (children: ReactElement) => children
 

--- a/libs/frontend/domain/renderer/src/renderer.model.ts
+++ b/libs/frontend/domain/renderer/src/renderer.model.ts
@@ -44,7 +44,7 @@ import { ActionRunner, getRunner } from './action-runner.model'
 import { ComponentRuntimeProps } from './component-runtime-props.model'
 import type { ElementWrapperProps } from './element/element-wrapper'
 import { ElementWrapper } from './element/element-wrapper'
-import { createTextEditor } from './element/wrapper.utils'
+import { createTextEditor, createTextRenderer } from './element/wrapper.utils'
 import { ElementRuntimeProps } from './element-runtime-props.model'
 import { ExpressionTransformer } from './expresssion-transformer.service'
 import {
@@ -174,10 +174,13 @@ export class Renderer
           element.renderType.current.allowCustomTextInjection
 
         if (shouldInjectText) {
-          // TODO: what to do for production?
-          const readOnly = this.rendererType === RendererType.Preview
+          const readOnly =
+            this.rendererType === RendererType.Preview ||
+            this.rendererType === RendererType.Production
 
-          return createTextEditor(injectedText, element.id, readOnly)
+          return readOnly
+            ? createTextRenderer(injectedText)
+            : createTextEditor(injectedText, element.id, readOnly)
         }
 
         /*

--- a/libs/frontend/domain/shared/src/inline-form.service.ts
+++ b/libs/frontend/domain/shared/src/inline-form.service.ts
@@ -15,7 +15,7 @@ export class InlineFormService<
     metadata: prop<TMetadata | null>(null),
   }))<TMetadata>
   implements IModalService<TMetadata>
-{
+{  
   @modelAction
   close() {
     this.isOpen = false

--- a/package.json
+++ b/package.json
@@ -125,6 +125,7 @@
     "csv-parser": "3.0.0",
     "diff": "^5.1.0",
     "dir-compare": "^4.2.0",
+    "editorjs-react-renderer": "^3.5.1",
     "editorjs-text-color-plugin": "^2.0.4",
     "env-var": "7.4.1",
     "find-up": "^6.3.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -17427,6 +17427,7 @@ __metadata:
     diff: ^5.1.0
     dir-compare: ^4.2.0
     dotenv: 15.0.0
+    editorjs-react-renderer: ^3.5.1
     editorjs-text-color-plugin: ^2.0.4
     env-cmd: 10.1.0
     env-var: 7.4.1
@@ -19845,6 +19846,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"domhandler@npm:5.0.3, domhandler@npm:^5.0.2, domhandler@npm:^5.0.3":
+  version: 5.0.3
+  resolution: "domhandler@npm:5.0.3"
+  dependencies:
+    domelementtype: ^2.3.0
+  checksum: 0f58f4a6af63e6f3a4320aa446d28b5790a009018707bce2859dcb1d21144c7876482b5188395a188dfa974238c019e0a1e610d2fc269a12b2c192ea2b0b131c
+  languageName: node
+  linkType: hard
+
 "domhandler@npm:^2.3.0":
   version: 2.4.2
   resolution: "domhandler@npm:2.4.2"
@@ -19860,15 +19870,6 @@ __metadata:
   dependencies:
     domelementtype: ^2.2.0
   checksum: 4c665ceed016e1911bf7d1dadc09dc888090b64dee7851cccd2fcf5442747ec39c647bb1cb8c8919f8bbdd0f0c625a6bafeeed4b2d656bbecdbae893f43ffaaa
-  languageName: node
-  linkType: hard
-
-"domhandler@npm:^5.0.2, domhandler@npm:^5.0.3":
-  version: 5.0.3
-  resolution: "domhandler@npm:5.0.3"
-  dependencies:
-    domelementtype: ^2.3.0
-  checksum: 0f58f4a6af63e6f3a4320aa446d28b5790a009018707bce2859dcb1d21144c7876482b5188395a188dfa974238c019e0a1e610d2fc269a12b2c192ea2b0b131c
   languageName: node
   linkType: hard
 
@@ -20018,6 +20019,16 @@ __metadata:
   version: 1.0.0
   resolution: "editor@npm:1.0.0"
   checksum: 41fb75f605f92e4f3dba3da594300928e66f93a8e60e1d5734c85e8597554d7af37ef823e1ae4aca6b40c72ae7fabfdc0f3ef31b0daa1bd945f8cb7b6380009f
+  languageName: node
+  linkType: hard
+
+"editorjs-react-renderer@npm:^3.5.1":
+  version: 3.5.1
+  resolution: "editorjs-react-renderer@npm:3.5.1"
+  dependencies:
+    html-react-parser: ^3.0.4
+    react: ^18.2.0
+  checksum: 1db9d350b9b8a859721d18683a51574dbdd0ba627c1c9c088ef2b360969702a6bf93fe0e6ab0653c7bab80fa937b084ba12c54440e108606cd3469529f5f2488
   languageName: node
   linkType: hard
 
@@ -23966,6 +23977,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"html-dom-parser@npm:3.1.7":
+  version: 3.1.7
+  resolution: "html-dom-parser@npm:3.1.7"
+  dependencies:
+    domhandler: 5.0.3
+    htmlparser2: 8.0.2
+  checksum: 72bc83cbb4fc67c0982afe0fef22f4c9d886b477776e369fc4bc079e8c96a35c3a819bd3604cbea13431ec7db9b96340f184afc73f5f3efa835ec4acd471db3b
+  languageName: node
+  linkType: hard
+
 "html-encoding-sniffer@npm:^3.0.0":
   version: 3.0.0
   resolution: "html-encoding-sniffer@npm:3.0.0"
@@ -24006,6 +24027,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"html-react-parser@npm:^3.0.4":
+  version: 3.0.16
+  resolution: "html-react-parser@npm:3.0.16"
+  dependencies:
+    domhandler: 5.0.3
+    html-dom-parser: 3.1.7
+    react-property: 2.0.0
+    style-to-js: 1.1.3
+  peerDependencies:
+    react: 0.14 || 15 || 16 || 17 || 18
+  checksum: 5026c24837d31d489a3cbf25931b3b063cd41e60f1d34063b70b41e0c3a6ef97f410892b718e5b90eba56c29badfca36b617520dd538fea948729aedd16714c1
+  languageName: node
+  linkType: hard
+
 "html-tags@npm:^3.1.0":
   version: 3.3.1
   resolution: "html-tags@npm:3.3.1"
@@ -24025,6 +24060,18 @@ __metadata:
   peerDependencies:
     webpack: ^5.20.0
   checksum: ccf685195739c372ad641bbd0c9100a847904f34eedc7aff3ece7856cd6c78fd3746d2d615af1bb71e5727993fe711b89e9b744f033ed3fde646540bf5d5e954
+  languageName: node
+  linkType: hard
+
+"htmlparser2@npm:8.0.2":
+  version: 8.0.2
+  resolution: "htmlparser2@npm:8.0.2"
+  dependencies:
+    domelementtype: ^2.3.0
+    domhandler: ^5.0.3
+    domutils: ^3.0.1
+    entities: ^4.4.0
+  checksum: 29167a0f9282f181da8a6d0311b76820c8a59bc9e3c87009e21968264c2987d2723d6fde5a964d4b7b6cba663fca96ffb373c06d8223a85f52a6089ced942700
   languageName: node
   linkType: hard
 
@@ -24515,6 +24562,13 @@ __metadata:
     validate-npm-package-license: ^3.0.4
     validate-npm-package-name: ^5.0.0
   checksum: ad601c717d5ea3ff5a416cbe7d39417bb3914596dce7a386bffe856229435ebef06eb600736326effdd4e57a02d41164aa525d31d51ec49812c8e8c215d1d7c8
+  languageName: node
+  linkType: hard
+
+"inline-style-parser@npm:0.1.1":
+  version: 0.1.1
+  resolution: "inline-style-parser@npm:0.1.1"
+  checksum: 5d545056a3e1f2bf864c928a886a0e1656a3517127d36917b973de581bd54adc91b4bf1febcb0da054f204b4934763f1a4e09308b4d55002327cf1d48ac5d966
   languageName: node
   linkType: hard
 
@@ -33398,6 +33452,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"react-property@npm:2.0.0":
+  version: 2.0.0
+  resolution: "react-property@npm:2.0.0"
+  checksum: 8a444df30ef0937689c7968dae2501a0ca523777169f450e1f7ef5beeb855d6509bd058bf612f6ed8f459aa35468335d356e50264492e1938586e59fdb988262
+  languageName: node
+  linkType: hard
+
 "react-quill@npm:2.0.0":
   version: 2.0.0
   resolution: "react-quill@npm:2.0.0"
@@ -33584,7 +33645,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react@npm:18.2.0":
+"react@npm:18.2.0, react@npm:^18.2.0":
   version: 18.2.0
   resolution: "react@npm:18.2.0"
   dependencies:
@@ -35958,6 +36019,24 @@ __metadata:
   version: 4.1.0
   resolution: "style-mod@npm:4.1.0"
   checksum: 8402b14ca11113a3640d46b3cf7ba49f05452df7846bc5185a3535d9b6a64a3019e7fb636b59ccbb7816aeb0725b24723e77a85b05612a9360e419958e13b4e6
+  languageName: node
+  linkType: hard
+
+"style-to-js@npm:1.1.3":
+  version: 1.1.3
+  resolution: "style-to-js@npm:1.1.3"
+  dependencies:
+    style-to-object: 0.4.1
+  checksum: 7aaeacff909d43bbfc28e9a004019224d0eda895ac3d0d9f3160b6ad044dca8d3965f7b2b92ac649f63f62889324b560147d21cf3149f29794692c5d7b207110
+  languageName: node
+  linkType: hard
+
+"style-to-object@npm:0.4.1":
+  version: 0.4.1
+  resolution: "style-to-object@npm:0.4.1"
+  dependencies:
+    inline-style-parser: 0.1.1
+  checksum: 2ea213e98eed21764ae1d1dc9359231a9f2d480d6ba55344c4c15eb275f0809f1845786e66d4caf62414a5cc8f112ce9425a58d251c77224060373e0db48f8c2
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(libs-ui-component): must begin with lowercase` -->

## Description

In builder we use `@editorjs/editorjs` package, it is a powerful editor, but it performs poorly in production.
It does not handle content updates from outside (like when the state changes and we need to replace it inside the editor).
So use a lightweight viewer without editing capabilities that handles updates better.

## Video or Image


https://github.com/codelab-app/platform/assets/74900868/029ea1dc-6462-48fc-b9d0-2c52d86e9cab



## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged -->

Fixes #3001 
