### PR TITLE
fix: app with reference to resource fail to open

### DIFF
--- a/libs/backend/infra/adapter/typebox/src/validator/validation.service.spec.ts
+++ b/libs/backend/infra/adapter/typebox/src/validator/validation.service.spec.ts
@@ -9,6 +9,7 @@ import { Test } from '@nestjs/testing'
 import type { TSchema } from '@sinclair/typebox'
 import { Type } from '@sinclair/typebox'
 import affixJson from 'data/export-v3/admin/atoms/AntDesignAffix.json'
+import omit from 'lodash/omit'
 import { ValidationService } from './validation.service'
 
 describe('ValidationService', () => {
@@ -38,7 +39,10 @@ describe('ValidationService', () => {
         affixJson,
       )
 
-      expect(result).toEqual(affixJson)
+      expect(result).toEqual({
+        api: omit(affixJson.api, 'kind', 'name', '__typename'),
+        atom: omit(affixJson.atom, 'owner'),
+      })
     })
 
     it('should throw an error for invalid input', () => {

--- a/libs/frontend/abstract/domain/src/app/app-development.service.interface.ts
+++ b/libs/frontend/abstract/domain/src/app/app-development.service.interface.ts
@@ -7,6 +7,7 @@ import type {
   FieldFragment,
   PageDevelopmentFragment,
   PropFragment,
+  ResourceFragment,
   StoreFragment,
   TypeFragment,
 } from '@codelab/shared/abstract/codegen'
@@ -27,6 +28,7 @@ export interface IAppDevelopmentDto {
   fields: Array<FieldFragment>
   pages: Array<PageDevelopmentFragment>
   props: Array<PropFragment>
+  resources: Array<ResourceFragment>
   stores: Array<StoreFragment>
   types: Array<TypeFragment>
 }

--- a/libs/frontend/application/app/src/use-cases/app-development/app-development.service.ts
+++ b/libs/frontend/application/app/src/use-cases/app-development/app-development.service.ts
@@ -10,6 +10,7 @@ import {
   getElementDomainService,
   getFieldDomainService,
   getPageDomainService,
+  getResourceDomainService,
   getStoreDomainService,
   IAppDevelopmentDto,
 } from '@codelab/frontend/abstract/domain'
@@ -129,6 +130,7 @@ export class AppDevelopmentService
       fields,
       pages,
       props,
+      resources: data.resources,
       stores,
       types: [...types, ...elementsDependantTypes, ...systemTypes],
     }
@@ -157,6 +159,10 @@ export class AppDevelopmentService
     data.stores.forEach((store) => this.storeDomainService.hydrate(store))
 
     data.actions.forEach((action) => this.actionDomainService.hydrate(action))
+
+    data.resources.forEach((resource) =>
+      this.resourceDomainService.hydrate(resource),
+    )
 
     this.elementDomainService.logElementTreeState()
 
@@ -206,5 +212,10 @@ export class AppDevelopmentService
   @computed
   private get typeDomainService() {
     return getTypeDomainService(this)
+  }
+
+  @computed
+  private get resourceDomainService() {
+    return getResourceDomainService(this)
   }
 }

--- a/libs/frontend/domain/app/src/test/root.test.store.ts
+++ b/libs/frontend/domain/app/src/test/root.test.store.ts
@@ -4,16 +4,14 @@ import {
   atomDomainServiceContext,
   elementDomainServiceContext,
   pageDomainServiceContext,
+  storeDomainServiceContext,
   userDomainServiceContext,
 } from '@codelab/frontend/abstract/domain'
 import { AtomDomainService } from '@codelab/frontend/domain/atom'
 import { ElementDomainService } from '@codelab/frontend/domain/element'
 import { PageDomainService } from '@codelab/frontend/domain/page'
 import { createRootDomainStore } from '@codelab/frontend/domain/shared'
-import {
-  StoreDomainService,
-  storeDomainServiceContext,
-} from '@codelab/frontend/domain/store'
+import { StoreDomainService } from '@codelab/frontend/domain/store'
 import {
   TypeDomainService,
   typeDomainServiceContext,

--- a/libs/frontend/infra/mobx/src/root.store.ts
+++ b/libs/frontend/infra/mobx/src/root.store.ts
@@ -41,6 +41,7 @@ import {
   elementDomainServiceContext,
   fieldDomainServiceContext,
   pageDomainServiceContext,
+  resourceDomainServiceContext,
   storeDomainServiceContext,
   tagDomainServiceContext,
   userDomainServiceContext,
@@ -164,6 +165,10 @@ export const createRootStore = ({ routerQuery, user }: RootStoreData) => {
       storeServiceContext.set(this, this.storeService)
       storeDomainServiceContext.set(this, this.storeService.storeDomainService)
       resourceServiceContext.set(this, this.resourceService)
+      resourceDomainServiceContext.set(
+        this,
+        this.resourceService.resourceDomainService,
+      )
       propServiceContext.set(this, this.propService)
       elementServiceContext.set(this, this.elementService)
       elementDomainServiceContext.set(


### PR DESCRIPTION
<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(libs-ui-component): must begin with lowercase` -->

## Description

If page uses an Api Action that holds a refference to some Resource - the entire app fails to open.
As a fix: hydrate resources as well, once app is hydrated.

Also, unit tests are fixed in this PR

## Video or Image

Before:

https://github.com/codelab-app/platform/assets/74900868/a760b175-f68e-4c88-99bb-247e00fe7b5b

After:

https://github.com/codelab-app/platform/assets/74900868/777453ca-a27d-423d-ad25-1e7f701ffb4c


## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged -->

Part of #3171
