### PR TITLE
chore: clean up unused descendantElements

### DIFF
--- a/libs/backend/domain/element/src/repository/element.repo.service.ts
+++ b/libs/backend/domain/element/src/repository/element.repo.service.ts
@@ -5,7 +5,7 @@ import type {
 } from '@codelab/backend/abstract/codegen'
 import {
   elementSelectionSet,
-  getDescendantsCypher,
+  getElementWithDescendants,
   Neo4jService,
   OgmService,
 } from '@codelab/backend/infra/adapter/neo4j'
@@ -23,7 +23,6 @@ import {
   reconnectNodeId,
 } from '@codelab/shared/domain/mapper'
 import { Injectable } from '@nestjs/common'
-import type { Node } from 'neo4j-driver'
 
 @Injectable()
 export class ElementRepository extends AbstractRepository<
@@ -42,17 +41,8 @@ export class ElementRepository extends AbstractRepository<
   }
 
   async getElementWithDescendants(rootId: string) {
-    return this.neo4jService.withReadTransaction(async (txn) => {
-      const { records } = await txn.run(getDescendantsCypher, { rootId })
-      const descendants = records[0]?.get(0)
-
-      const descendantIds = descendants.map(
-        ({ properties }: Node) => properties.id,
-      )
-
-      return await this.find({
-        where: { id_IN: [rootId, ...descendantIds] },
-      })
+    return getElementWithDescendants(this.neo4jService, this.ogmService, {
+      id: rootId,
     })
   }
 

--- a/libs/backend/infra/adapter/neo4j/src/resolver/index.ts
+++ b/libs/backend/infra/adapter/neo4j/src/resolver/index.ts
@@ -1,1 +1,2 @@
 export * from './pure-resolver'
+export * from './utils'

--- a/libs/backend/infra/adapter/neo4j/src/resolver/ogm-resolver/component/component.resolver.provider.ts
+++ b/libs/backend/infra/adapter/neo4j/src/resolver/ogm-resolver/component/component.resolver.provider.ts
@@ -3,7 +3,7 @@ import type { IFieldResolver, IResolvers } from '@graphql-tools/utils'
 import type { FactoryProvider } from '@nestjs/common'
 import { OgmService } from '../../../infra'
 import { Neo4jService } from '../../../infra/neo4j.service'
-import { getDescendantElements } from '../../utils'
+import { getElementWithDescendants } from '../../utils'
 import { COMPONENT_RESOLVER_PROVIDER } from './component.constant'
 
 export const ComponentResolverProvider: FactoryProvider<
@@ -13,13 +13,13 @@ export const ComponentResolverProvider: FactoryProvider<
   provide: COMPONENT_RESOLVER_PROVIDER,
   useFactory: async (ogmService: OgmService, neo4jService: Neo4jService) => {
     const elements: IFieldResolver<IComponent, unknown> = async (parent) => {
-      const descendants = await getDescendantElements(
+      const elementWithDescendants = await getElementWithDescendants(
         neo4jService,
         ogmService,
         parent.rootElement,
       )
 
-      return [parent.rootElement, ...descendants]
+      return elementWithDescendants
     }
 
     return {

--- a/libs/backend/infra/adapter/neo4j/src/resolver/ogm-resolver/element/element.resolver.provider.ts
+++ b/libs/backend/infra/adapter/neo4j/src/resolver/ogm-resolver/element/element.resolver.provider.ts
@@ -3,7 +3,6 @@ import type { IFieldResolver, IResolvers } from '@graphql-tools/utils'
 import type { FactoryProvider } from '@nestjs/common'
 import { OgmService } from '../../../infra'
 import { Neo4jService } from '../../../infra/neo4j.service'
-import { getDescendantElements } from '../../utils'
 import { ELEMENT_RESOLVER_PROVIDER } from './element.constant'
 import { getDependantTypes } from './util/get-dependant-types'
 
@@ -13,16 +12,12 @@ export const ElementResolverProvider: FactoryProvider<
   inject: [OgmService, Neo4jService],
   provide: ELEMENT_RESOLVER_PROVIDER,
   useFactory: async (ogmService: OgmService, neo4jService: Neo4jService) => {
-    const descendantElements: IFieldResolver<IRef, unknown> = (parent) =>
-      getDescendantElements(neo4jService, ogmService, parent)
-
     const dependantTypes: IFieldResolver<IRef, unknown> = (parent) =>
       getDependantTypes(neo4jService, ogmService, parent)
 
     return {
       Element: {
         dependantTypes,
-        descendantElements,
       },
     }
   },

--- a/libs/backend/infra/adapter/neo4j/src/resolver/ogm-resolver/page/page.resolver.provider.ts
+++ b/libs/backend/infra/adapter/neo4j/src/resolver/ogm-resolver/page/page.resolver.provider.ts
@@ -3,7 +3,7 @@ import type { IFieldResolver, IResolvers } from '@graphql-tools/utils'
 import type { FactoryProvider } from '@nestjs/common'
 import { OgmService } from '../../../infra'
 import { Neo4jService } from '../../../infra/neo4j.service'
-import { getDescendantElements } from '../../utils'
+import { getElementWithDescendants } from '../../utils'
 import { PAGE_RESOLVER_PROVIDER } from './page.constant'
 
 export const PageResolverProvider: FactoryProvider<
@@ -13,13 +13,13 @@ export const PageResolverProvider: FactoryProvider<
   provide: PAGE_RESOLVER_PROVIDER,
   useFactory: async (ogmService: OgmService, neo4jService: Neo4jService) => {
     const elements: IFieldResolver<IPage, unknown> = async (parent) => {
-      const descendants = await getDescendantElements(
+      const elementWithDescendants = await getElementWithDescendants(
         neo4jService,
         ogmService,
         parent.rootElement,
       )
 
-      return [parent.rootElement, ...descendants]
+      return elementWithDescendants
     }
 
     return {

--- a/libs/backend/infra/adapter/neo4j/src/resolver/tests/component.resolver.i.spec.ts
+++ b/libs/backend/infra/adapter/neo4j/src/resolver/tests/component.resolver.i.spec.ts
@@ -240,9 +240,6 @@ describe('PageResolvers', () => {
               name
               rootElement {
                 id
-                descendantElements {
-                  id
-                }
               }
               elements {
                 id
@@ -266,11 +263,6 @@ describe('PageResolvers', () => {
             id: component.id,
             name: component.name,
             rootElement: {
-              descendantElements: [
-                {
-                  id: childElement.id,
-                },
-              ],
               id: rootElement.id,
             },
           },

--- a/libs/backend/infra/adapter/neo4j/src/resolver/tests/page.resolver.i.spec.ts
+++ b/libs/backend/infra/adapter/neo4j/src/resolver/tests/page.resolver.i.spec.ts
@@ -236,9 +236,6 @@ describe('ComponentResolvers', () => {
               slug
               rootElement {
                 id
-                descendantElements {
-                  id
-                }
               }
               elements {
                 id
@@ -262,11 +259,6 @@ describe('ComponentResolvers', () => {
             id: testPage.id,
             name: IPageKindName.Provider,
             rootElement: {
-              descendantElements: [
-                {
-                  id: childElement.id,
-                },
-              ],
               id: rootElement.id,
             },
             slug: IPageKindName.Provider,

--- a/libs/backend/infra/adapter/neo4j/src/resolver/utils/get-descendant-elements.ts
+++ b/libs/backend/infra/adapter/neo4j/src/resolver/utils/get-descendant-elements.ts
@@ -4,7 +4,7 @@ import { getDescendantsCypher } from '../../cypher'
 import type { Neo4jService, OgmService } from '../../infra'
 import { elementSelectionSet } from '../../selectionSet'
 
-export const getDescendantElements = async (
+export const getElementWithDescendants = async (
   neo4jService: Neo4jService,
   ogmService: OgmService,
   parent: IRef,
@@ -23,10 +23,10 @@ export const getDescendantElements = async (
     },
   )
 
-  const decendants = await ogmService.Element.find({
+  const elements = await ogmService.Element.find({
     selectionSet: `{ ${elementSelectionSet} }`,
-    where: { id_IN: descendantIds },
+    where: { id_IN: [parent.id, ...descendantIds] },
   })
 
-  return decendants
+  return elements
 }

--- a/libs/frontend/abstract/domain/src/component/component-development.fragment.graphql
+++ b/libs/frontend/abstract/domain/src/component/component-development.fragment.graphql
@@ -1,10 +1,7 @@
 fragment ComponentDevelopment on Component {
   ...Component
   rootElement {
-    descendantElements {
-      ...Element
-    }
-    ...Element
+    id
   }
   elements {
     ...Element

--- a/libs/frontend/abstract/domain/src/component/component-development.fragment.graphql.gen.ts
+++ b/libs/frontend/abstract/domain/src/component/component-development.fragment.graphql.gen.ts
@@ -14,7 +14,7 @@ import {
   ElementProductionFragmentDoc,
 } from '../element/element.fragment.graphql.gen'
 export type ComponentDevelopmentFragment = {
-  rootElement: { descendantElements: Array<ElementFragment> } & ElementFragment
+  rootElement: { id: string }
   elements: Array<ElementFragment>
 } & ComponentFragment
 
@@ -22,10 +22,7 @@ export const ComponentDevelopmentFragmentDoc = gql`
   fragment ComponentDevelopment on Component {
     ...Component
     rootElement {
-      descendantElements {
-        ...Element
-      }
-      ...Element
+      id
     }
     elements {
       ...Element

--- a/libs/frontend/abstract/domain/src/page/page.fragment.graphql
+++ b/libs/frontend/abstract/domain/src/page/page.fragment.graphql
@@ -29,10 +29,7 @@ fragment Page on Page {
     id
   }
   rootElement {
-    descendantElements {
-      ...Element
-    }
-    ...Element
+    id
   }
   store {
     ...Store
@@ -55,10 +52,7 @@ fragment PageDevelopment on Page {
   }
   # slug
   rootElement {
-    descendantElements {
-      ...Element
-    }
-    ...Element
+    id
   }
   store {
     ...Store
@@ -80,10 +74,7 @@ fragment PageProduction on Page {
     id
   }
   rootElement {
-    descendantElements {
-      ...ElementProduction
-    }
-    ...ElementProduction
+    id
   }
   slug
   store {

--- a/libs/frontend/abstract/domain/src/page/page.fragment.graphql.gen.ts
+++ b/libs/frontend/abstract/domain/src/page/page.fragment.graphql.gen.ts
@@ -1,18 +1,18 @@
 import * as Types from '@codelab/shared/abstract/codegen'
 
+import { StoreFragment } from '../store/store.fragment.graphql.gen'
 import {
   ElementFragment,
   ElementProductionFragment,
 } from '../element/element.fragment.graphql.gen'
-import { StoreFragment } from '../store/store.fragment.graphql.gen'
 import { GraphQLClient } from 'graphql-request'
 import { GraphQLClientRequestHeaders } from 'graphql-request/build/cjs/types'
 import { gql } from 'graphql-tag'
+import { StoreFragmentDoc } from '../store/store.fragment.graphql.gen'
 import {
   ElementFragmentDoc,
   ElementProductionFragmentDoc,
 } from '../element/element.fragment.graphql.gen'
-import { StoreFragmentDoc } from '../store/store.fragment.graphql.gen'
 export type PagePreviewFragment = {
   id: string
   kind: Types.PageKind
@@ -30,7 +30,7 @@ export type PageFragment = {
   url: string
   app: { id: string }
   pageContentContainer?: { id: string } | null
-  rootElement: { descendantElements: Array<ElementFragment> } & ElementFragment
+  rootElement: { id: string }
   store: StoreFragment
   elements: Array<ElementFragment>
 }
@@ -42,7 +42,7 @@ export type PageDevelopmentFragment = {
   url: string
   app: { id: string }
   pageContentContainer?: { id: string } | null
-  rootElement: { descendantElements: Array<ElementFragment> } & ElementFragment
+  rootElement: { id: string }
   store: StoreFragment
   elements: Array<ElementFragment>
 }
@@ -55,9 +55,7 @@ export type PageProductionFragment = {
   url: string
   app: { id: string }
   pageContentContainer?: { id: string } | null
-  rootElement: {
-    descendantElements: Array<ElementProductionFragment>
-  } & ElementProductionFragment
+  rootElement: { id: string }
   store: StoreFragment
   elements: Array<ElementProductionFragment>
 }
@@ -91,10 +89,7 @@ export const PageFragmentDoc = gql`
       id
     }
     rootElement {
-      descendantElements {
-        ...Element
-      }
-      ...Element
+      id
     }
     store {
       ...Store
@@ -104,8 +99,8 @@ export const PageFragmentDoc = gql`
       ...Element
     }
   }
-  ${ElementFragmentDoc}
   ${StoreFragmentDoc}
+  ${ElementFragmentDoc}
 `
 export const PageDevelopmentFragmentDoc = gql`
   fragment PageDevelopment on Page {
@@ -119,10 +114,7 @@ export const PageDevelopmentFragmentDoc = gql`
       id
     }
     rootElement {
-      descendantElements {
-        ...Element
-      }
-      ...Element
+      id
     }
     store {
       ...Store
@@ -132,8 +124,8 @@ export const PageDevelopmentFragmentDoc = gql`
       ...Element
     }
   }
-  ${ElementFragmentDoc}
   ${StoreFragmentDoc}
+  ${ElementFragmentDoc}
 `
 export const PageProductionFragmentDoc = gql`
   fragment PageProduction on Page {
@@ -147,10 +139,7 @@ export const PageProductionFragmentDoc = gql`
       id
     }
     rootElement {
-      descendantElements {
-        ...ElementProduction
-      }
-      ...ElementProduction
+      id
     }
     slug
     store {
@@ -161,8 +150,8 @@ export const PageProductionFragmentDoc = gql`
       ...ElementProduction
     }
   }
-  ${ElementProductionFragmentDoc}
   ${StoreFragmentDoc}
+  ${ElementProductionFragmentDoc}
 `
 
 export type SdkFunctionWrapper = <T>(

--- a/libs/frontend/application/app/src/use-cases/app-development/app-development.endpoints.graphql.gen.ts
+++ b/libs/frontend/application/app/src/use-cases/app-development/app-development.endpoints.graphql.gen.ts
@@ -1,30 +1,30 @@
 import * as Types from '@codelab/shared/abstract/codegen'
 
 import { AppDevelopmentFragment } from '../../../../../abstract/domain/src/app/app.fragment.graphql.gen'
+import { ResourceFragment } from '../../../../../abstract/domain/src/resource/resource.fragment.graphql.gen'
 import {
   AtomDevelopmentFragment,
   AtomProductionFragment,
 } from '../../../../../abstract/domain/src/atom/atom.fragment.graphql.gen'
-import { ResourceFragment } from '../../../../../abstract/domain/src/resource/resource.fragment.graphql.gen'
-import { ComponentDevelopmentFragment } from '../../../../../abstract/domain/src/component/component-development.fragment.graphql.gen'
 import { ActionTypeFragment } from '../../../../../abstract/domain/src/type/fragments/action-type.fragment.graphql.gen'
 import { PrimitiveTypeFragment } from '../../../../../abstract/domain/src/type/fragments/primitive-type.fragment.graphql.gen'
 import { ReactNodeTypeFragment } from '../../../../../abstract/domain/src/type/fragments/react-node-type.fragment.graphql.gen'
 import { RenderPropTypeFragment } from '../../../../../abstract/domain/src/type/fragments/render-prop.fragment.graphql.gen'
+import { ComponentDevelopmentFragment } from '../../../../../abstract/domain/src/component/component-development.fragment.graphql.gen'
 import { GraphQLClient } from 'graphql-request'
 import { GraphQLClientRequestHeaders } from 'graphql-request/build/cjs/types'
 import { gql } from 'graphql-tag'
 import { AppDevelopmentFragmentDoc } from '../../../../../abstract/domain/src/app/app.fragment.graphql.gen'
+import { ResourceFragmentDoc } from '../../../../../abstract/domain/src/resource/resource.fragment.graphql.gen'
 import {
   AtomDevelopmentFragmentDoc,
   AtomProductionFragmentDoc,
 } from '../../../../../abstract/domain/src/atom/atom.fragment.graphql.gen'
-import { ResourceFragmentDoc } from '../../../../../abstract/domain/src/resource/resource.fragment.graphql.gen'
-import { ComponentDevelopmentFragmentDoc } from '../../../../../abstract/domain/src/component/component-development.fragment.graphql.gen'
 import { ActionTypeFragmentDoc } from '../../../../../abstract/domain/src/type/fragments/action-type.fragment.graphql.gen'
 import { PrimitiveTypeFragmentDoc } from '../../../../../abstract/domain/src/type/fragments/primitive-type.fragment.graphql.gen'
 import { ReactNodeTypeFragmentDoc } from '../../../../../abstract/domain/src/type/fragments/react-node-type.fragment.graphql.gen'
 import { RenderPropTypeFragmentDoc } from '../../../../../abstract/domain/src/type/fragments/render-prop.fragment.graphql.gen'
+import { ComponentDevelopmentFragmentDoc } from '../../../../../abstract/domain/src/component/component-development.fragment.graphql.gen'
 export type GetAppDevelopmentQueryVariables = Types.Exact<{
   appCompositeKey: Types.Scalars['String']['input']
   pageName: Types.Scalars['String']['input']
@@ -33,12 +33,12 @@ export type GetAppDevelopmentQueryVariables = Types.Exact<{
 export type GetAppDevelopmentQuery = {
   apps: Array<AppDevelopmentFragment>
   atoms: Array<AtomDevelopmentFragment>
+  components: Array<ComponentDevelopmentFragment>
   primitiveTypes: Array<PrimitiveTypeFragment>
   reactNodeTypes: Array<ReactNodeTypeFragment & ReactNodeTypeFragment>
   renderPropTypes: Array<RenderPropTypeFragment & RenderPropTypeFragment>
   actionTypes: Array<ActionTypeFragment>
   resources: Array<ResourceFragment>
-  components: Array<ComponentDevelopmentFragment>
 }
 
 export const GetAppDevelopmentDocument = gql`
@@ -48,6 +48,9 @@ export const GetAppDevelopmentDocument = gql`
     }
     atoms(where: { type: ReactFragment }) {
       ...AtomDevelopment
+    }
+    components {
+      ...ComponentDevelopment
     }
     primitiveTypes {
       ...PrimitiveType
@@ -70,18 +73,15 @@ export const GetAppDevelopmentDocument = gql`
     resources {
       ...Resource
     }
-    components {
-      ...ComponentDevelopment
-    }
   }
   ${AppDevelopmentFragmentDoc}
   ${AtomDevelopmentFragmentDoc}
+  ${ComponentDevelopmentFragmentDoc}
   ${PrimitiveTypeFragmentDoc}
   ${ReactNodeTypeFragmentDoc}
   ${RenderPropTypeFragmentDoc}
   ${ActionTypeFragmentDoc}
   ${ResourceFragmentDoc}
-  ${ComponentDevelopmentFragmentDoc}
 `
 
 export type SdkFunctionWrapper = <T>(

--- a/libs/frontend/application/app/src/use-cases/app-production/app-production.endpoints.graphql.gen.ts
+++ b/libs/frontend/application/app/src/use-cases/app-production/app-production.endpoints.graphql.gen.ts
@@ -1,14 +1,14 @@
 import * as Types from '@codelab/shared/abstract/codegen'
 
 import { AppProductionFragment } from '../../../../../abstract/domain/src/app/app.fragment.graphql.gen'
-import { AtomProductionFragment } from '../../../../../abstract/domain/src/atom/atom.fragment.graphql.gen'
 import { ResourceFragment } from '../../../../../abstract/domain/src/resource/resource.fragment.graphql.gen'
+import { AtomProductionFragment } from '../../../../../abstract/domain/src/atom/atom.fragment.graphql.gen'
 import { GraphQLClient } from 'graphql-request'
 import { GraphQLClientRequestHeaders } from 'graphql-request/build/cjs/types'
 import { gql } from 'graphql-tag'
 import { AppProductionFragmentDoc } from '../../../../../abstract/domain/src/app/app.fragment.graphql.gen'
-import { AtomProductionFragmentDoc } from '../../../../../abstract/domain/src/atom/atom.fragment.graphql.gen'
 import { ResourceFragmentDoc } from '../../../../../abstract/domain/src/resource/resource.fragment.graphql.gen'
+import { AtomProductionFragmentDoc } from '../../../../../abstract/domain/src/atom/atom.fragment.graphql.gen'
 export type GetAppProductionQueryVariables = Types.Exact<{
   domain: Types.Scalars['String']['input']
   pageUrl: Types.Scalars['String']['input']

--- a/libs/frontend/presentation/container/src/pageHooks/useRenderedComponent.hook.ts
+++ b/libs/frontend/presentation/container/src/pageHooks/useRenderedComponent.hook.ts
@@ -44,13 +44,15 @@ export const useRenderedComponent = (rendererType: RendererType) => {
       return null
     }
 
-    const roots = [component.rootElement.current]
-
     const rootElement = elementService.elementDomainService.maybeElement(
       component.rootElement.id,
     )
 
-    await loadAllTypesForElements(componentService, typeService, roots)
+    await loadAllTypesForElements(
+      componentService,
+      typeService,
+      component.elements,
+    )
 
     if (rootElement) {
       builderService.selectElementNode(rootElement)

--- a/libs/frontend/presentation/container/src/pageHooks/utils.ts
+++ b/libs/frontend/presentation/container/src/pageHooks/utils.ts
@@ -69,14 +69,9 @@ const getTypeIdsFromElements = (elements: Array<IElementModel>) => {
 export const loadAllTypesForElements = async (
   componentService: IComponentApplicationService,
   typeService: ITypeService,
-  roots: Array<IElementModel>,
+  elements: Array<IElementModel>,
 ) => {
   const loadedComponentElements: Array<IElementModel> = []
-
-  const elements = [
-    ...roots,
-    ...flatMap(roots.map((root) => root.descendantElements)),
-  ]
 
   // Loading custom components
   let componentsBatch = getComponentIdsFromElements(elements).filter(

--- a/libs/shared/abstract/codegen/src/types.api.graphql.gen.ts
+++ b/libs/shared/abstract/codegen/src/types.api.graphql.gen.ts
@@ -20638,7 +20638,7 @@ export type AtomProductionFragment = {
 }
 
 export type ComponentDevelopmentFragment = {
-  rootElement: { descendantElements: Array<ElementFragment> } & ElementFragment
+  rootElement: { id: string }
   elements: Array<ElementFragment>
 } & ComponentFragment
 
@@ -20790,7 +20790,7 @@ export type PageFragment = {
   url: string
   app: { id: string }
   pageContentContainer?: { id: string } | null
-  rootElement: { descendantElements: Array<ElementFragment> } & ElementFragment
+  rootElement: { id: string }
   store: StoreFragment
   elements: Array<ElementFragment>
 }
@@ -20802,7 +20802,7 @@ export type PageDevelopmentFragment = {
   url: string
   app: { id: string }
   pageContentContainer?: { id: string } | null
-  rootElement: { descendantElements: Array<ElementFragment> } & ElementFragment
+  rootElement: { id: string }
   store: StoreFragment
   elements: Array<ElementFragment>
 }
@@ -20815,9 +20815,7 @@ export type PageProductionFragment = {
   url: string
   app: { id: string }
   pageContentContainer?: { id: string } | null
-  rootElement: {
-    descendantElements: Array<ElementProductionFragment>
-  } & ElementProductionFragment
+  rootElement: { id: string }
   store: StoreFragment
   elements: Array<ElementProductionFragment>
 }

--- a/scripts/jest/setupFiles.js
+++ b/scripts/jest/setupFiles.js
@@ -15,7 +15,7 @@ if (process.env.NODE_ENV === 'test') {
   const envPath = path.resolve(__dirname, '../../.env.test')
 
   if (fs.existsSync(envPath)) {
-    config({ path: envPath })
+    config({ path: envPath, override: true })
   }
 
   const platformApiEnvPath = path.resolve(
@@ -24,7 +24,7 @@ if (process.env.NODE_ENV === 'test') {
   )
 
   if (fs.existsSync(platformApiEnvPath)) {
-    config({ path: platformApiEnvPath })
+    config({ path: platformApiEnvPath, override: true })
   }
 }
 


### PR DESCRIPTION
<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(libs-ui-component): must begin with lowercase` -->

## Description

<!-- This is a short description on the Pull Request -->
- removes the `descendantElements` resolver since it is not needed anymore after introducing a new field resolver `elements` for the Page and Component type.
- reduce response size by only needing id on `rootElement` on Page and Component when loading the builder
- fix env file used when running jest locally
  - the current issue is when using neo4j service, it is using the database used when running the platform locally

## Video or Image

<!-- Add video or image showing how the new feature works -->

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged -->

Fixes #3161
