### PR TITLE
feat: in-app routing

### DIFF
--- a/libs/frontend/abstract/application/src/page/page.application.service.interface.ts
+++ b/libs/frontend/abstract/application/src/page/page.application.service.interface.ts
@@ -31,6 +31,7 @@ export interface IPageApplicationService
   pageDomainService: IPageDomainService
   pageRepository: IPageRepository
 
+  getPagesByApp(appId: string): Array<IPageModel>
   getRenderedPage(pageId: string): Promise<GetRenderedPageQuery>
   getSelectPageOptions(appId?: string): Promise<Array<DefaultOptionType>>
   loadElements(elements: Array<IElementDTO>): void

--- a/libs/frontend/abstract/application/src/renderer/runtime-element/runtime-element.model.interface.ts
+++ b/libs/frontend/abstract/application/src/renderer/runtime-element/runtime-element.model.interface.ts
@@ -25,6 +25,9 @@ export interface IRuntimeElementModel extends AnyModel {
 
   id: string
 
+  postRenderActionDone: boolean
+  preRenderActionDone: boolean
+
   render: Nullable<ReactElement>
   renderChildren: ArrayOrSingle<ReactNode>
 
@@ -44,4 +47,6 @@ export interface IRuntimeElementModel extends AnyModel {
 
   runPostRenderAction(): void
   runPreRenderAction(): void
+  setPostRenderActionDone(value: boolean): void
+  setPreRenderActionDone(value: boolean): void
 }

--- a/libs/frontend/abstract/application/src/renderer/runtime-prop/runtime-prop.model.interface.ts
+++ b/libs/frontend/abstract/application/src/renderer/runtime-prop/runtime-prop.model.interface.ts
@@ -12,7 +12,7 @@ export interface IEvaluationContext {
   rootRefs: IPropData
   rootState: IPropData
   state: IPropData
-  url: IPropData
+  urlProps: IPropData
 }
 
 export interface IBaseRuntimeProps {

--- a/libs/frontend/abstract/domain/src/shared/test/root.domain.store.interface.ts
+++ b/libs/frontend/abstract/domain/src/shared/test/root.domain.store.interface.ts
@@ -4,6 +4,7 @@ import type { IAtomDomainService } from '../../atom'
 import type { IComponentDomainService } from '../../component'
 import type { IElementDomainService } from '../../element'
 import type { IPageDomainService } from '../../page'
+import type { IRedirectDomainService } from '../../redirect'
 import type { IResourceDomainService } from '../../resource'
 import type { IStoreDomainService } from '../../store'
 import type { IFieldDomainService, ITypeDomainService } from '../../type'
@@ -23,6 +24,7 @@ export interface IRootDomainStore {
   elementDomainService: IElementDomainService
   fieldDomainService: IFieldDomainService
   pageDomainService: IPageDomainService
+  redirectDomainService: IRedirectDomainService
   resourceDomainService: IResourceDomainService
   storeDomainService: IStoreDomainService
   typeDomainService: ITypeDomainService
@@ -38,6 +40,7 @@ export interface IRootDomainContext {
   elementDomainServiceContext: MaybeContext<IElementDomainService>
   fieldDomainServiceContext: MaybeContext<IFieldDomainService>
   pageDomainServiceContext: MaybeContext<IPageDomainService>
+  redirectDomainServiceContext: MaybeContext<IRedirectDomainService>
   resourceDomainServiceContext: MaybeContext<IResourceDomainService>
   storeDomainServiceContext: MaybeContext<IStoreDomainService>
   typeDomainServiceContext: MaybeContext<ITypeDomainService>

--- a/libs/frontend/application/builder/src/index.ts
+++ b/libs/frontend/application/builder/src/index.ts
@@ -1,3 +1,4 @@
+export * from './builder-url'
 export * from './dnd'
 export * from './hooks'
 export * from './sections'

--- a/libs/frontend/application/page/src/services/page.application.service.ts
+++ b/libs/frontend/application/page/src/services/page.application.service.ts
@@ -249,6 +249,13 @@ export class PageApplicationService
     })
   }
 
+  @modelAction
+  getPagesByApp = (appId: string) => {
+    return this.pageDomainService.pagesList.filter(
+      (page) => page.app.id === appId,
+    )
+  }
+
   @computed
   private get appService() {
     return getAppService(this)

--- a/libs/frontend/application/renderer/src/renderer.application.service.ts
+++ b/libs/frontend/application/renderer/src/renderer.application.service.ts
@@ -52,6 +52,22 @@ export class RendererApplicationService
     } else {
       // existing renderer may change type when switching between builder and preview modes
       renderer.rendererType = rendererDto.rendererType
+      renderer.urlSegments = rendererDto.urlSegments
+
+      // Reset the pre/post render actions for all elements when navigating.
+      // The stopper is used to prevent infinite re-rendering when the action mutates a state
+      // which causes re-rendering the root container node.
+      const runtimeElements = [
+        ...renderer.runtimeRootContainerNode.runtimeElementsList,
+        ...renderer.runtimeRootContainerNode.runtimeContainerNodesList.flatMap(
+          (node) => node.runtimeElementsList,
+        ),
+      ]
+
+      runtimeElements.forEach((runtimeElement) => {
+        runtimeElement.setPreRenderActionDone(false)
+        runtimeElement.setPostRenderActionDone(false)
+      })
     }
 
     return renderer

--- a/libs/frontend/application/renderer/src/runtime-action.model.ts
+++ b/libs/frontend/application/renderer/src/runtime-action.model.ts
@@ -84,7 +84,7 @@ export class RuntimeActionModel
           const rootState = this.rootState;
           const refs = this.refs;
           const rootRefs = this.rootRefs;
-          const url = this.url;
+          const urlProps = this.urlProps;
           const props = this.props;
           const componentProps = this.componentProps;
           return ${(this.action.current as ICodeActionModel).code}(...args)

--- a/libs/frontend/application/renderer/src/runtime-component-prop.model.ts
+++ b/libs/frontend/application/renderer/src/runtime-component-prop.model.ts
@@ -154,7 +154,7 @@ export class RuntimeComponentPropModel
       rootRefs: {},
       rootState: {},
       state: {},
-      url: {},
+      urlProps: {},
     })
   }
 }

