### PR TITLE
fix: use existing atoms as fallback in dropdown

### DIFF
--- a/libs/frontend/application/atom/src/use-cases/select-atom/SelectAtom.tsx
+++ b/libs/frontend/application/atom/src/use-cases/select-atom/SelectAtom.tsx
@@ -1,5 +1,6 @@
 import type { IAtomModel } from '@codelab/frontend/abstract/domain'
 import { useStore } from '@codelab/frontend/application/shared/store'
+import { mapAtomOptions } from '@codelab/frontend/domain/atom'
 import type { UniformSelectFieldProps } from '@codelab/shared/abstract/types'
 import { useAsync } from '@react-hookz/web'
 import React from 'react'
@@ -19,6 +20,7 @@ export type SelectAtomProps = Pick<
 export const SelectAtom = ({ error, label, name, parent }: SelectAtomProps) => {
   const { atomService } = useStore()
   const [fieldProps] = useField<{ value?: string }>(name, {})
+  const fallbackAtomOptions = atomService.atomsList.map(mapAtomOptions)
 
   const [{ error: queryError, result, status }, getSelectAtomOptions] =
     useAsync(() => atomService.getSelectAtomOptions(fieldProps, parent))
@@ -37,7 +39,7 @@ export const SelectAtom = ({ error, label, name, parent }: SelectAtomProps) => {
       }}
       optionFilterProp="label"
       optionLabelProp="label"
-      options={result}
+      options={result ?? fallbackAtomOptions}
       showSearch
     />
   )


### PR DESCRIPTION
<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(libs-ui-component): must begin with lowercase` -->

## Description

<!-- This is a short description on the Pull Request -->

## Video or Image

https://github.com/codelab-app/platform/assets/74900868/f3a926fc-e1da-43b0-aeff-ed8e8dbb0418

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged -->

Fixes #3086 
