### PR TITLE
fix: element atom props disappearing

### DIFF
--- a/libs/frontend/domain/type/src/type.domain.service.ts
+++ b/libs/frontend/domain/type/src/type.domain.service.ts
@@ -49,7 +49,13 @@ export class TypeDomainService
 
   @modelAction
   hydrateInterface(data: ICreateTypeData) {
-    const interfaceType = new InterfaceType({
+    let interfaceType = this.types.get(data.id) as InterfaceType | undefined
+
+    if (interfaceType) {
+      return interfaceType
+    }
+
+    interfaceType = new InterfaceType({
       id: data.id,
       name: data.name,
     })


### PR DESCRIPTION
<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(libs-ui-component): must begin with lowercase` -->

## Description

<!-- This is a short description on the Pull Request -->
The interface type in the cache for the atom used for the element was being re-created with a new instance of InterfaceType that causes the current rendered fields in the props config pane to disappear.

## Video or Image

<!-- Add video or image showing how the new feature works -->

https://github.com/codelab-app/platform/assets/27695022/9a7557a5-924d-484a-981f-e659c77e006b


## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged -->

Fixes #3165
