### PR TITLE
fix: production deployment and import fixes

### DIFF
--- a/apps/platform-api/pages/api/data/[[...index]].ts
+++ b/apps/platform-api/pages/api/data/[[...index]].ts
@@ -39,6 +39,7 @@ export const config = {
      */
     externalResolver: true,
   },
+  maxDuration: 60,
 }
 
 export default handler

--- a/apps/platform-api/pages/api/graphql.ts
+++ b/apps/platform-api/pages/api/graphql.ts
@@ -22,6 +22,7 @@ export const config = {
      */
     externalResolver: true,
   },
+  maxDuration: 60,
 }
 
 export default handler

--- a/apps/platform/pages/api/[[...index]].ts
+++ b/apps/platform/pages/api/[[...index]].ts
@@ -1,3 +1,7 @@
 import { proxyMiddleware } from '@codelab/backend/infra/adapter/graphql'
 
 export default proxyMiddleware
+
+export const config = {
+  maxDuration: 60,
+}

--- a/apps/platform/pages/api/auth/[...auth0].ts
+++ b/apps/platform/pages/api/auth/[...auth0].ts
@@ -3,6 +3,10 @@ import { getEnv } from '@codelab/shared/config'
 import { auth0Instance } from '@codelab/shared/infra/auth0'
 import type { NextApiRequest, NextApiResponse } from 'next'
 
+export const config = {
+  maxDuration: 60,
+}
+
 export default auth0Instance().handleAuth({
   callback: async (req: NextApiRequest, res: NextApiResponse) => {
     try {

--- a/libs/backend/application/admin/src/use-case/seed-data/seeder.application.service.ts
+++ b/libs/backend/application/admin/src/use-case/seed-data/seeder.application.service.ts
@@ -22,6 +22,12 @@ export class SeederApplicationService {
   async seedDevBootstrapData() {
     await this.seederApplicationService.seedUserFromRequest()
 
+    // in production we don't want to seed the database
+    // each time any user logs-in
+    if (process.env['NODE_ENV'] !== 'development') {
+      return
+    }
+
     await this.commandBus.execute<ImportSystemTypesCommand>(
       new ImportSystemTypesCommand(),
     )

--- a/libs/backend/application/atom/src/use-case/import-atom.command.service.ts
+++ b/libs/backend/application/atom/src/use-case/import-atom.command.service.ts
@@ -5,7 +5,6 @@ import { IAtomBoundedContext } from '@codelab/shared/abstract/core'
 import { Injectable } from '@nestjs/common'
 import type { ICommandHandler } from '@nestjs/cqrs'
 import { CommandBus, CommandHandler } from '@nestjs/cqrs'
-import omit from 'lodash/omit'
 
 @Injectable()
 export class ImportAtomCommand {
@@ -29,14 +28,6 @@ export class ImportAtomHandler
 
     await this.commandBus.execute<ImportApiCommand>(new ImportApiCommand(api))
 
-    /**
-     * Create all atoms but omit `suggestedChildren`, since it requires all atoms to be added first
-     */
-    await this.atomRepository.save(omit(atom, ['suggestedChildren']))
-
-    /**
-     * Here we assign suggestedChildren, since all atoms must be created first
-     */
     await this.atomRepository.save(atom)
   }
 }

--- a/libs/backend/domain/tag/src/repository/tag.repo.service.ts
+++ b/libs/backend/domain/tag/src/repository/tag.repo.service.ts
@@ -74,16 +74,16 @@ export class TagRepository extends AbstractRepository<
     where: TagWhere,
   ) {
     // Get existing tag so we know what to connect/disconnect
-    const existing = await this.findOne(where)
+    // const existing = await this.findOne(where)
 
-    if (!existing) {
-      return undefined
-    }
+    // if (!existing) {
+    //   return undefined
+    // }
 
     /**
      * Parent
      */
-    const parentTagToConnect = parent?.id
+    // const parentTagToConnect = parent?.id
     const childrenTagsToConnect = children?.map((child) => child.id)
 
     // cLog('Existing:', tag, 'Tags to connect', parentTagToConnect)

--- a/terraform/modules/vercel-platform-api/project.tf
+++ b/terraform/modules/vercel-platform-api/project.tf
@@ -25,8 +25,43 @@ resource "vercel_project" "platform_api" {
     # Auth0
     {
       target = ["production", "preview"]
+      key    = "AUTH0_M2M_CLIENT_ID"
+      value  = var.auth0_m2m_client_id
+    },
+    {
+      target = ["production", "preview"]
+      key    = "AUTH0_M2M_CLIENT_SECRET"
+      value  = var.auth0_m2m_client_secret
+    },
+    {
+      target = ["production", "preview"]
       key    = "AUTH0_ISSUER_BASE_URL"
       value  = var.auth0_issuer_base_url
+    },
+    {
+      target = ["production", "preview"]
+      key    = "AUTH0_BASE_URL"
+      value  = var.next_public_platform_api_host
+    },
+    {
+      target = ["production", "preview"]
+      key    = "AUTH0_SECRET"
+      value  = var.auth0_secret
+    },
+    {
+      target = ["production", "preview"]
+      key    = "AUTH0_CLIENT_SECRET"
+      value = var.auth0_web_client_secret
+    },
+    {
+      target = ["production", "preview"]
+      key    = "AUTH0_CLIENT_ID"
+      value = var.auth0_web_client_id
+    },
+    {
+      target = ["production", "preview"]
+      key    = "AUTH0_AUDIENCE"
+      value  = "${var.auth0_issuer_base_url}api/v2/"
     },
     # Neo4j
     {


### PR DESCRIPTION
<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(libs-ui-component): must begin with lowercase` -->

## Description

- fix environment variables for vercel production deployments
- increase `maxDuration` for serverless function on Vercel from 15s to 60s, since requests often rejected by timeout
- fix atoms import: import all atoms without `suggestedChildren` first, and then selectively update atoms that have `suggestedChildren`
- after user logs in - skip `importSystemTypes` and only seed user from request. This speeds up login as well as does not require us to deploy `data/export-v3` folder
- remove redundant request inside of `update` method in tag.repository, since it is not used anymore (previously it was used to get current value of tag `parent` property)

## Video or Image

<!-- Add video or image showing how the new feature works -->

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged -->

Fixes #
