### PR TITLE
fix: state expressions not evaluated

### DIFF
--- a/libs/frontend/domain/type/src/models/interface-type.model.ts
+++ b/libs/frontend/domain/type/src/models/interface-type.model.ts
@@ -16,6 +16,7 @@ import {
   ITypeKind,
 } from '@codelab/shared/abstract/core'
 import compact from 'lodash/compact'
+import isNil from 'lodash/isNil'
 import merge from 'lodash/merge'
 import { computed } from 'mobx'
 import type { Ref } from 'mobx-keystone'
@@ -91,7 +92,9 @@ export class InterfaceType
   get defaultValues(): IPropData {
     return compact(
       this.fields.map((field) =>
-        field.defaultValues ? { [field.key]: field.defaultValues } : undefined,
+        !isNil(field.defaultValues)
+          ? { [field.key]: field.defaultValues }
+          : undefined,
       ),
     ).reduce(merge, {})
   }


### PR DESCRIPTION
<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(libs-ui-component): must begin with lowercase` -->

## Description
There was a small truthy/falsy bug that caused variables with a value of 0 not to be included in the state.

<!-- This is a short description on the Pull Request -->

## Video or Image

<!-- Add video or image showing how the new feature works -->

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged -->

Fixes #3213 
