### PR TITLE
fix: loading incorrect page when opening an app

### DIFF
--- a/libs/frontend/application/app/src/use-cases/app-development/useAppDevlopment.hook.ts
+++ b/libs/frontend/application/app/src/use-cases/app-development/useAppDevlopment.hook.ts
@@ -54,7 +54,7 @@ export const useAppDevelopment = ({ rendererType }: DevelopmentPageProps) => {
 
       const page = find(
         Array.from(pageService.pages.values()),
-        (_page) => _page.name === pageName,
+        (_page) => _page.name === pageName && _page.app.id === app.id,
       )
 
       if (!page) {


### PR DESCRIPTION
<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(libs-ui-component): must begin with lowercase` -->

## Description

When attempting to open an app, if there are multiple apps available, the elements from the first app always load regardless of which app is selected. This issue arises because we are getting the page based on its name alone, rather than using both the name and the app id.

## Video or Image


https://github.com/codelab-app/platform/assets/32300655/48b6a9bc-5350-4398-8c3a-6f9e43da7e51



## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged -->

Fixes #
