### PR TITLE
fix: component props undefined in props evaluation context

### DIFF
--- a/libs/frontend/application/renderer/src/render.service.ts
+++ b/libs/frontend/application/renderer/src/render.service.ts
@@ -3,11 +3,7 @@ import type {
   IRenderService,
   RendererProps,
 } from '@codelab/frontend/abstract/domain'
-import {
-  componentRef,
-  getRendererId,
-  RendererType,
-} from '@codelab/frontend/abstract/domain'
+import { getRendererId } from '@codelab/frontend/abstract/domain'
 import type { Nullable } from '@codelab/shared/abstract/types'
 import type { Ref } from 'mobx-keystone'
 import { Model, model, modelAction, objectMap, prop } from 'mobx-keystone'
@@ -30,17 +26,6 @@ export class RenderService
 
     if (!renderer) {
       renderer = Renderer.create(props)
-
-      /**
-       * setup runtime props for component builder
-       * this is different from the one created in component-render-pipe
-       * because the other one creates runtime props for component instances
-       * while this one doesn't pass by the component pipe at all
-       */
-
-      if (props.rendererType === RendererType.ComponentBuilder) {
-        renderer.addRuntimeProps(componentRef(props.id))
-      }
 
       this.renderers.set(props.id, renderer)
     }

--- a/libs/frontend/application/renderer/src/renderer.model.ts
+++ b/libs/frontend/application/renderer/src/renderer.model.ts
@@ -355,11 +355,22 @@ export class Renderer
   renderRoot() {
     const root = this.elementTree.maybeCurrent?.rootElement.current
     const providerRoot = this.providerTree?.current.rootElement.current
+    const parentComponent = root?.parentComponent
 
     if (!root) {
       console.warn('Renderer: No root element found')
 
       return null
+    }
+
+    if (parentComponent) {
+      /**
+       * setup runtime props for component builder
+       * this is different from the one created in component-render-pipe
+       * because the other one creates runtime props for component instances
+       * while this one doesn't pass by the component pipe at all
+       */
+      this.addRuntimeProps(componentRef(parentComponent.id))
     }
 
     return providerRoot && root.page?.current.kind === IPageKind.Regular

--- a/libs/frontend/domain/element/src/store/element.model.ts
+++ b/libs/frontend/domain/element/src/store/element.model.ts
@@ -374,7 +374,7 @@ export class Element
 
   @computed
   get propsEvaluationContext(): IEvaluationContext {
-    const component = this.parentComponent?.current
+    const component = this.closestSubTreeRootElement.parentComponent?.current
 
     return {
       actions: this.store.current.actionRunners,


### PR DESCRIPTION
## Description

Issue used to happen because

1. Component props are not attached to the builder unless it is in a `component-builder` mode
2. no element inside the component other than the root had access to the component props no matter what.

## Video or Image

1. first component testing component props usage in the root element
2. second component testing component props usage in another element

https://github.com/codelab-app/platform/assets/51242349/5db576be-1b2f-4c3e-8cae-2f39f099d9e7

## Related Issue(s)

Fixes #3070
