### PR TITLE
fix: persist element render type in the db

### DIFF
--- a/libs/frontend/domain/element/src/store/element.model.ts
+++ b/libs/frontend/domain/element/src/store/element.model.ts
@@ -31,6 +31,7 @@ import {
   isAtom,
   isAtomRef,
   isComponent,
+  isComponentRef,
   pageRef,
   propRef,
   RendererType,
@@ -45,6 +46,7 @@ import type { IEntity, Nullable } from '@codelab/shared/abstract/types'
 import { Maybe, Nullish } from '@codelab/shared/abstract/types'
 import {
   connectNodeId,
+  disconnectAll,
   disconnectNodeId,
   ElementProperties,
   reconnectNodeId,
@@ -849,12 +851,12 @@ export class Element
     // We need to disconnect the atom if render type changed to component or empty
     const renderAtomType = isAtomRef(this.renderType)
       ? reconnectNodeId(this.renderType.id)
-      : disconnectNodeId(undefined)
+      : disconnectAll()
 
     // We need to disconnect the component if render type changed to atom or empty
-    const renderComponentType = isComponent(this.renderType)
+    const renderComponentType = isComponentRef(this.renderType)
       ? reconnectNodeId(this.renderType.id)
-      : disconnectNodeId(undefined)
+      : disconnectAll()
 
     const preRenderAction = this.preRenderAction?.id
       ? reconnectNodeId(this.preRenderAction.id)
@@ -885,12 +887,8 @@ export class Element
       renderForEachPropKey: this.renderForEachPropKey,
       renderIfExpression: this.renderIfExpression,
       renderType: {
-        Atom: isAtomRef(this.renderType)
-          ? connectNodeId(this.renderType.id)
-          : undefined,
-        Component: isComponent(this.renderType)
-          ? connectNodeId(this.renderType.id)
-          : undefined,
+        Atom: renderAtomType,
+        Component: renderComponentType,
       },
       style: this.style,
       tailwindClassNames: this.tailwindClassNames,


### PR DESCRIPTION
## Description

This pr fixes 2 issue

1. Setting the render type to a component is not persisted.
2. Changing render type would not cause the removal of the previous render type. Render types are just added to the element instead.

## Video or Image

https://github.com/codelab-app/platform/assets/51242349/689feacc-858f-47e1-9799-4d7f6148b912


## Related Issue(s)

Fixes #3079
