### PR TITLE
2955 display margins and paddings

### DIFF
--- a/libs/backend/domain/prop/src/model/prop.model.ts
+++ b/libs/backend/domain/prop/src/model/prop.model.ts
@@ -4,7 +4,7 @@ import type { IEntity, Nullable } from '@codelab/shared/abstract/types'
 export class Prop implements IPropDTO {
   api?: Nullable<IEntity> | undefined
 
-  data?: string | undefined
+  data: string
 
   id: string
 

--- a/libs/frontend/domain/app/src/use-cases/create-app/CreateAppModal.tsx
+++ b/libs/frontend/domain/app/src/use-cases/create-app/CreateAppModal.tsx
@@ -9,7 +9,7 @@ import { v4 } from 'uuid'
 import { createAppSchema } from './create-app.schema'
 
 export const CreateAppModal = observer(() => {
-  const { appService, userService } = useStore()
+  const { appService, atomService, userService } = useStore()
 
   const onSubmit = async (appDTO: ICreateAppData) => {
     await appService.create(appDTO)

--- a/libs/frontend/domain/atom/src/store/atom.model.ts
+++ b/libs/frontend/domain/atom/src/store/atom.model.ts
@@ -114,8 +114,6 @@ export class Atom
 
   @modelAction
   toCreateInput(): AtomCreateInput {
-    console.log(this.userService.user)
-
     return {
       api: {
         create: {

--- a/libs/frontend/domain/builder/src/sections/content/Builder.tsx
+++ b/libs/frontend/domain/builder/src/sections/content/Builder.tsx
@@ -13,9 +13,11 @@ import { observer } from 'mobx-react-lite'
 import React, { useEffect, useMemo, useRef } from 'react'
 import styled from 'styled-components'
 import { useBuilderHotkeys } from '../../hooks'
-import { BuilderClickOverlay } from '../overlay-toolbar/BuilderClickOverlay'
-import { BuilderDragDropOverlay } from '../overlay-toolbar/BuilderDragDropOverlay'
-import { BuilderHoverOverlay } from '../overlay-toolbar/BuilderHoverOverlay'
+import {
+  BuilderClickOverlay,
+  BuilderDragDropOverlay,
+  BuilderHoverOverlay,
+} from '../overlay-toolbar'
 import { BuilderResizeHandle } from './BuilderResizeHandle'
 
 /**

--- a/libs/frontend/domain/builder/src/sections/overlay-toolbar/BuilderClickOverlay.tsx
+++ b/libs/frontend/domain/builder/src/sections/overlay-toolbar/BuilderClickOverlay.tsx
@@ -95,7 +95,13 @@ export const BuilderClickOverlay = observer<{
   return createPortal(
     <ClickOverlay
       content={content}
-      dependencies={dependencies}
+      dependencies={[
+        selectedNode.current.guiCss,
+        selectedNode.current.customCss,
+        selectedNode.current.props.current.values,
+        selectedNode.current.nextSibling?.id,
+        selectedNode.current.parentElement?.id,
+      ]}
       element={element}
       renderContainer={renderContainerRef.current}
     />,

--- a/libs/frontend/domain/builder/src/sections/overlay-toolbar/BuilderHoverOverlay.tsx
+++ b/libs/frontend/domain/builder/src/sections/overlay-toolbar/BuilderHoverOverlay.tsx
@@ -4,7 +4,10 @@ import type {
 } from '@codelab/frontend/abstract/core'
 import { isElementRef } from '@codelab/frontend/abstract/core'
 import { queryRenderedElementById } from '@codelab/frontend/domain/renderer'
-import { HoverOverlay } from '@codelab/frontend/presentation/view'
+import {
+  HoverOverlay,
+  MarginPaddingOverlay,
+} from '@codelab/frontend/presentation/view'
 import { isServer } from '@codelab/shared/utils'
 import { observer } from 'mobx-react-lite'
 import React from 'react'
@@ -14,7 +17,7 @@ export const BuilderHoverOverlay = observer<{
   builderService: IBuilderService
   elementService: IElementService
   renderContainerRef: React.MutableRefObject<HTMLElement | null>
-}>(({ builderService, elementService, renderContainerRef }) => {
+}>(({ builderService, renderContainerRef }) => {
   const hoveredNode = builderService.hoveredNode
   const selectedNode = builderService.selectedNode
 
@@ -33,10 +36,18 @@ export const BuilderHoverOverlay = observer<{
   }
 
   return createPortal(
-    <HoverOverlay
-      element={element}
-      renderContainer={renderContainerRef.current}
-    />,
+    <>
+      {hoveredNode.id !== selectedNode?.id && (
+        <HoverOverlay
+          element={element}
+          renderContainer={renderContainerRef.current}
+        />
+      )}
+      <MarginPaddingOverlay
+        element={element}
+        renderContainer={renderContainerRef.current}
+      />
+    </>,
     renderContainerRef.current,
   )
 })

--- a/libs/frontend/domain/builder/src/sections/overlay-toolbar/index.ts
+++ b/libs/frontend/domain/builder/src/sections/overlay-toolbar/index.ts
@@ -1,2 +1,3 @@
-// export * from './BuilderClickOverlay'
-// export * from './BuilderHoverOverlay'
+export * from './BuilderClickOverlay'
+export * from './BuilderDragDropOverlay'
+export * from './BuilderHoverOverlay'

--- a/libs/frontend/domain/builder/src/store/builder.service.ts
+++ b/libs/frontend/domain/builder/src/store/builder.service.ts
@@ -164,8 +164,6 @@ export class BuilderService
     }
 
     this.hoveredNode = elementRef(node)
-
-    // this.updateExpandedNodes()
   }
 
   @modelAction

--- a/libs/frontend/domain/renderer/src/element/wrapper.utils.ts
+++ b/libs/frontend/domain/renderer/src/element/wrapper.utils.ts
@@ -81,3 +81,47 @@ export const makeDraggableElement = ({
     makeRenderedElements,
   })
 }
+
+let dragImage: HTMLElement | undefined
+
+export const createDragImage = (name: string) => {
+  if (dragImage) {
+    dragImage.innerText = name
+
+    return dragImage
+  }
+
+  dragImage = document.createElement('div')
+  dragImage.style.width = 'auto'
+  dragImage.style.height = '40px'
+  dragImage.style.position = 'fixed'
+  dragImage.style.top = '-400px'
+  dragImage.style.borderRadius = '5px'
+  dragImage.style.backgroundColor = 'white'
+  dragImage.style.textAlign = 'center'
+  dragImage.style.display = 'flex'
+  dragImage.style.justifyContent = 'center'
+  dragImage.style.alignItems = 'center'
+  dragImage.style.fontSize = '14px'
+  dragImage.style.padding = '5px'
+  dragImage.innerText = name
+  document.body.appendChild(dragImage)
+
+  return dragImage
+}
+
+let transparentDragImage: HTMLElement | undefined
+
+export const createTransparentDragImage = () => {
+  if (transparentDragImage) {
+    return transparentDragImage
+  }
+
+  transparentDragImage = document.createElement('div')
+  transparentDragImage.style.width = '1px'
+  transparentDragImage.style.height = '1px'
+  transparentDragImage.style.opacity = '0'
+  document.body.appendChild(transparentDragImage)
+
+  return transparentDragImage
+}

--- a/libs/frontend/domain/renderer/src/utils/useDragDropHandlers.hook.ts
+++ b/libs/frontend/domain/renderer/src/utils/useDragDropHandlers.hook.ts
@@ -1,10 +1,7 @@
 import type {
   IAtomModel,
-  IAtomService,
-  IBuilderService,
   IDropPosition,
   IElementModel,
-  IElementService,
 } from '@codelab/frontend/abstract/core'
 import { RendererType } from '@codelab/frontend/abstract/core'
 import { useStore } from '@codelab/frontend/presentation/container'
@@ -21,10 +18,11 @@ export const useDragDropHandlers = (
   rendererType: RendererType,
 ) => {
   const { atomService, builderService, elementService } = useStore()
+  const { moveElementService } = elementService
 
   const dragStartHandler = useCallback(
     (event: React.DragEvent<HTMLElement>) => {
-      // we stop propogation because we only want the event to be triggered on currenty dragged element and not the parents
+      // we stop propagation because we only want the event to be triggered on currently dragged element and not the parents
       event.stopPropagation()
       draggedElement = currentElement
 
@@ -36,7 +34,7 @@ export const useDragDropHandlers = (
       target.style.opacity = '0.2'
 
       // set drag image
-      // drag image is something you see attaced to the pointer while dragging
+      // drag image is something you see attached to the pointer while dragging
       event.dataTransfer.setDragImage(
         createDragImage(currentElement.name),
         5,
@@ -50,14 +48,15 @@ export const useDragDropHandlers = (
   const dragOverHandler = useCallback(
     (event: React.DragEvent<HTMLElement>) => {
       event.preventDefault()
-      // we stop propogation because we only want the event to be triggered on currenty dragged element and not the parents
+      // we stop propagation because we only want the event to be triggered on currently dragged element and not the parents
       event.stopPropagation()
 
       dropTargetElement = currentElement
 
       const parentElement =
-        queryRenderedElementById(currentElement.closestParent?.id ?? '') ??
-        document.getElementById('render-root')
+        queryRenderedElementById(
+          currentElement.closestParentElement?.id ?? '',
+        ) ?? document.getElementById('render-root')
 
       if (!parentElement) {
         return
@@ -97,7 +96,6 @@ export const useDragDropHandlers = (
       event.preventDefault()
       event.stopPropagation()
 
-      const { moveElementService } = elementService
       const target = event.target as HTMLElement
       target.classList.remove('currently-dragged')
       target.style.opacity = '1'
@@ -223,7 +221,7 @@ const isDroppable = (
   draggedAtom: IAtomModel | undefined,
 ) => {
   return true
-  /**  
+  /**
    For now, all atoms are droppable.
    Basically, we will add a new field called "allowedChildren" to the atom schema.
    If the allowedChildren is empty, then any atoms can be dropped.

--- a/libs/frontend/domain/renderer/src/utils/useSelectionHandlers.hook.ts
+++ b/libs/frontend/domain/renderer/src/utils/useSelectionHandlers.hook.ts
@@ -1,7 +1,4 @@
-import type {
-  IBuilderService,
-  IElementModel,
-} from '@codelab/frontend/abstract/core'
+import type { IElementModel } from '@codelab/frontend/abstract/core'
 import { RendererType } from '@codelab/frontend/abstract/core'
 import { useStore } from '@codelab/frontend/presentation/container'
 import { type MouseEvent, useCallback } from 'react'
@@ -9,7 +6,7 @@ import { type MouseEvent, useCallback } from 'react'
 /**
  * Provides interactions handlers for builder elements like selecting and hovering.
  */
-let lastEditedElemet: IElementModel | undefined
+let lastEditedElement: IElementModel | undefined
 
 export const useSelectionHandlers = (
   element: IElementModel,
@@ -21,8 +18,8 @@ export const useSelectionHandlers = (
     (event: MouseEvent) => {
       event.stopPropagation()
 
-      if (lastEditedElemet && lastEditedElemet.id !== element.id) {
-        lastEditedElemet.setIsTextContentEditable(false)
+      if (lastEditedElement && lastEditedElement.id !== element.id) {
+        lastEditedElement.setIsTextContentEditable(false)
       }
 
       builderService.selectElementNode(element)
@@ -35,7 +32,7 @@ export const useSelectionHandlers = (
       event.stopPropagation()
 
       element.setIsTextContentEditable(true)
-      lastEditedElemet = element
+      lastEditedElement = element
     },
     [element],
   )

--- a/libs/frontend/presentation/view/components/overlay/ClickOverlay.tsx
+++ b/libs/frontend/presentation/view/components/overlay/ClickOverlay.tsx
@@ -57,7 +57,7 @@ export const ClickOverlay = ({
       right: `${rect.right}px`,
       top: `${rect.top - containerRect.top}px`,
       width: `${rect.width}px`,
-      zIndex: 2,
+      zIndex: 3,
     }),
     [containerRect, rect],
   )

--- a/libs/frontend/presentation/view/components/overlay/index.ts
+++ b/libs/frontend/presentation/view/components/overlay/index.ts
@@ -1,3 +1,4 @@
 export * from './ClickOverlay'
 export * from './DragDropOverlay'
 export * from './HoverOverlay'
+export * from './spacingOverlay'

--- a/libs/frontend/presentation/view/components/overlay/overlay.interface.ts
+++ b/libs/frontend/presentation/view/components/overlay/overlay.interface.ts
@@ -18,3 +18,8 @@ export interface DragDropOverlayProps {
   element: HTMLElement
   renderContainer: HTMLElement
 }
+
+export interface MarginPaddingOverlayProps {
+  element: HTMLElement
+  renderContainer: HTMLElement
+}

--- a/libs/frontend/presentation/view/components/overlay/spacingOverlay/Margins.tsx
+++ b/libs/frontend/presentation/view/components/overlay/spacingOverlay/Margins.tsx
@@ -1,0 +1,82 @@
+import React from 'react'
+import styled from 'styled-components'
+import type { ISpacingValues, SpacingProps } from './shared'
+import { MIN_DISPLAYABLE_VALUE, Spacing, SpacingValue } from './shared'
+
+export const Margins = ({ values }: { values: ISpacingValues }) => {
+  return (
+    <>
+      {/* Margin Top */}
+      <Margin
+        $bottom="auto"
+        $height={values.$top}
+        $left="0px"
+        $right="0px"
+        $top={`-${values.$top}`}
+        $width="auto"
+        value={values.$top}
+      />
+      {/* Margin Bottom */}
+      <Margin
+        $bottom={`-${values.$bottom}`}
+        $height={values.$bottom}
+        $left="0"
+        $right="0"
+        $top="auto"
+        $width="auto"
+        value={values.$bottom}
+      />
+      {/* Margin Left */}
+      <Margin
+        $bottom={`-${values.$bottom}`}
+        $height="auto"
+        $left={`-${values.$left}`}
+        $right="0"
+        $top={`-${values.$top}`}
+        $width={values.$left}
+        value={values.$left}
+      />
+      {/* Margin Right */}
+      <Margin
+        $bottom={`-${values.$bottom}`}
+        $height="auto"
+        $left="auto"
+        $right={`-${values.$right}`}
+        $top={`-${values.$top}`}
+        $width={values.$right}
+        value={values.$right}
+      />
+    </>
+  )
+}
+
+const marginBackgroundPattern = () => `
+  background-color: #e5e5f7;
+  opacity: 0.8;
+  background-size: 4px 4px;
+  background-image: repeating-linear-gradient(45deg, #e58911 0,
+    #e58911 1px,
+    #e5e5f7 0,
+    #e5e5f7 50%);
+`
+
+const MarginBox = styled(Spacing)`
+  ${marginBackgroundPattern()};
+`
+
+const Margin = ({ value, ...rest }: SpacingProps & { value: string }) => {
+  const numberValue = Math.round(Number(value.replace('px', '')))
+
+  if (!numberValue) {
+    return null
+  }
+
+  return (
+    // eslint-disable-next-line react/jsx-props-no-spreading
+    <MarginBox {...rest}>
+      {numberValue > MIN_DISPLAYABLE_VALUE && (
+        <SpacingValue $backgroundColor="#d75300">{`${numberValue}px`}</SpacingValue>
+      )}
+    </MarginBox>
+  )
+}

--- a/libs/frontend/presentation/view/components/overlay/spacingOverlay/Paddings.tsx
+++ b/libs/frontend/presentation/view/components/overlay/spacingOverlay/Paddings.tsx
@@ -1,0 +1,82 @@
+import React from 'react'
+import styled from 'styled-components'
+import type { ISpacingValues, SpacingProps } from './shared'
+import { MIN_DISPLAYABLE_VALUE, Spacing, SpacingValue } from './shared'
+
+export const Paddings = ({ values }: { values: ISpacingValues }) => {
+  return (
+    <>
+      {/* Padding Top */}
+      <Padding
+        $bottom="auto"
+        $height={values.$top}
+        $left="1px"
+        $right="1px"
+        $top="1px"
+        $width="auto"
+        value={values.$top}
+      />
+      {/* Padding Bottom */}
+      <Padding
+        $bottom="1px"
+        $height={values.$bottom}
+        $left="1px"
+        $right="1px"
+        $top="auto"
+        $width="auto"
+        value={values.$bottom}
+      />
+      {/* Padding Left */}
+      <Padding
+        $bottom={`${values.$bottom}`}
+        $height="auto"
+        $left="1px"
+        $right="auto"
+        $top={`${values.$top}`}
+        $width={values.$left}
+        value={values.$left}
+      />
+      {/* Padding Right */}
+      <Padding
+        $bottom={`${values.$bottom}`}
+        $height="auto"
+        $left="auto"
+        $right="1px"
+        $top={`${values.$top}`}
+        $width={values.$right}
+        value={values.$right}
+      />
+    </>
+  )
+}
+
+const paddingBackgroundPattern = () => `
+  background-color: #e5e5f7;
+  opacity: 0.8;
+  background-size: 4px 4px;
+  background-image: repeating-linear-gradient(45deg, #069165 0,
+    #22e9aa 1px,
+    #e5e5f7 0,
+    #e5e5f7 50%);
+`
+
+const PaddingBox = styled(Spacing)`
+  ${paddingBackgroundPattern()};
+`
+
+const Padding = ({ value, ...rest }: SpacingProps & { value: string }) => {
+  const numberValue = Math.round(Number(value.replace('px', '')))
+
+  if (!numberValue) {
+    return null
+  }
+
+  return (
+    // eslint-disable-next-line react/jsx-props-no-spreading
+    <PaddingBox {...rest}>
+      {numberValue > MIN_DISPLAYABLE_VALUE && (
+        <SpacingValue $backgroundColor="#0a9166">{`${numberValue}px`}</SpacingValue>
+      )}
+    </PaddingBox>
+  )
+}

--- a/libs/frontend/presentation/view/components/overlay/spacingOverlay/index.tsx
+++ b/libs/frontend/presentation/view/components/overlay/spacingOverlay/index.tsx
@@ -1,0 +1,76 @@
+import type { CSSProperties } from 'react'
+import React, { useEffect, useMemo, useState } from 'react'
+import type { MarginPaddingOverlayProps } from '../overlay.interface'
+import { Margins } from './Margins'
+import { Paddings } from './Paddings'
+import type { ISpacingValues } from './shared'
+
+export const MarginPaddingOverlay = ({
+  element,
+  renderContainer,
+}: MarginPaddingOverlayProps) => {
+  const [containerRect, setContainerRect] = useState(() =>
+    renderContainer.getBoundingClientRect(),
+  )
+
+  const [rect, setRect] = useState(() => element.getBoundingClientRect())
+  const [margins, setMargins] = useState<ISpacingValues | null>(null)
+  const [paddings, setPaddings] = useState<ISpacingValues | null>(null)
+
+  useEffect(() => {
+    setRect(element.getBoundingClientRect())
+    setContainerRect(renderContainer.getBoundingClientRect())
+
+    const {
+      marginBottom,
+      marginLeft,
+      marginRight,
+      marginTop,
+      paddingBottom,
+      paddingLeft,
+      paddingRight,
+      paddingTop,
+    } = window.getComputedStyle(element)
+
+    setMargins({
+      $bottom: marginBottom,
+      $left: marginLeft,
+      $right: marginRight,
+      $top: marginTop,
+    })
+
+    setPaddings({
+      $bottom: paddingBottom,
+      $left: paddingLeft,
+      $right: paddingRight,
+      $top: paddingTop,
+    })
+  }, [element, renderContainer])
+
+  const rootStyle: CSSProperties = useMemo(
+    () => ({
+      border: '0px solid blue',
+      bottom: `${rect.bottom}px`,
+      height: `${rect.height}px`,
+      left: `${rect.left - containerRect.left}px`,
+      pointerEvents: 'none',
+      position: 'absolute',
+      right: `${rect.right}px`,
+      top: `${rect.top - containerRect.top}px`,
+      width: `${rect.width}px`,
+      zIndex: 2,
+    }),
+    [containerRect, rect],
+  )
+
+  if (!margins || !paddings) {
+    return null
+  }
+
+  return (
+    <div style={rootStyle}>
+      <Margins values={margins} />
+      <Paddings values={paddings} />
+    </div>
+  )
+}

--- a/libs/frontend/presentation/view/components/overlay/spacingOverlay/shared.ts
+++ b/libs/frontend/presentation/view/components/overlay/spacingOverlay/shared.ts
@@ -1,0 +1,38 @@
+import styled from 'styled-components'
+
+export const SpacingValue = styled.div<{ $backgroundColor: string }>`
+  background-color: ${({ $backgroundColor }) => $backgroundColor};
+  color: white;
+  padding: 2px;
+  font-size: 9px;
+  border-radius: 2px;
+`
+
+export const Spacing = styled.div<SpacingProps>`
+  position: absolute;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  height: ${({ $height: height }) => height};
+  width: ${({ $width: width }) => width};
+  left: ${({ $left: left }) => left};
+  right: ${({ $right: right }) => right};
+  top: ${({ $top: top }) => top};
+  bottom: ${({ $bottom: bottom }) => bottom};
+  overflow: hidden;
+`
+
+export interface SpacingProps extends ISpacingValues {
+  $height: string
+  $width: string
+}
+
+export interface ISpacingValues {
+  $bottom: string
+  $left: string
+  $right: string
+  $top: string
+}
+
+// if it's less than 18px, we prefer not to display the value to avoid truncation
+export const MIN_DISPLAYABLE_VALUE = 18

--- a/libs/shared/data/test/src/app.data.ts
+++ b/libs/shared/data/test/src/app.data.ts
@@ -1,6 +1,6 @@
-import type { ICreateElementData } from '@codelab/frontend/abstract/core'
 import type {
   IAppDTO,
+  IElementDTO,
   IInterfaceTypeDTO,
   IStoreDTO,
 } from '@codelab/shared/abstract/core'
@@ -28,7 +28,7 @@ export const appData = (owner: IEntity): IAppDTO => ({
   owner,
 })
 
-export const buttonElementData: Pick<ICreateElementData, 'id' | 'name'> = {
+export const buttonElementData: Pick<IElementDTO, 'id' | 'name'> = {
   id: v4(),
   name: 'Button',
 }


### PR DESCRIPTION
<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(libs-ui-component): must begin with lowercase` -->

## Description

In this PR, we visually represent paddings and margins using differently colored squares. This enables users to easily identify the spacing associated with each element, along with their respective values.

## Video or Image

![paddings-margins](https://github.com/codelab-app/platform/assets/32300655/e97853fd-b7d1-4f5a-81c7-37192c0c6e5e)

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged -->

Fixes #2955 
