### PR TITLE
fix: nestjs endpoint prefix after migration

### DIFF
--- a/libs/backend/application/app/src/app.application.controller.ts
+++ b/libs/backend/application/app/src/app.application.controller.ts
@@ -8,7 +8,7 @@ import {
 import { CommandBus } from '@nestjs/cqrs'
 import { SeedCypressAppCommand } from './use-case'
 
-@Controller('app')
+@Controller('data/app')
 export class AppApplicationController {
   constructor(private commandBus: CommandBus) {}
 

--- a/libs/backend/application/atom/src/atom.application.controller.ts
+++ b/libs/backend/application/atom/src/atom.application.controller.ts
@@ -7,7 +7,7 @@ import {
 import { CommandBus } from '@nestjs/cqrs'
 import { SeedCypressAtomsCommand } from './use-case'
 
-@Controller('atom')
+@Controller('data/atom')
 export class AtomApplicationController {
   constructor(private commandBus: CommandBus) {}
 

--- a/libs/backend/application/tag/src/tag.application.controller.ts
+++ b/libs/backend/application/tag/src/tag.application.controller.ts
@@ -7,7 +7,7 @@ import {
 import { CommandBus } from '@nestjs/cqrs'
 import { SeedCypressTagsCommand } from './use-case'
 
-@Controller('tag')
+@Controller('data/tag')
 export class TagApplicationController {
   constructor(private commandBus: CommandBus) {}
 

--- a/libs/backend/application/type/src/type.application.controller.ts
+++ b/libs/backend/application/type/src/type.application.controller.ts
@@ -7,7 +7,7 @@ import {
 import { CommandBus } from '@nestjs/cqrs'
 import { SeedCypressTypesCommand } from './use-case'
 
-@Controller('type')
+@Controller('data/type')
 export class TypeApplicationController {
   constructor(private commandBus: CommandBus) {}
 

--- a/libs/backend/application/user/src/user.application.controller.ts
+++ b/libs/backend/application/user/src/user.application.controller.ts
@@ -3,7 +3,7 @@ import { UserRepository } from '@codelab/backend/domain/user'
 import { IUserDTO } from '@codelab/shared/abstract/core'
 import { Controller, Post } from '@nestjs/common'
 
-@Controller('user')
+@Controller('data/user')
 export class UserApplicationController {
   constructor(private userRepository: UserRepository) {}
 


### PR DESCRIPTION
<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(libs-ui-component): must begin with lowercase` -->

## Description

Recently the `platform-api` was migrated to digital ocean, and the NestJs wrapper around it was removed.
When NestJs wrapper was used - it had two separate endpoint URLs: /data and /graphql, and for /data endpoint global prefix was defined. But now global prefix is not an option since all the controllers are a part of a global root module. So specify prefix individually.
This /data requests are used in cypress tests to seed the database

## Video or Image

<!-- Add video or image showing how the new feature works -->

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged -->

Part of #3171
