### PR TITLE
feat: support ReactNode type for components

### DIFF
--- a/data/export-v3/admin/atoms/HtmlDiv.json
+++ b/data/export-v3/admin/atoms/HtmlDiv.json
@@ -1,7 +1,24 @@
 {
   "api": {
     "__typename": "InterfaceType",
-    "fields": [],
+    "fields": [
+      {
+        "api": {
+          "id": "b3054c85-a130-4e3e-b889-13bf286acbc2"
+        },
+        "defaultValues": "null",
+        "description": "Binds a component prop into the current element's children",
+        "fieldType": {
+          "id": "7333edde-f8f5-4d3c-a595-01b5585b37da"
+        },
+        "id": "374be3ad-e7ad-4367-8ef7-c83bd7ff3e2d",
+        "key": "codelab_internal_prop_binding_children",
+        "name": "Children (Prop Binding)",
+        "nextSibling": null,
+        "prevSibling": null,
+        "validationRules": "{}"
+      }
+    ],
     "id": "b3054c85-a130-4e3e-b889-13bf286acbc2",
     "kind": "InterfaceType",
     "name": "HtmlDiv API",
@@ -27,7 +44,7 @@
     "id": "1bb6993d-8f45-4098-90bc-5d09a414c10e",
     "name": "HtmlDiv",
     "owner": {
-      "id": "0147b1b3-03b2-469a-b94e-c7fe3239edda"
+      "id": "78b08172-d643-4adf-9044-cd2dc5e2a47a"
     },
     "requiredParents": [],
     "suggestedChildren": [],

--- a/libs/frontend/abstract/application/src/component/component.application.service.interface.ts
+++ b/libs/frontend/abstract/application/src/component/component.application.service.interface.ts
@@ -31,6 +31,6 @@ export interface IComponentApplicationService
   componentDomainService: IComponentDomainService
   componentRepository: IComponentRepository
   createForm: IFormService
-
+  getSelectActiveComponentPropOptions(): Array<DefaultOptionType>
   getSelectComponentOptions(): Promise<Array<DefaultOptionType>>
 }

--- a/libs/frontend/abstract/domain/src/shared/constant.ts
+++ b/libs/frontend/abstract/domain/src/shared/constant.ts
@@ -36,7 +36,8 @@ export const LAST_WORD_AFTER_DOT_REGEX = /\.\w+$/
 
 export const WORD_BEFORE_DOT_REGEX = /\w*(\.)?/
 
-export const CUSTOM_TEXT_PROP_KEY = 'customText'
+export const TEXT_CHILDREN = 'textChildren'
+export const PROP_BINDING_CHILDREN = 'codelab_internal_prop_binding_children'
 
 // export const DEFAULT_GET_SERVER_SIDE_PROPS = `async function (context) {
 //     return {

--- a/libs/frontend/application/component/src/services/component.application.service.ts
+++ b/libs/frontend/application/component/src/services/component.application.service.ts
@@ -287,6 +287,21 @@ export class ComponentApplicationService
     }))
   })
 
