### PR TITLE
fix: error during export

### DIFF
--- a/libs/backend/application/atom/src/services/atom.application.service.ts
+++ b/libs/backend/application/atom/src/services/atom.application.service.ts
@@ -25,13 +25,14 @@ export class AtomApplicationService {
       selectionSet: `{ id }`,
     })
 
-    return await Promise.all(
-      atomIds.map(
-        async ({ id }) =>
-          await this.commandBus.execute<ExportAtomCommand, IAtomBoundedContext>(
-            new ExportAtomCommand({ id }),
-          ),
-      ),
-    )
+    const exportedAtoms = []
+
+    for (const { id } of atomIds) {
+      exportedAtoms.push(
+        await this.commandBus.execute(new ExportAtomCommand({ id })),
+      )
+    }
+
+    return exportedAtoms
   }
 }

--- a/libs/backend/domain/atom/src/repository/atom.repo.service.ts
+++ b/libs/backend/domain/atom/src/repository/atom.repo.service.ts
@@ -84,18 +84,16 @@ export class AtomRepository extends AbstractRepository<
 
   protected async _find({
     options,
+    selectionSet = `{ ${atomSelectionSet} }`,
     where,
   }: {
     where?: AtomWhere
     options?: AtomOptions
+    selectionSet?: string
   }) {
     return await (
       await this.ogmService.Atom
-    ).find({
-      options,
-      selectionSet: `{ ${atomSelectionSet} }`,
-      where,
-    })
+    ).find({ options, selectionSet, where })
   }
 
   protected async _update(

--- a/libs/backend/infra/core/src/abstract.repository.ts
+++ b/libs/backend/infra/core/src/abstract.repository.ts
@@ -45,7 +45,11 @@ export abstract class AbstractRepository<
     })
   }
 
-  find(args?: { where?: Where; options?: Options }): Promise<Array<ModelData>>
+  find(args?: {
+    where?: Where
+    options?: Options
+    selectionSet?: string
+  }): Promise<Array<ModelData>>
 
   find<T extends TAnySchema>(
     args: {
@@ -64,17 +68,19 @@ export abstract class AbstractRepository<
   async find<T extends TAnySchema>(
     {
       options,
+      selectionSet,
       where,
     }: {
       where?: Where
       options?: Options
+      selectionSet?: string
     } = {},
     schema?: T,
   ): Promise<Array<ModelData> | Array<Static<T>>> {
     return withActiveSpan(`${this.constructor.name}.find`, async (span) => {
       this.traceService.addJsonAttributes('where', where)
 
-      const results = await this._find({ options, where })
+      const results = await this._find({ options, selectionSet, where })
 
       this.traceService.addJsonAttributes('results', results)
 
@@ -184,10 +190,12 @@ export abstract class AbstractRepository<
 
   protected abstract _find({
     options,
+    selectionSet,
     where,
   }: {
     where?: Where
     options?: Options
+    selectionSet?: string
   }): Promise<Array<ModelData>>
 
   protected abstract _update(


### PR DESCRIPTION
<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(libs-ui-component): must begin with lowercase` -->

## Description

- an error was thrown during atoms export (too many opened DB connections) because all atoms were imported in parallel. Instead import 10 at a time
- allow to specify `selectionSet` in backend repo classes for more effective queries. In future can benefit from this also by updating `exists` method on all repos to fetch only record `id` instead of getting entire record with all relationships

## Video or Image

<!-- Add video or image showing how the new feature works -->

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged -->

Fixes #
