### PR TITLE
refactor: do not explicitly set "Atom" renderType in e2e

### DIFF
--- a/apps/platform-e2e/src/e2e/builder/child-mapper.cy.ts
+++ b/apps/platform-e2e/src/e2e/builder/child-mapper.cy.ts
@@ -68,11 +68,6 @@ describe('Element Child Mapper', () => {
         .click()
 
       cy.findByTestId('create-element-form').setFormFieldValue({
-        label: 'Render Type',
-        type: FIELD_TYPE.SELECT,
-        value: 'Atom',
-      })
-      cy.findByTestId('create-element-form').setFormFieldValue({
         label: 'Atom',
         type: FIELD_TYPE.SELECT,
         value: child.atom,

--- a/apps/platform-e2e/src/e2e/builder/in-app-routing.cy.ts
+++ b/apps/platform-e2e/src/e2e/builder/in-app-routing.cy.ts
@@ -79,11 +79,6 @@ describe('Routing between app pages within the builder', () => {
       .click()
 
     cy.findByTestId('create-element-form').setFormFieldValue({
-      label: 'Render Type',
-      type: FIELD_TYPE.SELECT,
-      value: 'Atom',
-    })
-    cy.findByTestId('create-element-form').setFormFieldValue({
       label: 'Atom',
       type: FIELD_TYPE.SELECT,
       value: IAtomType.AntDesignTypographyText,
@@ -142,11 +137,6 @@ describe('Routing between app pages within the builder', () => {
       .click()
 
     cy.findByTestId('create-element-form').setFormFieldValue({
-      label: 'Render Type',
-      type: FIELD_TYPE.SELECT,
-      value: 'Atom',
-    })
-    cy.findByTestId('create-element-form').setFormFieldValue({
       label: 'Atom',
       type: FIELD_TYPE.SELECT,
       value: IAtomType.AntDesignTypographyText,
@@ -187,12 +177,6 @@ describe('Routing between app pages within the builder', () => {
       .getCuiToolbarItem('Add Element')
       .first()
       .click()
-
-    cy.findByTestId('create-element-form').setFormFieldValue({
-      label: 'Render Type',
-      type: FIELD_TYPE.SELECT,
-      value: 'Atom',
-    })
 
     cy.findByTestId('create-element-form').setFormFieldValue({
       label: 'Atom',
@@ -246,11 +230,6 @@ describe('Routing between app pages within the builder', () => {
       .first()
       .click()
 
-    cy.findByTestId('create-element-form').setFormFieldValue({
-      label: 'Render Type',
-      type: FIELD_TYPE.SELECT,
-      value: 'Atom',
-    })
     cy.findByTestId('create-element-form').setFormFieldValue({
       label: 'Atom',
       type: FIELD_TYPE.SELECT,

--- a/apps/platform-e2e/src/e2e/builder/state-sharing.cy.ts
+++ b/apps/platform-e2e/src/e2e/builder/state-sharing.cy.ts
@@ -86,11 +86,6 @@ describe('State variables sharing between pages', () => {
         .click()
 
       cy.findByTestId('create-element-form').setFormFieldValue({
-        label: 'Render Type',
-        type: FIELD_TYPE.SELECT,
-        value: 'Atom',
-      })
-      cy.findByTestId('create-element-form').setFormFieldValue({
         label: 'Atom',
         type: FIELD_TYPE.SELECT,
         value: child.atom,

--- a/apps/platform-e2e/src/e2e/component/component.cy.ts
+++ b/apps/platform-e2e/src/e2e/component/component.cy.ts
@@ -106,11 +106,6 @@ describe('Component CRUD', () => {
           .click()
 
         cy.findByTestId('create-element-form').setFormFieldValue({
-          label: 'Render Type',
-          type: FIELD_TYPE.SELECT,
-          value: 'Atom',
-        })
-        cy.findByTestId('create-element-form').setFormFieldValue({
           label: 'Atom',
           type: FIELD_TYPE.SELECT,
           value: child.atom,
@@ -222,12 +217,6 @@ describe('Component CRUD', () => {
 
     it('should be able to add children to component instance', () => {
       cy.getCuiSidebar('Explorer').getCuiToolbarItem('Add Element').click()
-
-      cy.findByTestId('create-element-form').setFormFieldValue({
-        label: 'Render Type',
-        type: FIELD_TYPE.SELECT,
-        value: 'Atom',
-      })
 
       cy.findByTestId('create-element-form').setFormFieldValue({
         label: 'Atom',

--- a/apps/platform-e2e/src/e2e/store/actions-inside-code-actions.cy.ts
+++ b/apps/platform-e2e/src/e2e/store/actions-inside-code-actions.cy.ts
@@ -251,11 +251,6 @@ describe('Running actions inside code action with arguments', () => {
       .click()
 
     cy.findByTestId('create-element-form').setFormFieldValue({
-      label: 'Render Type',
-      type: FIELD_TYPE.SELECT,
-      value: 'Atom',
-    })
-    cy.findByTestId('create-element-form').setFormFieldValue({
       label: 'Atom',
       type: FIELD_TYPE.SELECT,
       value: IAtomType.AntDesignTypographyText,
@@ -299,11 +294,6 @@ describe('Running actions inside code action with arguments', () => {
       .first()
       .click()
 
-    cy.findByTestId('create-element-form').setFormFieldValue({
-      label: 'Render Type',
-      type: FIELD_TYPE.SELECT,
-      value: 'Atom',
-    })
     cy.findByTestId('create-element-form').setFormFieldValue({
       label: 'Atom',
       type: FIELD_TYPE.SELECT,

--- a/apps/platform-e2e/src/e2e/store/child-mapper-api-actions-with-props.cy.ts
+++ b/apps/platform-e2e/src/e2e/store/child-mapper-api-actions-with-props.cy.ts
@@ -155,11 +155,6 @@ describe('Element Child Mapper', () => {
       .click()
 
     cy.findByTestId('create-element-form').setFormFieldValue({
-      label: 'Render Type',
-      type: FIELD_TYPE.SELECT,
-      value: 'Atom',
-    })
-    cy.findByTestId('create-element-form').setFormFieldValue({
       label: 'Atom',
       type: FIELD_TYPE.SELECT,
       value: IAtomType.AntDesignButton,

--- a/apps/platform-e2e/src/e2e/store/nested-api-actions.cy.ts
+++ b/apps/platform-e2e/src/e2e/store/nested-api-actions.cy.ts
@@ -236,11 +236,6 @@ describe('Running nested API and code actions', () => {
       .click()
 
     cy.findByTestId('create-element-form').setFormFieldValue({
-      label: 'Render Type',
-      type: FIELD_TYPE.SELECT,
-      value: 'Atom',
-    })
-    cy.findByTestId('create-element-form').setFormFieldValue({
       label: 'Atom',
       type: FIELD_TYPE.SELECT,
       value: IAtomType.AntDesignTypographyText,
@@ -282,11 +277,6 @@ describe('Running nested API and code actions', () => {
       .first()
       .click()
 
-    cy.findByTestId('create-element-form').setFormFieldValue({
-      label: 'Render Type',
-      type: FIELD_TYPE.SELECT,
-      value: 'Atom',
-    })
     cy.findByTestId('create-element-form').setFormFieldValue({
       label: 'Atom',
       type: FIELD_TYPE.SELECT,

--- a/apps/platform-e2e/src/e2e/store/pre-render-api-action-and-set-state.cy.ts
+++ b/apps/platform-e2e/src/e2e/store/pre-render-api-action-and-set-state.cy.ts
@@ -171,11 +171,6 @@ describe('Running API action and setting state on element pre-render', () => {
       .click()
 
     cy.findByTestId('create-element-form').setFormFieldValue({
-      label: 'Render Type',
-      type: FIELD_TYPE.SELECT,
-      value: 'Atom',
-    })
-    cy.findByTestId('create-element-form').setFormFieldValue({
       label: 'Atom',
       type: FIELD_TYPE.SELECT,
       value: IAtomType.AntDesignTypographyText,

--- a/apps/platform-e2e/src/support/commands/builder/builder.command.ts
+++ b/apps/platform-e2e/src/support/commands/builder/builder.command.ts
@@ -36,11 +36,6 @@ export const createElementTree = (elements: Array<ElementData>) => {
     }
 
     cy.findByTestId('create-element-form').setFormFieldValue({
-      label: 'Render Type',
-      type: FIELD_TYPE.SELECT,
-      value: 'Atom',
-    })
-    cy.findByTestId('create-element-form').setFormFieldValue({
       label: 'Atom',
       type: FIELD_TYPE.SELECT,
       value: atom,


### PR DESCRIPTION
<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(libs-ui-component): must begin with lowercase` -->

## Description

Do not set "Atom" render type explicitly in e2e tests. The form filed is already pre-populated with this value by default.

## Video or Image

<!-- Add video or image showing how the new feature works -->

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged -->

Part of #3171 
