### PR TITLE
fix: routing issue and multiple children in component issue

### DIFF
--- a/libs/frontend/abstract/application/src/shared/router.service.interface.ts
+++ b/libs/frontend/abstract/application/src/shared/router.service.interface.ts
@@ -11,7 +11,7 @@ export interface IRouterQuery {
   primarySidebarKey?: string
 }
 
-export type IRouterService = Required<IRouterPath> &
+export type IRouterService = IRouterPath &
   Required<IRouterQuery> & {
     path: IRouterPath
     query: IRouterQuery

--- a/libs/frontend/application/shared/store/src/router/router.service.ts
+++ b/libs/frontend/application/shared/store/src/router/router.service.ts
@@ -5,17 +5,7 @@ import type {
 } from '@codelab/frontend/abstract/application'
 import { throwIfUndefined } from '@codelab/shared/utils'
 import { computed } from 'mobx'
-import {
-  _async,
-  _await,
-  Model,
-  model,
-  modelAction,
-  modelFlow,
-  prop,
-  transaction,
-} from 'mobx-keystone'
-import type { NextRouter } from 'next/router'
+import { Model, model, modelAction, prop } from 'mobx-keystone'
 import { ParsedUrlQuery } from 'querystring'
 
 const init = (routerQuery: ParsedUrlQuery) => {
@@ -54,22 +44,22 @@ export class RouterService
 
   @computed
   get appSlug() {
-    return throwIfUndefined(this.path.appSlug)
+    return this.path.appSlug
   }
 
   @computed
   get componentSlug() {
-    return throwIfUndefined(this.path.componentSlug)
+    return this.path.componentSlug
   }
 
   @computed
   get pageSlug() {
-    return throwIfUndefined(this.path.pageSlug)
+    return this.path.pageSlug
   }
 
   @computed
   get userSlug() {
-    return throwIfUndefined(this.path.userSlug)
+    return this.path.userSlug
   }
 
   @computed
@@ -83,10 +73,10 @@ export class RouterService
       routerQuery
 
     this.setPath({
-      appSlug: `${appSlug}`,
-      componentSlug: `${componentSlug}`,
-      pageSlug: `${pageSlug}`,
-      userSlug: `${userSlug}`,
+      appSlug: appSlug ? `${appSlug}` : undefined,
+      componentSlug: componentSlug ? `${componentSlug}` : undefined,
+      pageSlug: pageSlug ? `${pageSlug}` : undefined,
+      userSlug: userSlug ? `${userSlug} ` : undefined,
     })
 
     this.setQuery({

--- a/libs/frontend/domain/element/src/services/element.validate.ts
+++ b/libs/frontend/domain/element/src/services/element.validate.ts
@@ -33,7 +33,6 @@ export const validateElementDto = (element: IElementDTO) => {
 
     // These are mutually exclusive
     assertContainsAtMostOne([prevSibling, parentElement])
-    assertContainsAtMostOne([nextSibling, parentElement])
   } else {
     assertContainsExactlyOne([parentComponent, page], {
       message: 'Can only have 1 container',

--- a/libs/frontend/presentation/view/templates/Dashboard/NavigationBar/default-navigation-bar-items.ts
+++ b/libs/frontend/presentation/view/templates/Dashboard/NavigationBar/default-navigation-bar-items.ts
@@ -1,3 +1,4 @@
+import type { IRouterPath } from '@codelab/frontend/abstract/application'
 import type { NavigationBarItem } from '@codelab/frontend/presentation/codelab-ui'
 import {
   adminMenuItems,
@@ -8,19 +9,12 @@ import {
   resourceMenuItem,
 } from '../../../sections'
 
-interface SidebarNavigationRequirements {
-  appSlug: string
-  componentSlug: string
-  pageSlug: string
-  userSlug: string
-}
-
 export const defaultNavigationBarItems = ({
   appSlug,
   componentSlug,
   pageSlug,
   userSlug,
-}: SidebarNavigationRequirements): {
+}: IRouterPath): {
   primaryItems: Array<NavigationBarItem>
   secondaryItems: Array<NavigationBarItem>
 } => ({


### PR DESCRIPTION
<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(libs-ui-component): must begin with lowercase` -->

## Description

1. Fix issue when sidebar buttons were not disabled when necessary (when on `/app` page, buttons for `components`, `pageList` and `builder` should be disabled). This happened because `routerServer` assigned values like this: 
```
    this.setPath({
      appSlug: `${appSlug}`,
      componentSlug: `${componentSlug}`,
      pageSlug: `${pageSlug}`,
      userSlug: `${userSlug}`,
    })
```
and in case if slug was undefined - value "undefined" as string was saved.

Before             |  After
:-------------------------:|:-------------------------:
<img width="608" alt="Screenshot 2024-01-24 at 09 28 47" src="https://github.com/codelab-app/platform/assets/74900868/86479f4f-c30f-4d0a-bfdb-8f530f5a374a">|<img width="610" alt="Screenshot 2024-01-24 at 09 27 56" src="https://github.com/codelab-app/platform/assets/74900868/d3d50c05-13f1-46de-8c00-c6ec6704d01a">

2. Fix the issue when apps fail to open when a component with 2 children exists. This happened because of this validation:
```
assertContainsAtMostOne([nextSibling, parentElement])
```
But this is not valid, since the first child will have both references to parentElement, and to the nextSibling.

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged -->

Fixes #3199 
