### PR TITLE
fix: update overlay on position/breakpoint change

### DIFF
--- a/libs/frontend/domain/builder/src/sections/overlay-toolbar/BuilderClickOverlay.tsx
+++ b/libs/frontend/domain/builder/src/sections/overlay-toolbar/BuilderClickOverlay.tsx
@@ -59,7 +59,7 @@ export const BuilderClickOverlay = observer<{
   }
 
   const content = (
-    <StyledOverlayContainer className="click-overlay-toolbar">
+    <StyledOverlayContainer>
       <StyledSpan>{selectedNode.current.name}</StyledSpan>
       <StyledOverlayButtonGroup>
         <Button
@@ -76,14 +76,25 @@ export const BuilderClickOverlay = observer<{
     </StyledOverlayContainer>
   )
 
+  const { closestParent, customCss, guiCss, nextSibling } = selectedNode.current
+  const breakpoint = builderService.selectedBuilderBreakpoint
+  const props = selectedNode.current.props.current.values
+  const parentId = closestParent?.id
+  const nextSiblingId = nextSibling?.id
+
+  const dependencies = [
+    guiCss,
+    customCss,
+    props,
+    nextSiblingId,
+    breakpoint,
+    parentId,
+  ]
+
   return createPortal(
     <ClickOverlay
       content={content}
-      dependencies={[
-        selectedNode.current.guiCss,
-        selectedNode.current.customCss,
-        selectedNode.current.props.current.values,
-      ]}
+      dependencies={dependencies}
       element={element}
       renderContainer={renderContainerRef.current}
     />,

--- a/libs/frontend/presentation/view/components/hoverOverlay/ClickOverlay.tsx
+++ b/libs/frontend/presentation/view/components/hoverOverlay/ClickOverlay.tsx
@@ -19,6 +19,8 @@ export const ClickOverlay = ({
   // - the content is scrolled
   // - element css is updated, especially height, width, margin, padding
   // - element props is updated (some props may affect size and position when using 'auto')
+  // - element order is changed (or element parent is changed)
+  // - screen breakpoint is changed
 
   const { height, width } = useResizeObserver({ ref: renderContainer })
   useScrollIntoView(element, renderContainer)


### PR DESCRIPTION
<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(libs-ui-component): must begin with lowercase` -->

## Description

Whenever selected element is moved on the page, or whenever breakpoint changes - update the selected element overlay

## Video or Image

https://github.com/codelab-app/platform/assets/74900868/de970b2b-bb46-43af-bca9-471704ffece6

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged -->

Fixes #3016 
