### PR TITLE
fix: import fails and apps does not open

### DIFF
--- a/libs/backend/application/atom/src/use-case/import-atom.command.service.ts
+++ b/libs/backend/application/atom/src/use-case/import-atom.command.service.ts
@@ -27,14 +27,19 @@ export class ImportAtomHandler
 
     await this.commandBus.execute<ImportApiCommand>(new ImportApiCommand(api))
 
+    const whereCondition = { name: atom.name }
+
     /**
      * Create all atoms but omit `suggestedChildren`, since it requires all atoms to be added first
      */
-    await this.atomRepository.save(omit(atom, ['suggestedChildren']))
+    await this.atomRepository.save(
+      omit(atom, ['suggestedChildren']),
+      whereCondition,
+    )
 
     /**
      * Here we assign suggestedChildren, since all atoms must be created first
      */
-    await this.atomRepository.save(atom)
+    await this.atomRepository.save(atom, whereCondition)
   }
 }

--- a/libs/backend/application/type/src/use-case/import/import-api.command.service.ts
+++ b/libs/backend/application/type/src/use-case/import/import-api.command.service.ts
@@ -20,8 +20,10 @@ export class ImportApiHandler
       apiOutput: { fields, types, ...api },
     } = command
 
-    for (const type of types) {
-      await this.typeFactory.save(type)
+    const descendantTypesWithApiType = [...types, { ...api, fields: [] }]
+
+    for (const type of descendantTypesWithApiType) {
+      await this.typeFactory.save(type, { name: type.name })
     }
 
     for (const field of fields) {

--- a/libs/frontend/abstract/core/src/domain/tag/tag.fragment.graphql
+++ b/libs/frontend/abstract/core/src/domain/tag/tag.fragment.graphql
@@ -6,7 +6,7 @@ fragment Tag on Tag {
     id
   }
   id
-  isRoot
+  #isRoot
   name
   owner {
     ...Owner

--- a/libs/frontend/abstract/core/src/domain/tag/tag.fragment.graphql.gen.ts
+++ b/libs/frontend/abstract/core/src/domain/tag/tag.fragment.graphql.gen.ts
@@ -7,7 +7,6 @@ import { gql } from 'graphql-tag'
 import { OwnerFragmentDoc } from '../user/owner.fragment.graphql.gen'
 export type TagFragment = {
   id: string
-  isRoot: boolean
   name: string
   children: Array<{ id: string }>
   descendants: Array<{ id: string }>
@@ -26,7 +25,6 @@ export const TagFragmentDoc = gql`
       id
     }
     id
-    isRoot
     name
     owner {
       ...Owner

--- a/libs/frontend/domain/app/src/use-cases/app-development/app-development.service.ts
+++ b/libs/frontend/domain/app/src/use-cases/app-development/app-development.service.ts
@@ -63,7 +63,11 @@ export class AppDevelopmentService
 
     const elements = pages.flatMap((page) =>
       [page.rootElement, ...page.rootElement.descendantElements].map(
-        (element) => ({ ...element, closestContainerNode: { id: page.id } }),
+        (element) => ({
+          ...element,
+          closestContainerNode: { id: page.id },
+          page: { id: page.id },
+        }),
       ),
     )
 

--- a/libs/frontend/domain/atom/src/use-cases/get-select-atom-options/get-select-atom-options.endpoints.graphql.gen.ts
+++ b/libs/frontend/domain/atom/src/use-cases/get-select-atom-options/get-select-atom-options.endpoints.graphql.gen.ts
@@ -1,0 +1,74 @@
+import * as Types from '@codelab/shared/abstract/codegen'
+
+import { InterfaceTypeFragment } from '../../../../../abstract/core/src/domain/type/fragments/interface.fragment.graphql.gen'
+import { GraphQLClient } from 'graphql-request'
+import { GraphQLClientRequestHeaders } from 'graphql-request/build/cjs/types'
+import { gql } from 'graphql-tag'
+import { InterfaceTypeFragmentDoc } from '../../../../../abstract/core/src/domain/type/fragments/interface.fragment.graphql.gen'
+export type GetSelectAtomOptionsQueryVariables = Types.Exact<{
+  [key: string]: never
+}>
+
+export type GetSelectAtomOptionsQuery = {
+  atoms: Array<{
+    id: string
+    name: string
+    type: Types.AtomType
+    api: InterfaceTypeFragment
+    requiredParents: Array<{ id: string; type: Types.AtomType }>
+  }>
+}
+
+export const GetSelectAtomOptionsDocument = gql`
+  query GetSelectAtomOptions {
+    atoms {
+      api {
+        ...InterfaceType
+      }
+      id
+      name
+      requiredParents {
+        id
+        type
+      }
+      type
+    }
+  }
+  ${InterfaceTypeFragmentDoc}
+`
+
+export type SdkFunctionWrapper = <T>(
+  action: (requestHeaders?: Record<string, string>) => Promise<T>,
+  operationName: string,
+  operationType?: string,
+) => Promise<T>
+
+const defaultWrapper: SdkFunctionWrapper = (
+  action,
+  _operationName,
+  _operationType,
+) => action()
+
+export function getSdk(
+  client: GraphQLClient,
+  withWrapper: SdkFunctionWrapper = defaultWrapper,
+) {
+  return {
+    GetSelectAtomOptions(
+      variables?: GetSelectAtomOptionsQueryVariables,
+      requestHeaders?: GraphQLClientRequestHeaders,
+    ): Promise<GetSelectAtomOptionsQuery> {
+      return withWrapper(
+        (wrappedRequestHeaders) =>
+          client.request<GetSelectAtomOptionsQuery>(
+            GetSelectAtomOptionsDocument,
+            variables,
+            { ...requestHeaders, ...wrappedRequestHeaders },
+          ),
+        'GetSelectAtomOptions',
+        'query',
+      )
+    },
+  }
+}
+export type Sdk = ReturnType<typeof getSdk>

--- a/libs/frontend/domain/tag/src/store/tag.service.ts
+++ b/libs/frontend/domain/tag/src/store/tag.service.ts
@@ -165,7 +165,7 @@ export class TagService
       children: children?.map((child) => tagRef(child.id)),
       descendants: descendants?.map((child) => tagRef(child.id)),
       id,
-      isRoot,
+      isRoot: isRoot === undefined ? !parent?.id : isRoot,
       name,
       parent: parent?.id ? tagRef(parent.id) : null,
     })

--- a/libs/shared/abstract/codegen/src/types.api.graphql.gen.ts
+++ b/libs/shared/abstract/codegen/src/types.api.graphql.gen.ts
@@ -20803,7 +20803,6 @@ export type ProductionStoreFragment = {
 export type TagFragment = {
   __typename?: 'Tag'
   id: string
-  isRoot: boolean
   name: string
   children: Array<{ __typename?: 'Tag'; id: string }>
   descendants: Array<{ __typename?: 'Tag'; id: string }>


### PR DESCRIPTION
<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(libs-ui-component): must begin with lowercase` -->

## Description

This PR fixes issues with error during importing types and atoms to the DB, and errors with opening Apps

- during atoms and types import, use `name` instead of id to upsert. ReactFragment already exists in the database by the moment the import command is run, and the ReactFragment is seeded with a random id, and error was thrown when it was seeded with a different ID during import.
- comment out tag.isRoot for now
- after codegen command was run - it appeared that one file was not committed, so it was added in this PR
- add a missing reference to the page for elements. Without it, an error is thrown on an attempt to render a page

## Video or Image

<!-- Add video or image showing how the new feature works -->

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged -->

Fixes #
