### PR TITLE
fix: script error and some e2e tests

### DIFF
--- a/apps/platform-e2e/src/e2e/builder/form.cy.ts
+++ b/apps/platform-e2e/src/e2e/builder/form.cy.ts
@@ -232,6 +232,8 @@ describe('Testing the Form atom', () => {
   })
 
   it('should populate the form fields - input, select, and checkbox', () => {
+    cy.openPreview()
+
     cy.get(`#render-root #${ELEMENT_INPUT_NAME}`).type('testing')
     cy.get(`#render-root #${ELEMENT_SELECT_NAME}`).click()
     cy.findByText('Select Option B').click()
@@ -245,14 +247,10 @@ describe('Testing the Form atom', () => {
 
     cy.get('#render-root button').first().click({ force: true })
 
-    cy.wait('@submitData')
-
-    cy.get('@submitData').should(({ request }: any) => {
-      expect(request.body).toMatchObject({
-        checkboxField: true,
-        inputField: 'testing',
-        selectField: 'selectOptionB',
-      })
+    cy.wait('@submitData').its('request.body').should('deep.equal', {
+      checkboxField: true,
+      inputField: 'testing',
+      selectField: 'selectOptionB',
     })
   })
 })

--- a/apps/platform-e2e/src/e2e/store/actions-inside-code-actions.cy.ts
+++ b/apps/platform-e2e/src/e2e/store/actions-inside-code-actions.cy.ts
@@ -331,21 +331,18 @@ describe('Running actions inside code action with arguments', () => {
   })
 
   it('should run the code action that calls another call action and an API action with arguments when the button is clicked', () => {
+    cy.openPreview()
+
     cy.intercept('POST', `${resourceUrl}${urlSegment}`, {
       statusCode: 200,
     }).as('apiAction')
 
     cy.get('#render-root').findByText('Click button to run actions').click()
 
-    cy.wait('@apiAction')
-    cy.get('@apiAction').should(({ request }: any) => {
-      expect(request.body).toMatchObject({
-        firstArg: 'yo',
-        secondArg: 456,
-      })
+    cy.wait('@apiAction').its('request.body').should('deep.equal', {
+      firstArg: 'yo',
+      secondArg: 456,
     })
-
-    cy.openPreview()
     cy.get('#render-root').contains(`${stateKey1} - hey, ${stateKey2} - 123`)
   })
 })

--- a/apps/platform-e2e/src/e2e/store/nested-api-actions.cy.ts
+++ b/apps/platform-e2e/src/e2e/store/nested-api-actions.cy.ts
@@ -316,6 +316,7 @@ describe('Running nested API and code actions', () => {
   })
 
   it('should run the POST api, GET api, and code action in order when the button is clicked', () => {
+    cy.openPreview()
     cy.intercept('POST', `${resourceUrl}${urlPostSegment}`, {
       statusCode: 200,
     }).as('updateData')
@@ -330,7 +331,6 @@ describe('Running nested API and code actions', () => {
     cy.wait('@updateData')
     cy.wait('@getData')
 
-    cy.openPreview()
     cy.get('#render-root')
       .contains(`response from api - ${mockGetResponse}`)
       .should('exist')

--- a/apps/platform-e2e/src/support/commands/builder/builder.command.ts
+++ b/apps/platform-e2e/src/support/commands/builder/builder.command.ts
@@ -91,6 +91,7 @@ export const openPreview = () => {
   // eslint-disable-next-line cypress/no-unnecessary-waiting
   cy.wait(1000)
   cy.get('[data-cy="cui-toolbar-item-Preview"] button').click()
+  cy.get('[data-cy="cui-toolbar-item-Builder"] button').should('be.visible')
   // wait for the multiple api calls
   // this is just the simplest way, we should improve this
   // eslint-disable-next-line cypress/no-unnecessary-waiting
@@ -101,6 +102,7 @@ export const openPreview = () => {
 
 export const openBuilder = () => {
   cy.get('[data-cy="cui-toolbar-item-Builder"] button').click()
+  cy.get('[data-cy="cui-toolbar-item-Preview"] button').should('be.visible')
   // wait for the multiple api calls
   // eslint-disable-next-line cypress/no-unnecessary-waiting
   cy.wait(1000)

--- a/libs/frontend/application/builder/src/sections/explorer-pane/tab-contents/ComponentList.tsx
+++ b/libs/frontend/application/builder/src/sections/explorer-pane/tab-contents/ComponentList.tsx
@@ -59,6 +59,7 @@ export const ComponentList = observer<{
                 name: component.name,
               }}
               id={component.id}
+              key={component.id}
             >
               <ComponentItem
                 component={component}

--- a/libs/frontend/application/renderer/src/element/ElementWrapper.tsx
+++ b/libs/frontend/application/renderer/src/element/ElementWrapper.tsx
@@ -73,6 +73,10 @@ export const ElementWrapper = observer<ElementWrapperProps>(
       tailwindClassNames,
     )
 
+    const isDroppable =
+      renderer.rendererType !== RendererType.Production &&
+      renderer.rendererType !== RendererType.Preview
+
     return (
       <ErrorBoundary
         fallbackRender={() => null}
@@ -84,7 +88,7 @@ export const ElementWrapper = observer<ElementWrapperProps>(
           ReactComponent={ReactComponent}
           componentProps={mergedProps}
           id={element.id}
-          isDroppable={renderer.rendererType !== RendererType.Production}
+          isDroppable={isDroppable}
           parentId={element.current.closestParentElement?.current.id}
         >
           {children}

--- a/libs/frontend/application/renderer/src/text-editor/TextEditor.tsx
+++ b/libs/frontend/application/renderer/src/text-editor/TextEditor.tsx
@@ -31,13 +31,13 @@ const TextEditor = ({ data, elementId, readOnly }: Props) => {
   // This is for being backwards compatible with the old text editor
   const getInitialData = (): OutputData => {
     if (!data) {
-      return emptyBlock
+      return createEditorContent()
     }
 
     try {
       return JSON.parse(data)
     } catch {
-      return emptyBlock
+      return createEditorContent(data)
     }
   }
 
@@ -87,7 +87,9 @@ const TextEditor = ({ data, elementId, readOnly }: Props) => {
 
         if (editor.blocks.getBlocksCount() === 0) {
           // without a placeholder text, adding a new text is a little difficult
-          await editor.render(placholderBlock)
+          const placeholderBlock = createEditorContent('Text')
+
+          await editor.render(placeholderBlock)
         }
 
         selectAllTextInTheElement(elementId)
@@ -121,15 +123,15 @@ const selectAllTextInTheElement = (elementId: string) => {
   selection?.addRange(range)
 }
 
-const placholderBlock = {
-  blocks: [
-    {
-      data: {
-        text: 'Text',
+const createEditorContent = (text = '') => {
+  return {
+    blocks: [
+      {
+        data: {
+          text,
+        },
+        type: 'paragraph',
       },
-      type: 'paragraph',
-    },
-  ],
+    ],
+  }
 }
-
-const emptyBlock = { blocks: [{ data: { text: '' }, type: 'paragraph' }] }

--- a/libs/frontend/test/cypress/antd/src/form/form.commands.ts
+++ b/libs/frontend/test/cypress/antd/src/form/form.commands.ts
@@ -549,32 +549,18 @@ export const setFormFieldValue = (
 
       // This should also work for dropdowns where the items are only fetched upon opening it
       // e.g. selecting an atom or type
+      getField().findByLabelText(label).click({ force: true })
+
+      // wait for the options to be fetched
+      cy.get('.ant-select-arrow-loading', { timeout: 10000 }).should(
+        'not.exist',
+      )
+
       getField()
         .findByLabelText(label)
+        .type(`${value}`, { force: true })
+        .get(`.ant-select-item-option[title="${value}"]`)
         .click({ force: true })
-        .get('body')
-        .then((body) => {
-          // This is for awaiting the options in case they are fetched upon opening the dropdown
-          cy.get(`.ant-select-item-option-content`, { timeout: 5000 }).should(
-            'be.visible',
-          )
-
-          if (
-            body.find(`.ant-select-item-option[title="${value}"]`).length > 0
-          ) {
-            // Just click the option if its already visible in the dropdown
-            cy.get(`.ant-select-item-option[title="${value}"]`).click({
-              force: true,
-            })
-          } else {
-            // Types the value so that the option will show in case it is needed to scroll down
-            getField()
-              .findByLabelText(label)
-              .type(`${value}`, { force: true })
-              .get(`.ant-select-item-option[title="${value}"]`)
-              .click({ force: true })
-          }
-        })
 
       return
     case FIELD_TYPE.MULTISELECT:

--- a/libs/frontend/test/cypress/utils/src/api/api.command.ts
+++ b/libs/frontend/test/cypress/utils/src/api/api.command.ts
@@ -4,7 +4,7 @@ export const postApiRequest = <T>(url: string, body?: object) => {
   return cy.request<T>({
     body,
     method: 'POST',
-    timeout: 15000,
+    timeout: 60000,
     url: path.join('/api/data', url),
   })
 }

--- a/libs/frontend/test/cypress/utils/src/text-editor/text-editor.command.ts
+++ b/libs/frontend/test/cypress/utils/src/text-editor/text-editor.command.ts
@@ -8,11 +8,12 @@
  */
 export const typeIntoTextEditor = (content: string, parentId?: string) => {
   const id = parentId ? `#${parentId}-editor` : '#render-root'
+  const editorSelector = `.codex-editor .ce-block__content .cdx-block[contenteditable]`
 
-  return cy
-    .get(id)
-    .find(`.codex-editor .ce-block__content .cdx-block[contenteditable="true"]`)
-    .type(content, {
-      parseSpecialCharSequences: false,
-    })
+  cy.get(id).find(editorSelector).dblclick()
+  cy.get(id).find(editorSelector).clear()
+
+  return cy.get(id).find(editorSelector).type(content, {
+    parseSpecialCharSequences: false,
+  })
 }


### PR DESCRIPTION
<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(libs-ui-component): must begin with lowercase` -->

## Description

- in e2e tests do not interact with created elements in builder, go to preview mode and test elements there. This will test expression evaluation, click and other event handlers, and exclude functionality like DnD of elements
- update cypress commands `openPreview` and `openBuilder` to wait until page is loaded
- fix script error when component list was rendered without assigning `key` property
- disable DnD for preview mode
- increase timeout for seed requests. Currently, almost all e2e tests fail in the beginning because 15s was not enough to seed all required data
- fix cy command to interact with inner text editor. After refactoring, text editor activates after double click only.
- update TextEditor component to allow accept plain text as value (in addition to JSON object with blocks), this allows to easier set text content in e2e specs
## Video or Image

<!-- Add video or image showing how the new feature works -->

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged -->

Part of  #3171
