### PR TITLE
fix: cant create component due to ref issue

### DIFF
--- a/libs/frontend/application/component/src/services/component.application.service.ts
+++ b/libs/frontend/application/component/src/services/component.application.service.ts
@@ -131,10 +131,6 @@ export class ComponentApplicationService
           },
         })
 
-    if (!rootElement) {
-      yield* _await(this.elementService.elementRepository.add(rootElementModel))
-    }
-
     const component = this.componentDomainService.hydrate({
       api,
       childrenContainerElement: { id: rootElementModel.id },
@@ -144,6 +140,10 @@ export class ComponentApplicationService
       rootElement: rootElementModel,
       store,
     })
+
+    if (!rootElement) {
+      yield* _await(this.elementService.elementRepository.add(rootElementModel))
+    }
 
     yield* _await(this.componentRepository.add(component))
 


### PR DESCRIPTION
<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(libs-ui-component): must begin with lowercase` -->

## Description

<!-- This is a short description on the Pull Request -->
The [closestContainerNode](https://github.com/codelab-app/platform/blob/da360f07606f0ebef0f758fcf7f0e5253301bb66/libs/frontend/domain/element/src/store/element.model.ts#L231) in [toCreateInput](https://github.com/codelab-app/platform/blob/da360f07606f0ebef0f758fcf7f0e5253301bb66/libs/frontend/domain/element/src/store/element.model.ts#L623) is needed but the current code causes the ref issue for the parent component because it has not been hydrated yet in the cache.

This PR updates the logic so that we only do the mutations after the hydrations in the cache so that the refs are resolved successfully.

~Also includes the fix for the missing `tagDomainServiceContext`  error~ Looks like this has been fixed already by some other PR that just got merged.

## Video or Image

<!-- Add video or image showing how the new feature works -->

https://github.com/codelab-app/platform/assets/27695022/1923af8e-098b-44e1-a5fa-e5cf29b3f98f



## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged -->

Fixes #3151