--- a/libs/frontend/application/renderer/src/runtime-element-prop.model.ts
+++ b/libs/frontend/application/renderer/src/runtime-element-prop.model.ts
@@ -182,11 +182,13 @@ export class RuntimeElementPropsModel
     )
 
     if (this.providerStore) {
-      // If a root action is called in a regular page, the `state` should be from the provider's page store
-      context['state'] = context.rootState
       context['rootActions'] = this.transformRuntimeActions(
         this.providerStore.runtimeActionsList,
-        context,
+        {
+          ...context,
+          // If a root action is called in a regular page, the `state` should be from the provider's page store
+          state: context.rootState,
+        },
       )
     }
 
@@ -246,7 +248,7 @@ export class RuntimeElementPropsModel
       rootRefs: this.providerStore?.refs ?? {},
       rootState: this.providerStore?.state ?? {},
       state: this.runtimeStore.state,
-      url: this.urlProps ?? {},
+      urlProps: this.urlProps ?? {},
     })
   }
 }

--- a/libs/frontend/application/renderer/src/runtime-element-prop.model.ts
+++ b/libs/frontend/application/renderer/src/runtime-element-prop.model.ts
@@ -182,13 +182,10 @@ export class RuntimeElementPropsModel
     )
 
     if (this.providerStore) {
+      // If a root action is called in a regular page, the `state` should be from the provider's page store
       context['rootActions'] = this.transformRuntimeActions(
         this.providerStore.runtimeActionsList,
-        {
-          ...context,
-          // If a root action is called in a regular page, the `state` should be from the provider's page store
-          state: context.rootState,
-        },
+        merge(context, { state: context.rootState }),
       )
     }
 

--- a/libs/frontend/application/renderer/src/runtime-element.model.ts
+++ b/libs/frontend/application/renderer/src/runtime-element.model.ts
@@ -45,6 +45,8 @@ export class RuntimeElementModel
     closestContainerNode: prop<Ref<IRuntimeContainerNodeModel>>(),
     element: prop<Ref<IElementModel>>(),
     id: idProp,
+    postRenderActionDone: prop(false).withSetter(),
+    preRenderActionDone: prop(false).withSetter(),
     runtimeProps: prop<IRuntimeElementPropModel>(),
   })
   implements IRuntimeElementModel
@@ -65,10 +67,6 @@ export class RuntimeElementModel
   }
 
   static create = create
