### PR TITLE
fix: atom is required as render type

### DIFF
--- a/apps/platform-e2e/src/e2e/builder/form.cy.ts
+++ b/apps/platform-e2e/src/e2e/builder/form.cy.ts
@@ -10,7 +10,7 @@ import type { IAppDTO } from '@codelab/shared/abstract/core'
 import { IAtomType, IPageKindName } from '@codelab/shared/abstract/core'
 import { ROOT_ELEMENT_NAME } from '@codelab/shared/config'
 import { slugify } from '@codelab/shared/utils'
-import type { ElementData } from '../../../../../libs/frontend/test/cypress/helper/src/builder/builder.command'
+import type { ElementData } from '../../support/commands/builder/builder.command'
 
 const ELEMENT_FORM = 'Element Form'
 const ELEMENT_FORM_ITEM_INPUT = 'Element Form Item Input'

--- a/apps/platform-e2e/src/e2e/component/convert-element-to-component.cy.ts
+++ b/apps/platform-e2e/src/e2e/component/convert-element-to-component.cy.ts
@@ -12,10 +12,12 @@ const ELEMENT_TEXT_1 = 'Text 1'
 
 const elements = [
   {
+    atom: IAtomType.ReactFragment,
     name: ELEMENT_CONTAINER,
     parentElement: ROOT_ELEMENT_NAME,
   },
   {
+    atom: IAtomType.ReactFragment,
     name: ELEMENT_ROW,
     parentElement: ELEMENT_CONTAINER,
   },

--- a/apps/platform-e2e/src/e2e/store/child-mapper-api-actions-with-props.cy.ts
+++ b/apps/platform-e2e/src/e2e/store/child-mapper-api-actions-with-props.cy.ts
@@ -211,6 +211,7 @@ describe('Element Child Mapper', () => {
 
     cy.createElementTree([
       {
+        atom: IAtomType.ReactFragment,
         name: ELEMENT_ROW,
         parentElement: ROOT_ELEMENT_NAME,
       },


### PR DESCRIPTION
<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(libs-ui-component): must begin with lowercase` -->

## Description

- fix invalid import path
- fix error in e2e test when renderType was set to Atom but no atom was selected. Atom can't be skipped anymore, so use ReactFragment

## Video or Image

<!-- Add video or image showing how the new feature works -->

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged -->

Part of #3171 