+  getSelectActiveComponentPropOptions = () => {
+    const activeComponent = this.builderService.activeComponent?.current
+
+    if (!activeComponent) {
+      return []
+    }
+
+    const componentProps = activeComponent.props.values
+
+    return Object.keys(componentProps).map((key) => ({
+      label: `props.${key}`,
+      value: `{{componentProps.${key}}}`,
+    }))
+  }
+
   @modelFlow
   @transaction
   update = _async(function* (

--- a/libs/frontend/application/element/src/use-cases/element/update-element-props/UpdateElementPropsForm.tsx
+++ b/libs/frontend/application/element/src/use-cases/element/update-element-props/UpdateElementPropsForm.tsx
@@ -1,5 +1,8 @@
 import type { IElementModel } from '@codelab/frontend/abstract/domain'
-import { isComponent } from '@codelab/frontend/abstract/domain'
+import {
+  isComponent,
+  PROP_BINDING_CHILDREN,
+} from '@codelab/frontend/abstract/domain'
 import type { SubmitController } from '@codelab/frontend/abstract/types'
 import { AdminPropsPanel } from '@codelab/frontend/application/admin'
 import { useStore } from '@codelab/frontend/application/shared/store'
@@ -21,13 +24,12 @@ export interface UpdateElementPropsFormProps {
 
 export const UpdateElementPropsForm = observer<UpdateElementPropsFormProps>(
   ({ element }) => {
-    const {
-      builderService,
-      componentService,
-      propService,
-      rendererService,
-      typeService,
-    } = useStore()
+    const { componentService, propService, rendererService, typeService } =
+      useStore()
+
+    const activeComponent =
+      rendererService.activeElementTree?.rootElement.current.parentComponent
+        ?.maybeCurrent
 
     const currentElement = element.current
     const apiId = currentElement.renderType.current.api.id
@@ -84,6 +86,14 @@ export const UpdateElementPropsForm = observer<UpdateElementPropsFormProps>(
     const runtimeElement = rendererService.runtimeElement(currentElement)
     const runtimeProps = runtimeElement?.runtimeProps
 
+    const isFieldHidden = (interfaceId: string, fieldKey: string) => {
+      return (
+        !activeComponent &&
+        interfaceType?.id === interfaceId &&
+        fieldKey === PROP_BINDING_CHILDREN
+      )
+    }
+
     return (
       <Spinner isLoading={status === 'loading'}>
         {interfaceType && (
@@ -94,6 +104,7 @@ export const UpdateElementPropsForm = observer<UpdateElementPropsFormProps>(
                 autosave
                 initialSchema={{}}
                 interfaceType={interfaceType}
+                isFieldHidden={isFieldHidden}
                 key={element.id}
                 model={propsModel}
                 onSubmit={onSubmit}

--- a/libs/frontend/application/renderer/src/element/wrapper.utils.ts
+++ b/libs/frontend/application/renderer/src/element/wrapper.utils.ts
@@ -1,8 +1,8 @@
 import type { IRenderOutput } from '@codelab/frontend/abstract/application'
 import { RendererType } from '@codelab/frontend/abstract/application'
 import {
-  CUSTOM_TEXT_PROP_KEY,
   DATA_COMPONENT_ID,
+  TEXT_CHILDREN,
 } from '@codelab/frontend/abstract/domain'
 import { IAtomType } from '@codelab/shared/abstract/core'
 import type { Nullable } from '@codelab/shared/abstract/types'
@@ -32,7 +32,7 @@ export const extractValidProps = (
 ) =>
   ReactComponent === Fragment
     ? { key: renderOutput.props?.['key'] }
-    : omit(renderOutput.props, [CUSTOM_TEXT_PROP_KEY])
+    : omit(renderOutput.props, [TEXT_CHILDREN])
 
 export const getReactComponent = (renderOutput: IRenderOutput) => {
   // if component does not have atom assigned to the root element

--- a/libs/frontend/application/renderer/src/runtime-element-prop.model.ts
+++ b/libs/frontend/application/renderer/src/runtime-element-prop.model.ts
@@ -12,13 +12,13 @@ import {
   runtimeElementRef,
 } from '@codelab/frontend/abstract/application'
 import {
-  CUSTOM_TEXT_PROP_KEY,
   DATA_ELEMENT_ID,
   elementRef,
   IComponentModel,
   IElementModel,
   isAtomRef,
   isTypedProp,
+  TEXT_CHILDREN,
 } from '@codelab/frontend/abstract/domain'
 import {
   evaluateExpression,
@@ -161,13 +161,11 @@ export class RuntimeElementProps
       )
     }
 
-    const customTextProp =
-      this.element.current.props.values[CUSTOM_TEXT_PROP_KEY]
-
-    const props = omit(this.renderedTypedProps, [CUSTOM_TEXT_PROP_KEY])
+    const customTextProp = this.element.current.props.values[TEXT_CHILDREN]
+    const props = omit(this.renderedTypedProps, [TEXT_CHILDREN])
     const evaluated = evaluateObject(props, this.propsEvaluationContext)
 
-    return { ...evaluated, [CUSTOM_TEXT_PROP_KEY]: customTextProp }
+    return { ...evaluated, [TEXT_CHILDREN]: customTextProp }
   }
 
   @computed

--- a/libs/frontend/application/renderer/src/runtime-element.model.ts
+++ b/libs/frontend/application/renderer/src/runtime-element.model.ts
@@ -17,12 +17,13 @@ import type {
   IPageModel,
 } from '@codelab/frontend/abstract/domain'
 import {
-  CUSTOM_TEXT_PROP_KEY,
   elementRef,
   IElementModel,
   isAtom,
   isComponent,
   isPage,
+  PROP_BINDING_CHILDREN,
+  TEXT_CHILDREN,
 } from '@codelab/frontend/abstract/domain'
 import {
   evaluateExpression,
@@ -258,9 +259,17 @@ export class RuntimeElement
     const hasOneChild = this.sortedRuntimeChildren.length === 1
 
     if (hasNoChildren) {
-      // Inject text, but only if we have no regular children
+      // Inject prop or text, but only if we have no regular children
+      // (prop binding has precedence)
+      const injectedProp =
+        this.runtimeProps.evaluatedProps[PROP_BINDING_CHILDREN]
+
       const injectedText =
-        this.runtimeProps.evaluatedProps[CUSTOM_TEXT_PROP_KEY] || '""'
+        this.runtimeProps.evaluatedProps[TEXT_CHILDREN] || '""'
+
+      if (injectedProp) {
+        return injectedProp
+      }
 
       const shouldInjectText =
         isAtom(this.element.current.renderType.current) &&

--- a/libs/frontend/application/shared/core/src/state-expression.ts
+++ b/libs/frontend/application/shared/core/src/state-expression.ts
@@ -12,6 +12,9 @@ import {
   STATE_PATH_TEMPLATE_START,
 } from './state-expression.constants'
 
+export const isComponentPropsStateExpression = (str: unknown) =>
+  isString(str) && /{{componentProps\.[a-zA-Z0-9_]+}}/g.test(str)
+
 export const hasStateExpression = (str: unknown): boolean =>
   isString(str) &&
   str.includes(STATE_PATH_TEMPLATE_START) &&

--- a/libs/frontend/application/type/src/interface-form/fields/select-component/SelectComponent.tsx
+++ b/libs/frontend/application/type/src/interface-form/fields/select-component/SelectComponent.tsx
@@ -16,6 +16,9 @@ export const SelectComponent = ({ ...fieldProps }: SelectComponentProps) => {
   const [{ error: queryError, result, status }, getSelectComponentOptions] =
     useAsync(() => componentService.getSelectComponentOptions())
 
+  const componentOptions = result || []
+  const propOptions = componentService.getSelectActiveComponentPropOptions()
+
   return (
     <SelectField
       {...fieldProps}
@@ -28,7 +31,7 @@ export const SelectComponent = ({ ...fieldProps }: SelectComponentProps) => {
         }
       }}
       optionFilterProp="label"
-      options={result}
+      options={[...componentOptions, ...propOptions]}
       showSearch
     />
   )

--- a/libs/frontend/application/type/src/interface-form/type-schema.factory.ts
+++ b/libs/frontend/application/type/src/interface-form/type-schema.factory.ts
@@ -129,7 +129,13 @@ export class TypeSchemaFactory {
       field: IFieldModel,
     ) => {
       acc = acc || {}
-      acc[field.key] = makeFieldSchema(field)
+
+      if (
+        !context?.isFieldHidden ||
+        !context.isFieldHidden(type.id, field.key)
+      ) {
+        acc[field.key] = makeFieldSchema(field)
+      }
 
       return acc
     }

--- a/libs/frontend/application/type/src/interface-form/types.ts
+++ b/libs/frontend/application/type/src/interface-form/types.ts
@@ -36,4 +36,9 @@ export interface UiPropertiesContext {
   defaultValues?: IFieldDefaultValue | null
   fieldName?: string | null
   validationRules?: IValidationRules
+  /**
+   * used to hide some interface fields if they're irrelevant.
+   * if undefined all fields are visible
+   */
+  isFieldHidden?(interfaceId: string, fieldKey: string): boolean
 }

--- a/libs/frontend/application/type/src/interface-form/ui-properties/select-component-ui-properties.ts
+++ b/libs/frontend/application/type/src/interface-form/ui-properties/select-component-ui-properties.ts
@@ -2,6 +2,10 @@ import {
   createAutoCompleteOptions,
   ToggleExpressionField,
 } from '@codelab/frontend/presentation/view'
+import {
+  hasStateExpression,
+  isComponentPropsStateExpression,
+} from '@codelab/frontend/shared/utils'
 import { SelectComponent } from '../fields'
 import type { UiPropertiesFn } from '../types'
 
@@ -31,6 +35,8 @@ export const selectComponentUiProperties: UiPropertiesFn = (type, context) => ({
           onChange(lastValue ?? field.default)
         }
       },
+      shouldAutoToggleExpressionEditor: (value) =>
+        !isComponentPropsStateExpression(value) && hasStateExpression(value),
     }),
   },
 })

--- a/libs/frontend/application/type/src/interface-form/ui-properties/select-component-ui-properties.ts
+++ b/libs/frontend/application/type/src/interface-form/ui-properties/select-component-ui-properties.ts
@@ -1,11 +1,11 @@
 import {
+  hasStateExpression,
+  isComponentPropsStateExpression,
+} from '@codelab/frontend/application/shared/core'
+import {
   createAutoCompleteOptions,
   ToggleExpressionField,
 } from '@codelab/frontend/presentation/view'
-import {
-  hasStateExpression,
-  isComponentPropsStateExpression,
-} from '@codelab/frontend/shared/utils'
 import { SelectComponent } from '../fields'
 import type { UiPropertiesFn } from '../types'
 

--- a/libs/frontend/application/type/src/props-form/PropsForm.tsx
+++ b/libs/frontend/application/type/src/props-form/PropsForm.tsx
@@ -7,6 +7,7 @@ import type { IPropData } from '@codelab/shared/abstract/core'
 import { observer } from 'mobx-react-lite'
 import React from 'react'
 import type { DeepPartial } from 'utility-types'
+import type { UiPropertiesContext } from '../interface-form'
 import { InterfaceForm } from '../interface-form'
 
 export interface PropsFormProps
@@ -20,6 +21,7 @@ export interface PropsFormProps
   cssString?: string
   initialSchema?: object
   interfaceType?: IInterfaceTypeModel
+  isFieldHidden?: UiPropertiesContext['isFieldHidden']
   model?: IPropData
   setIsLoading?: SetIsLoading
 
@@ -36,6 +38,7 @@ export const PropsForm = observer<PropsFormProps>(
     cssString,
     initialSchema,
     interfaceType,
+    isFieldHidden,
     model,
     onSubmit,
     onSubmitError,
@@ -56,7 +59,7 @@ export const PropsForm = observer<PropsFormProps>(
       >
         <InterfaceForm
           autosave={autosave}
-          context={{ autocomplete }}
+          context={{ autocomplete, isFieldHidden }}
           initialSchema={initialSchema}
           interfaceType={interfaceType}
           model={model || {}}

--- a/libs/frontend/domain/builder/src/builder.domain.service.ts
+++ b/libs/frontend/domain/builder/src/builder.domain.service.ts
@@ -55,21 +55,9 @@ export class BuilderDomainService
    */
   @computed
   get activeComponent() {
-    const { selectedNode } = this
+    const { activeElementTree } = this
 
-    if (!selectedNode) {
-      return null
-    }
-
-    if (isComponentRef(selectedNode)) {
-      return selectedNode
-    }
-
-    if (isElementRef(selectedNode)) {
-      return selectedNode.current.parentComponent ?? null
-    }
-
-    return null
+    return activeElementTree?.rootElement.current.parentComponent ?? null
   }
 
   /**

--- a/libs/frontend/domain/prop/src/store/prop.model.ts
+++ b/libs/frontend/domain/prop/src/store/prop.model.ts
@@ -2,10 +2,7 @@ import type {
   IInterfaceTypeModel,
   IPropModel,
 } from '@codelab/frontend/abstract/domain'
-import {
-  CUSTOM_TEXT_PROP_KEY,
-  typeRef,
-} from '@codelab/frontend/abstract/domain'
+import { TEXT_CHILDREN, typeRef } from '@codelab/frontend/abstract/domain'
 import type {
   PropCreateInput,
   PropUpdateInput,
@@ -80,7 +77,7 @@ export class Prop
       return omitBy(this.data.data, (_, key) => {
         // CUSTOM_TEXT_PROP_KEY is a special case, it's an element prop
         // that is not part of the api
-        if (key === CUSTOM_TEXT_PROP_KEY) {
+        if (key === TEXT_CHILDREN) {
           return false
         }
 

--- a/libs/frontend/presentation/view/components/form/fields/ToggleExpressionField.tsx
+++ b/libs/frontend/presentation/view/components/form/fields/ToggleExpressionField.tsx
@@ -25,6 +25,7 @@ interface CodeMirrorFieldProps {
     props: CodeMirrorConnectFieldProps,
     lastValue?: Value,
   ): void
+  shouldAutoToggleExpressionEditor?(value: unknown): boolean
 }
 
 type CodeMirrorConnectFieldProps = FieldProps<Value, InnerProps>
@@ -77,7 +78,10 @@ const ToggleExpression = ({
     ? String(fieldProps.value ?? fieldProps.field?.default)
     : undefined
 
-  const isExpression = value && hasStateExpression(value)
+  const hasExpression =
+    mainProps.shouldAutoToggleExpressionEditor ?? hasStateExpression
+
+  const isExpression = value && hasExpression(value)
   const [showExpressionEditor, setShowExpressionEditor] = useState(isExpression)
   const [valueBeforeToggle, setValueBeforeToggle] = useState<Value>()
 


### PR DESCRIPTION
## Description

This PR mainly adds support for binding component props to the children of any of the component elements.

The implementation involves allowing `SelectComponent` field to view the component props of type `ReactNodeType` as part of the options in addition to the default options (the components).

The reason this solution is picked include:

1. This approach utilizes the existing type transformer.
2. Allows for the use of the component props for any atom that accepts `ReactNodeType` for any of it's props (previously limited to components only).

## Video or Image


https://github.com/codelab-app/platform/assets/51242349/e6ac226b-4db2-4e4d-845e-8734842ec4e8



## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged -->

Fixes #3104