-
-  private preRenderActionDone = false
-
-  private postRenderActionDone = false
 
   @computed
   get renderer() {
@@ -198,7 +196,7 @@ export class RuntimeElementModel
 
       runner()
 
-      this.postRenderActionDone = true
+      this.setPostRenderActionDone(true)
     }
   }
 
@@ -217,7 +215,7 @@ export class RuntimeElementModel
 
       runner()
 
-      this.preRenderActionDone = true
+      this.setPreRenderActionDone(true)
     }
   }
 

--- a/libs/frontend/application/renderer/src/runtime-store.model.ts
+++ b/libs/frontend/application/renderer/src/runtime-store.model.ts
@@ -56,13 +56,13 @@ export class RuntimeStoreModel
   @computed
   get state() {
     // To update the cache if a new state variable is added
-    const apiFieldsLength = this.store.current.api.maybeCurrent?.fields.length
+    const apiFieldsLength = this.store.current.api.current.fields.length
     const cachedStateKeysLength = Object.keys(this.cachedState ?? {}).length
 
     // cachedState is for persisting state when navigating between pages
     if (!this.cachedState || apiFieldsLength !== cachedStateKeysLength) {
       this.cachedState = observable(
-        this.store.current.api.maybeCurrent?.defaultValues ?? {},
+        this.store.current.api.current.defaultValues,
       )
     }
 

--- a/libs/frontend/application/renderer/src/runtime-store.model.ts
+++ b/libs/frontend/application/renderer/src/runtime-store.model.ts
@@ -12,6 +12,8 @@ import type { IPropData } from '@codelab/shared/abstract/core'
 import { IRef } from '@codelab/shared/abstract/core'
 import type { Maybe } from '@codelab/shared/abstract/types'
 import { Nullable } from '@codelab/shared/abstract/types'
+import cloneDeep from 'lodash/cloneDeep'
+import isEqual from 'lodash/isEqual'
 import keys from 'lodash/keys'
 import { computed, observable, set } from 'mobx'
 import type { ObjectMap, Ref } from 'mobx-keystone'
@@ -41,6 +43,8 @@ export class RuntimeStoreModel
 
   private cachedState: Nullable<object> = null
 
+  private cachedStateDefaultValues: Nullable<object> = null
+
   refs = observable.object<IPropData>({})
 
   @computed
@@ -55,15 +59,19 @@ export class RuntimeStoreModel
 
   @computed
   get state() {
-    // To update the cache if a new state variable is added
-    const apiFieldsLength = this.store.current.api.current.fields.length
-    const cachedStateKeysLength = Object.keys(this.cachedState ?? {}).length
-
     // cachedState is for persisting state when navigating between pages
-    if (!this.cachedState || apiFieldsLength !== cachedStateKeysLength) {
-      this.cachedState = observable(
+    // cachedStateDefaultValues is for checking if the default values have changed or new variables have been added
+    if (
+      !this.cachedState ||
+      !isEqual(
+        this.cachedStateDefaultValues,
         this.store.current.api.current.defaultValues,
       )
+    ) {
+      const defaultValues = this.store.current.api.current.defaultValues
+
+      this.cachedState = observable(defaultValues)
+      this.cachedStateDefaultValues = cloneDeep(defaultValues)
     }
 
     return this.cachedState

--- a/libs/frontend/domain/app/src/test/root.test.store.ts
+++ b/libs/frontend/domain/app/src/test/root.test.store.ts
@@ -4,12 +4,14 @@ import {
   atomDomainServiceContext,
   elementDomainServiceContext,
   pageDomainServiceContext,
+  redirectDomainServiceContext,
   storeDomainServiceContext,
   userDomainServiceContext,
 } from '@codelab/frontend/abstract/domain'
 import { AtomDomainService } from '@codelab/frontend/domain/atom'
 import { ElementDomainService } from '@codelab/frontend/domain/element'
 import { PageDomainService } from '@codelab/frontend/domain/page'
+import { RedirectDomainService } from '@codelab/frontend/domain/redirect'
 import { createRootDomainStore } from '@codelab/frontend/domain/shared'
 import { StoreDomainService } from '@codelab/frontend/domain/store'
 import {
@@ -26,6 +28,7 @@ export const rootDomainStore = createRootDomainStore({
     atomDomainServiceContext,
     elementDomainServiceContext,
     pageDomainServiceContext,
+    redirectDomainServiceContext,
     storeDomainServiceContext,
     typeDomainServiceContext,
     userDomainServiceContext,
@@ -35,6 +38,7 @@ export const rootDomainStore = createRootDomainStore({
     atomDomainService: new AtomDomainService({}),
     elementDomainService: new ElementDomainService({}),
     pageDomainService: new PageDomainService({}),
+    redirectDomainService: new RedirectDomainService({}),
     storeDomainService: new StoreDomainService({}),
     typeDomainService: new TypeDomainService({}),
     userDomainService: UserDomainService.fromDto(userDto),

--- a/libs/frontend/domain/shared/src/test/root.domain.store.ts
+++ b/libs/frontend/domain/shared/src/test/root.domain.store.ts
@@ -5,6 +5,7 @@ import type {
   IElementDomainService,
   IFieldDomainService,
   IPageDomainService,
+  IRedirectDomainService,
   IResourceDomainService,
   IRootDomainStore,
   IRootDomainStoreDto,
@@ -29,6 +30,9 @@ export const createRootDomainStore = ({
       elementDomainService: prop<IElementDomainService | undefined>(undefined),
       fieldDomainService: prop<IFieldDomainService | undefined>(undefined),
       pageDomainService: prop<IPageDomainService | undefined>(undefined),
+      redirectDomainService: prop<IRedirectDomainService | undefined>(
+        undefined,
+      ),
       resourceDomainService: prop<IResourceDomainService | undefined>(
         undefined,
       ),
@@ -55,6 +59,11 @@ export const createRootDomainStore = ({
         context.storeDomainServiceContext?.set(this, this.storeDomainService)
       this.pageDomainService &&
         context.pageDomainServiceContext?.set(this, this.pageDomainService)
+      this.redirectDomainService &&
+        context.redirectDomainServiceContext?.set(
+          this,
+          this.redirectDomainService,
+        )
       this.resourceDomainService &&
         context.resourceDomainServiceContext?.set(
           this,

--- a/libs/frontend/domain/type/src/models/interface-type.model.ts
+++ b/libs/frontend/domain/type/src/models/interface-type.model.ts
@@ -90,13 +90,11 @@ export class InterfaceType
 
   @computed
   get defaultValues(): IPropData {
-    return compact(
-      this.fields.map((field) =>
-        !isNil(field.defaultValues)
-          ? { [field.key]: field.defaultValues }
-          : undefined,
-      ),
-    ).reduce(merge, {})
+    // do not omit undefined values
+    // object keys length is used for cache busting in runtimeStore.state
+    return this.fields
+      .map((field) => ({ [field.key]: field.defaultValues ?? undefined }))
+      .reduce(merge, {})
   }
 
   @computed

--- a/libs/frontend/presentation/view/components/codeMirror/completion-options.ts
+++ b/libs/frontend/presentation/view/components/codeMirror/completion-options.ts
@@ -54,7 +54,7 @@ export const createAutoCompleteOptions = (
   ...getOptions(ctx?.refs, 'refs', 'References'),
   ...getOptions(ctx?.rootState, 'rootState', 'Root State'),
   ...getOptions(ctx?.rootRefs, 'rootRefs', 'Root References'),
-  ...getOptions(ctx?.url, 'url', 'Urls'),
+  ...getOptions(ctx?.urlProps, 'urlProps', 'Url Props'),
   ...getOptions(ctx?.rootActions, 'rootActions', 'Root Actions'),
   ...getOptions(ctx?.actions, 'actions', 'Actions'),
   ...getOptions(ctx?.args, 'args', 'Args'),


### PR DESCRIPTION
<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(libs-ui-component): must begin with lowercase` -->

## Description

<!-- This is a short description on the Pull Request -->
This PR just revives the old functionality around in-app routing that was done in https://github.com/codelab-app/platform/pull/2843, and will only work when in preview. Also updated the logic around executing pre/post render actions so that they are executed again when navigating

This also includes some fixes around cached state for a page not changing when navigating with a different url props e.g. _going to product-1 then going back to product list then going to product-2_

This also includes fixes on the unit tests for `frontend-application-renderer` and `frontend-domain-app`


## Video or Image

<!-- Add video or image showing how the new feature works -->

https://github.com/codelab-app/platform/assets/27695022/81bb8151-8724-4cbf-b6d9-a2ddea8c3747


## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged -->

Fixes #3227
