### PR TITLE
refactor: add pre-render pipe and simplify element wrapper

### DIFF
--- a/libs/frontend/abstract/domain/src/domain/render/render.interface.ts
+++ b/libs/frontend/abstract/domain/src/domain/render/render.interface.ts
@@ -18,6 +18,7 @@ export interface IRenderOutput {
   /** Any props that should get passed to descendants of this element, mapped by id */
   globalProps?: IPropDataByElementId
   props?: IPropData
+  shouldRender?: boolean
 }
 
 export interface IBaseRenderPipe {

--- a/libs/frontend/abstract/domain/src/domain/render/renderer.model.interface.ts
+++ b/libs/frontend/abstract/domain/src/domain/render/renderer.model.interface.ts
@@ -32,12 +32,11 @@ export interface IRenderer {
   urlSegments?: Record<string, string>
 
   addRuntimeProps(nodeRef: IPageNodeRef): IRuntimeProp<IPageNode>
-  logRendered(
-    element: IElementModel,
-    rendered: ArrayOrSingle<IRenderOutput>,
-  ): void
+  logRendered(rendered: IRenderOutput): void
   renderChildren(parentOutput: IRenderOutput): ArrayOrSingle<ReactNode>
-  renderElement(element: IElementModel): ReactElement
+  renderElement(element: IElementModel): Nullable<ReactElement>
   renderIntermediateElement(element: IElementModel): IRenderOutput
   renderRoot(): ReactElement | null
+  runPostRenderAction(element: IElementModel): void
+  runPreRenderAction(element: IElementModel): void
 }

--- a/libs/frontend/application/renderer/src/renderPipes/pre-render-pipe.ts
+++ b/libs/frontend/application/renderer/src/renderPipes/pre-render-pipe.ts
@@ -5,28 +5,19 @@ import type {
 } from '@codelab/frontend/abstract/domain'
 import type { IPropData } from '@codelab/shared/abstract/core'
 import { ExtendedModel, model, prop } from 'mobx-keystone'
-import { RenderOutput, shouldRenderElement } from '../utils'
 import { BaseRenderPipe } from './render-pipe.base'
 
-@model('@codelab/ConditionalRenderPipe')
-export class ConditionalRenderPipe
+@model('@codelab/PreRenderPipe')
+export class PreRenderPipe
   extends ExtendedModel(BaseRenderPipe, {
     next: prop<IRenderPipe>(),
   })
   implements IRenderPipe
 {
   render(element: IElementModel, props: IPropData): IRenderOutput {
-    if (shouldRenderElement(element, props)) {
-      return this.next.render(element, props)
-    }
+    const renderer = this.renderService.activeRenderer?.current
+    renderer?.runPreRenderAction(element)
 
-    if (this.renderer.debugMode) {
-      console.info('ConditionalRenderPipe: should stop rendering', {
-        element: element.name,
-        value: true,
-      })
-    }
-
-    return RenderOutput.notRenderable({ element })
+    return this.next.render(element, props)
   }
 }

--- a/libs/frontend/application/renderer/src/renderPipes/render-pipe.base.ts
+++ b/libs/frontend/application/renderer/src/renderPipes/render-pipe.base.ts
@@ -34,7 +34,7 @@ export class BaseRenderPipe
   }
 
   @computed
-  private get renderService() {
+  protected get renderService() {
     return getRenderService(this)
   }
 }

--- a/libs/frontend/application/renderer/src/renderPipes/render-pipe.factory.ts
+++ b/libs/frontend/application/renderer/src/renderPipes/render-pipe.factory.ts
@@ -4,16 +4,19 @@ import { ComponentRenderPipe } from './component-render-pipe'
 import { ConditionalRenderPipe } from './conditional-render-pipe'
 import { NullRenderPipe } from './null-render-pipe'
 import type { PassThroughRenderPipe } from './pass-through-render-pipe'
+import { PreRenderPipe } from './pre-render-pipe'
 
 export type RenderPipeClass =
   | typeof AtomRenderPipe
   | typeof ComponentRenderPipe
   | typeof ConditionalRenderPipe
   | typeof PassThroughRenderPipe
+  | typeof PreRenderPipe
 
 // define pipes in order of execution, we reverse it so that it matches the order of calling next
 export const defaultPipes: Array<RenderPipeClass> = [
   ConditionalRenderPipe,
+  PreRenderPipe,
   ComponentRenderPipe,
   AtomRenderPipe,
 ].reverse()

--- a/libs/frontend/application/renderer/src/test/conditional-render-pipe.spec.ts
+++ b/libs/frontend/application/renderer/src/test/conditional-render-pipe.spec.ts
@@ -68,7 +68,7 @@ describe('ConditionalRenderPipe', () => {
           }),
         })
       } else {
-        expect(output).toEqual({ element: elementModel })
+        expect(output).toEqual({ element: elementModel, shouldRender })
       }
     },
   )

--- a/libs/frontend/application/renderer/src/utils/render-output.ts
+++ b/libs/frontend/application/renderer/src/utils/render-output.ts
@@ -7,6 +7,9 @@ import type { Nullish } from '@codelab/shared/abstract/types'
 export const RenderOutput = {
   empty: (input: Pick<IRenderOutput, 'element' | 'props'>): IRenderOutput =>
     input,
+  notRenderable: (
+    input: Pick<IRenderOutput, 'element' | 'props'>,
+  ): IRenderOutput => ({ ...input, shouldRender: false }),
   overrideProps: (input: IRenderOutput, props: Nullish<IPropData>) => {
     return { ...input, props: mergeProps(input.props, props) }
   },


### PR DESCRIPTION
## Description

This PR apllies the changes proposed in #3005. in addition to that, 

1. The element Wrapper implementatin is simplified:
- ~removed element prop~ reverted this back for now
- added errorBoundary and onRendered props to move some unnecessary logic to outside the element wrapper

2. added methods to run pre/post render methods to renderModel so that the logic is located in close proximity.

## Video or Image

### root element's children render and render hooks run regardless of "render if" value

Before


https://github.com/codelab-app/platform/assets/51242349/8975d757-7135-44c3-a49a-3fcb084e1f4d



After


https://github.com/codelab-app/platform/assets/51242349/dc622b6a-7113-42ae-a286-32cd35688af6



## Related Issue(s)

Fixes #3005
