### PR TITLE
fix: expressions are not evaluated in preview mode

### DIFF
--- a/libs/frontend/application/renderer/src/renderer.application.service.ts
+++ b/libs/frontend/application/renderer/src/renderer.application.service.ts
@@ -48,6 +48,9 @@ export class RendererApplicationService
       renderer = Renderer.create(rendererDto)
 
       this.renderers.set(rendererDto.id, renderer)
+    } else {
+      // existing renderer may change type when switching between builder and preview modes
+      renderer.rendererType = rendererDto.rendererType
     }
 
     return renderer


### PR DESCRIPTION
<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(libs-ui-component): must begin with lowercase` -->

## Description

During renderer hydration - `renderType` property value is not updated. As a result, when switching from builder mode to preview mode - expressions are not evaluated (the render type remains 'builder').

## Video or Image

Before:

https://github.com/codelab-app/platform/assets/74900868/7a45905a-807a-4ed2-b52d-a1a5cbd011d9

After:

https://github.com/codelab-app/platform/assets/74900868/6b10b35d-9dfa-4c04-8192-64d0653dea1a

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged -->

Part of #3171 
