### PR TITLE
wip: styles for different states

### DIFF
--- a/libs/frontend/abstract/application/src/element/element.service.interface.ts
+++ b/libs/frontend/abstract/application/src/element/element.service.interface.ts
@@ -1,4 +1,5 @@
 import type {
+  ElementStyleSelector,
   ICloneElementService,
   IElementDomainService,
   IElementModel,
@@ -65,6 +66,7 @@ export interface IElementService
   > {
   cloneElementService: ICloneElementService
   createForm: IFormService<CreateElementData, CreateElementProperties>
+  currentStyleSelector: ElementStyleSelector
   elementDomainService: IElementDomainService
   elementRepository: IElementRepository
   // Moved from element model to decouple renderer
@@ -83,6 +85,7 @@ export interface IElementService
     rootElement: IElementModel
   }
   move(context: IMoveElementContext): Promise<void>
+  setCurrentStyleSelector(selector: ElementStyleSelector): void
   styleStringWithBreakpoints(element: IElementModel): string
   syncModifiedElements(): Promise<void>
   update(data: IUpdateElementData): Promise<IElementModel>

--- a/libs/frontend/abstract/application/src/element/element.service.interface.ts
+++ b/libs/frontend/abstract/application/src/element/element.service.interface.ts
@@ -1,5 +1,5 @@
 import type {
-  ElementStyleSelector,
+  ElementStylePseudoClass,
   ICloneElementService,
   IElementDomainService,
   IElementModel,
@@ -66,7 +66,7 @@ export interface IElementService
   > {
   cloneElementService: ICloneElementService
   createForm: IFormService<CreateElementData, CreateElementProperties>
-  currentStyleSelector: ElementStyleSelector
+  currentStylePseudoClass: ElementStylePseudoClass
   elementDomainService: IElementDomainService
   elementRepository: IElementRepository
   // Moved from element model to decouple renderer
@@ -85,7 +85,7 @@ export interface IElementService
     rootElement: IElementModel
   }
   move(context: IMoveElementContext): Promise<void>
-  setCurrentStyleSelector(selector: ElementStyleSelector): void
+  setCurrentStylePseudoClass(pseudoClass: ElementStylePseudoClass): void
   styleStringWithBreakpoints(element: IElementModel): string
   syncModifiedElements(): Promise<void>
   update(data: IUpdateElementData): Promise<IElementModel>

--- a/libs/frontend/abstract/domain/src/element/element-style.model.interface.ts
+++ b/libs/frontend/abstract/domain/src/element/element-style.model.interface.ts
@@ -2,9 +2,15 @@ import type { Nullable } from '@codelab/shared/abstract/types'
 import type { BuilderWidthBreakPoint } from '../builder'
 import type { CssMap } from './element.model.interface'
 
+export enum ElementStyleSelector {
+  None = 'none',
+  Hover = 'hover',
+  Focus = 'focus',
+}
+
 export interface IBreakpointStyle {
   cssString?: string
-  guiString?: string
+  guiString?: { [key in ElementStyleSelector]?: string }
 }
 
 export type IElementStyle = Record<
@@ -24,7 +30,6 @@ export interface IElementStyleModel {
    * for production - uses media queries to apply styles
    * for development - uses container queries, for better UX
    */
-  guiCss?: Nullable<string>
   styleParsed: IElementStyle
   /**
    * styles that are inherited from other breakpoints,
@@ -37,7 +42,11 @@ export interface IElementStyleModel {
     inheritedStyles: ElementCssRules
   }
 
-  appendToGuiCss(css: CssMap): void
-  deleteFromGuiCss(propNames: Array<string>): void
+  appendToGuiCss(selector: ElementStyleSelector, css: CssMap): void
+  deleteFromGuiCss(
+    selector: ElementStyleSelector,
+    propNames: Array<string>,
+  ): void
+  guiCss(selector: ElementStyleSelector): Nullable<string>
   setCustomCss(css: string): void
 }

--- a/libs/frontend/abstract/domain/src/element/element-style.model.interface.ts
+++ b/libs/frontend/abstract/domain/src/element/element-style.model.interface.ts
@@ -2,7 +2,7 @@ import type { Nullable } from '@codelab/shared/abstract/types'
 import type { BuilderWidthBreakPoint } from '../builder'
 import type { CssMap } from './element.model.interface'
 
-export enum ElementStyleSelector {
+export enum ElementStylePseudoClass {
   None = 'none',
   Hover = 'hover',
   Focus = 'focus',
@@ -10,7 +10,7 @@ export enum ElementStyleSelector {
 
 export interface IBreakpointStyle {
   cssString?: string
-  guiString?: { [key in ElementStyleSelector]?: string }
+  guiString?: { [key in ElementStylePseudoClass]?: string }
 }
 
 export type IElementStyle = Record<
@@ -42,11 +42,11 @@ export interface IElementStyleModel {
     inheritedStyles: ElementCssRules
   }
 
-  appendToGuiCss(selector: ElementStyleSelector, css: CssMap): void
+  appendToGuiCss(selector: ElementStylePseudoClass, css: CssMap): void
   deleteFromGuiCss(
-    selector: ElementStyleSelector,
+    selector: ElementStylePseudoClass,
     propNames: Array<string>,
   ): void
-  guiCss(selector: ElementStyleSelector): Nullable<string>
+  guiCss(selector: ElementStylePseudoClass): Nullable<string>
   setCustomCss(css: string): void
 }

--- a/libs/frontend/application/builder/src/sections/overlay-toolbar/BuilderClickOverlay.tsx
+++ b/libs/frontend/application/builder/src/sections/overlay-toolbar/BuilderClickOverlay.tsx
@@ -105,7 +105,7 @@ export const BuilderClickOverlay = observer<{
     <ClickOverlay
       content={content}
       dependencies={[
-        selectedNode.current.style.guiCss,
+        selectedNode.current.style.guiCss(elementService.currentStyleSelector),
         selectedNode.current.style.customCss,
         selectedNode.current.tailwindClassNames,
         selectedNode.current.props.values,

--- a/libs/frontend/application/builder/src/sections/overlay-toolbar/BuilderClickOverlay.tsx
+++ b/libs/frontend/application/builder/src/sections/overlay-toolbar/BuilderClickOverlay.tsx
@@ -105,7 +105,9 @@ export const BuilderClickOverlay = observer<{
     <ClickOverlay
       content={content}
       dependencies={[
-        selectedNode.current.style.guiCss(elementService.currentStyleSelector),
+        selectedNode.current.style.guiCss(
+          elementService.currentStylePseudoClass,
+        ),
         selectedNode.current.style.customCss,
         selectedNode.current.tailwindClassNames,
         selectedNode.current.props.values,

--- a/libs/frontend/application/element/src/css-editor/StylesEditor.tsx
+++ b/libs/frontend/application/element/src/css-editor/StylesEditor.tsx
@@ -1,5 +1,8 @@
 import CaretRightOutlined from '@ant-design/icons/CaretRightOutlined'
-import { Collapse, ConfigProvider, Typography } from 'antd'
+import { ElementStyleSelector } from '@codelab/frontend/abstract/domain'
+import { useStore } from '@codelab/frontend/application/shared/store'
+import { Collapse, ConfigProvider, Select, Typography } from 'antd'
+import { observer } from 'mobx-react-lite'
 import React from 'react'
 import { BackgroundEditor } from './background'
 import { BorderEditor } from './border'
@@ -17,8 +20,9 @@ const panelHeader = (title: string) => {
   return <Typography className="text-[12px] font-semibold">{title}</Typography>
 }
 
-export const StylesEditor = () => {
+export const StylesEditor = observer(() => {
   const className = '[&>*:first-child]:bg-gray-100 [&>*:first-child]:!py-1.5'
+  const { elementService } = useStore()
 
   return (
     <ConfigProvider
@@ -40,6 +44,17 @@ export const StylesEditor = () => {
         },
       }}
     >
+      <div>Style Selector: </div>
+      <Select
+        className="mb-2 w-full"
+        onSelect={(value) => elementService.setCurrentStyleSelector(value)}
+        options={[
+          { label: 'None', value: ElementStyleSelector.None },
+          { label: 'Focused', value: ElementStyleSelector.Hover },
+          { label: 'Hover', value: ElementStyleSelector.Focus },
+        ]}
+        value={elementService.currentStyleSelector}
+      />
       <Collapse
         bordered={false}
         defaultActiveKey={['1', '2', '3', '4', '5', '6', '7', '8']}
@@ -79,4 +94,4 @@ export const StylesEditor = () => {
       </Collapse>
     </ConfigProvider>
   )
-}
+})

--- a/libs/frontend/application/element/src/css-editor/StylesEditor.tsx
+++ b/libs/frontend/application/element/src/css-editor/StylesEditor.tsx
@@ -1,5 +1,5 @@
 import CaretRightOutlined from '@ant-design/icons/CaretRightOutlined'
-import { ElementStyleSelector } from '@codelab/frontend/abstract/domain'
+import { ElementStylePseudoClass } from '@codelab/frontend/abstract/domain'
 import { useStore } from '@codelab/frontend/application/shared/store'
 import { Collapse, ConfigProvider, Select, Typography } from 'antd'
 import { observer } from 'mobx-react-lite'
@@ -47,13 +47,13 @@ export const StylesEditor = observer(() => {
       <div>Style Selector: </div>
       <Select
         className="mb-2 w-full"
-        onSelect={(value) => elementService.setCurrentStyleSelector(value)}
+        onSelect={(value) => elementService.setCurrentStylePseudoClass(value)}
         options={[
-          { label: 'None', value: ElementStyleSelector.None },
-          { label: 'Hover', value: ElementStyleSelector.Hover },
-          { label: 'Focused', value: ElementStyleSelector.Focus },
+          { label: 'None', value: ElementStylePseudoClass.None },
+          { label: 'Hover', value: ElementStylePseudoClass.Hover },
+          { label: 'Focused', value: ElementStylePseudoClass.Focus },
         ]}
-        value={elementService.currentStyleSelector}
+        value={elementService.currentStylePseudoClass}
       />
       <Collapse
         bordered={false}

--- a/libs/frontend/application/element/src/css-editor/StylesEditor.tsx
+++ b/libs/frontend/application/element/src/css-editor/StylesEditor.tsx
@@ -50,8 +50,8 @@ export const StylesEditor = observer(() => {
         onSelect={(value) => elementService.setCurrentStyleSelector(value)}
         options={[
           { label: 'None', value: ElementStyleSelector.None },
-          { label: 'Focused', value: ElementStyleSelector.Hover },
-          { label: 'Hover', value: ElementStyleSelector.Focus },
+          { label: 'Hover', value: ElementStyleSelector.Hover },
+          { label: 'Focused', value: ElementStyleSelector.Focus },
         ]}
         value={elementService.currentStyleSelector}
       />

--- a/libs/frontend/application/element/src/css-editor/style.hook.ts
+++ b/libs/frontend/application/element/src/css-editor/style.hook.ts
@@ -1,15 +1,21 @@
 import { isElementRef } from '@codelab/frontend/abstract/domain'
 import { useStore } from '@codelab/frontend/application/shared/store'
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import type { CssProperty } from './css'
 import { DefaultCssProperties } from './css'
 
 export const useStyle = () => {
-  const { builderService } = useStore()
+  const { builderService, elementService } = useStore()
 
   const [currentStyles, setCurrentStyles] = useState<{
     [key: string]: string
   }>()
+
+  const selector = elementService.currentStyleSelector
+
+  useEffect(() => {
+    loadCurrentStyles()
+  }, [elementService.currentStyleSelector])
 
   const loadCurrentStyles = () => {
     if (
@@ -17,7 +23,7 @@ export const useStyle = () => {
       isElementRef(builderService.selectedNode)
     ) {
       const newStyles = JSON.parse(
-        builderService.selectedNode.current.style.guiCss || '{}',
+        builderService.selectedNode.current.style.guiCss(selector) || '{}',
       )
 
       setCurrentStyles(newStyles)
@@ -48,13 +54,15 @@ export const useStyle = () => {
 
     setCurrentStyles(updatedStyles)
 
-    selectedNode.current.style.appendToGuiCss({ [key]: value })
+    selectedNode.current.style.appendToGuiCss(selector, { [key]: value })
+
+    console.log(selectedNode.current.style.styleParsed)
   }
 
   const resetStyle = (property: CssProperty) => {
-    const { defaultValue } = DefaultCssProperties[property]
+    // const { defaultValue } = DefaultCssProperties[property]
 
-    setStyle(property, defaultValue)
+    removeStyles([property])
   }
 
   const canReset = (property: CssProperty) => {
@@ -73,7 +81,7 @@ export const useStyle = () => {
       return
     }
 
-    selectedNode.current.style.deleteFromGuiCss(properties)
+    selectedNode.current.style.deleteFromGuiCss(selector, properties)
 
     loadCurrentStyles()
   }

--- a/libs/frontend/application/element/src/css-editor/style.hook.ts
+++ b/libs/frontend/application/element/src/css-editor/style.hook.ts
@@ -11,11 +11,11 @@ export const useStyle = () => {
     [key: string]: string
   }>()
 
-  const selector = elementService.currentStyleSelector
+  const currentStylePseudoClass = elementService.currentStylePseudoClass
 
   useEffect(() => {
     loadCurrentStyles()
-  }, [elementService.currentStyleSelector])
+  }, [elementService.currentStylePseudoClass])
 
   const loadCurrentStyles = () => {
     if (
@@ -23,7 +23,9 @@ export const useStyle = () => {
       isElementRef(builderService.selectedNode)
     ) {
       const newStyles = JSON.parse(
-        builderService.selectedNode.current.style.guiCss(selector) || '{}',
+        builderService.selectedNode.current.style.guiCss(
+          currentStylePseudoClass,
+        ) || '{}',
       )
 
       setCurrentStyles(newStyles)
@@ -54,7 +56,9 @@ export const useStyle = () => {
 
     setCurrentStyles(updatedStyles)
 
-    selectedNode.current.style.appendToGuiCss(selector, { [key]: value })
+    selectedNode.current.style.appendToGuiCss(currentStylePseudoClass, {
+      [key]: value,
+    })
 
     console.log(selectedNode.current.style.styleParsed)
   }
@@ -81,7 +85,10 @@ export const useStyle = () => {
       return
     }
 
-    selectedNode.current.style.deleteFromGuiCss(selector, properties)
+    selectedNode.current.style.deleteFromGuiCss(
+      currentStylePseudoClass,
+      properties,
+    )
 
     loadCurrentStyles()
   }

--- a/libs/frontend/application/element/src/services/element.service.ts
+++ b/libs/frontend/application/element/src/services/element.service.ts
@@ -16,6 +16,7 @@ import {
   BuilderWidthBreakPoint,
   defaultBuilderWidthBreakPoints,
   elementRef,
+  ElementStyleSelector,
   getBuilderDomainService,
 } from '@codelab/frontend/abstract/domain'
 import { getPropService } from '@codelab/frontend/application/prop'
@@ -65,6 +66,7 @@ export class ElementService
   extends Model({
     cloneElementService: prop(() => new CloneElementService({})),
     createForm: prop(() => new CreateElementFormService({})),
+    currentStyleSelector: prop(() => ElementStyleSelector.None).withSetter(),
     // createModal: prop(() => new CreateElementModalService({})),
     deleteModal: prop(() => new ElementModalService({})),
     elementDomainService: prop(() => new ElementDomainService({})),
@@ -380,7 +382,21 @@ export class ElementService
         breakpointStyles.push(
           `${mediaQueryString} (width >= ${lowerBound}px) {
             ${breakpointStyle.cssString ?? ''}
-            ${jsonStringToCss(breakpointStyle.guiString ?? '{}')}
+            ${jsonStringToCss(
+              breakpointStyle.guiString?.[ElementStyleSelector.None] ?? '{}',
+            )}
+            &:hover {
+              ${jsonStringToCss(
+                breakpointStyle.guiString?.[ElementStyleSelector.Hover] ?? '{}',
+              )}
+            }
+            &:focus {
+              ${jsonStringToCss(
+                breakpointStyle.guiString?.[ElementStyleSelector.Focus] ?? '{}',
+              )}
+            }
+
+            .ce-inline-toolbar { color: initial; }
           }`,
         )
       }

--- a/libs/frontend/application/element/src/services/element.service.ts
+++ b/libs/frontend/application/element/src/services/element.service.ts
@@ -16,7 +16,7 @@ import {
   BuilderWidthBreakPoint,
   defaultBuilderWidthBreakPoints,
   elementRef,
-  ElementStyleSelector,
+  ElementStylePseudoClass,
   getBuilderDomainService,
 } from '@codelab/frontend/abstract/domain'
 import { getPropService } from '@codelab/frontend/application/prop'
@@ -66,7 +66,9 @@ export class ElementService
   extends Model({
     cloneElementService: prop(() => new CloneElementService({})),
     createForm: prop(() => new CreateElementFormService({})),
-    currentStyleSelector: prop(() => ElementStyleSelector.None).withSetter(),
+    currentStylePseudoClass: prop(
+      () => ElementStylePseudoClass.None,
+    ).withSetter(),
     // createModal: prop(() => new CreateElementModalService({})),
     deleteModal: prop(() => new ElementModalService({})),
     elementDomainService: prop(() => new ElementDomainService({})),
@@ -382,16 +384,18 @@ export class ElementService
           `@container root (min-width: ${lowerBound}px) {
             ${breakpointStyle.cssString ?? ''}
             ${jsonStringToCss(
-              breakpointStyle.guiString?.[ElementStyleSelector.None] ?? '{}',
+              breakpointStyle.guiString?.[ElementStylePseudoClass.None] ?? '{}',
             )}
             &:hover {
               ${jsonStringToCss(
-                breakpointStyle.guiString?.[ElementStyleSelector.Hover] ?? '{}',
+                breakpointStyle.guiString?.[ElementStylePseudoClass.Hover] ??
+                  '{}',
               )}
             }
             &:focus {
               ${jsonStringToCss(
-                breakpointStyle.guiString?.[ElementStyleSelector.Focus] ?? '{}',
+                breakpointStyle.guiString?.[ElementStylePseudoClass.Focus] ??
+                  '{}',
               )}
             }
 

--- a/libs/frontend/application/element/src/services/element.service.ts
+++ b/libs/frontend/application/element/src/services/element.service.ts
@@ -366,7 +366,6 @@ export class ElementService
       rendererType === RendererType.Production ||
       rendererType === RendererType.Preview
 
-    const mediaQueryString = isProduction ? '@media' : '@container root'
     const breakpointStyles = []
 
     for (const breakpoint of element.style.breakpointsByPrecedence) {
@@ -380,7 +379,7 @@ export class ElementService
 
       if (breakpointStyle) {
         breakpointStyles.push(
-          `${mediaQueryString} (width >= ${lowerBound}px) {
+          `@container root (min-width: ${lowerBound}px) {
             ${breakpointStyle.cssString ?? ''}
             ${jsonStringToCss(
               breakpointStyle.guiString?.[ElementStyleSelector.None] ?? '{}',

--- a/libs/frontend/application/renderer/src/text-editor/TextRenderer.tsx
+++ b/libs/frontend/application/renderer/src/text-editor/TextRenderer.tsx
@@ -1,5 +1,11 @@
-import Output from 'editorjs-react-renderer'
+// import Output from 'editorjs-react-renderer'
+import dynamic from 'next/dynamic'
 import React, { memo, useMemo } from 'react'
+
+const Output = dynamic(
+  async () => (await import('editorjs-react-renderer')).default,
+  { ssr: false },
+)
 
 interface Props {
   data?: string
@@ -14,7 +20,14 @@ const TextRenderer = ({ data }: Props) => {
     }
   }, [data])
 
-  return <Output data={parsedData} />
+  return (
+    <Output
+      data={parsedData}
+      // TODO: the renderer adds some margin and text align, which can conflict
+      // with the element's styles. Find out why this happens.
+      style={{ paragraph: { margin: 'initial', textAlign: 'unset' } }}
+    />
+  )
 }
 
 export default memo(TextRenderer)

--- a/libs/frontend/application/renderer/src/text-editor/TextRenderer.tsx
+++ b/libs/frontend/application/renderer/src/text-editor/TextRenderer.tsx
@@ -1,11 +1,5 @@
-// import Output from 'editorjs-react-renderer'
-import dynamic from 'next/dynamic'
+import Output from 'editorjs-react-renderer'
 import React, { memo, useMemo } from 'react'
-
-const Output = dynamic(
-  async () => (await import('editorjs-react-renderer')).default,
-  { ssr: false },
-)
 
 interface Props {
   data?: string

--- a/libs/frontend/domain/element/src/store/element-style.model.ts
+++ b/libs/frontend/domain/element/src/store/element-style.model.ts
@@ -5,7 +5,7 @@ import type {
 import {
   BuilderWidthBreakPoint,
   CssMap,
-  ElementStyleSelector,
+  ElementStylePseudoClass,
   getBuilderDomainService,
   IElementStyle,
 } from '@codelab/frontend/abstract/domain'
@@ -42,11 +42,11 @@ export class ElementStyle
 
   @computed
   get guiCss() {
-    return (selector: ElementStyleSelector) => {
+    return (pseudoClass: ElementStylePseudoClass) => {
       const breakpoint = this.builderService.selectedBuilderBreakpoint
       const { guiString } = this.styleParsed[breakpoint] ?? {}
 
-      return guiString?.[selector] ?? '{}'
+      return guiString?.[pseudoClass] ?? '{}'
     }
   }
 
@@ -82,10 +82,10 @@ export class ElementStyle
   }
 
   @modelAction
-  appendToGuiCss(selector: ElementStyleSelector, css: CssMap) {
+  appendToGuiCss(pseudoClass: ElementStylePseudoClass, css: CssMap) {
     const breakpoint = this.builderService.selectedBuilderBreakpoint
     const styleObject = this.styleParsed
-    const curGuiCss = JSON.parse(this.guiCss(selector) || '{}')
+    const curGuiCss = JSON.parse(this.guiCss(pseudoClass) || '{}')
     const newGuiCss = { ...curGuiCss, ...css }
     const guiString = JSON.stringify(newGuiCss)
 
@@ -93,17 +93,20 @@ export class ElementStyle
       ...styleObject[breakpoint],
       guiString: {
         ...styleObject[breakpoint]?.guiString,
-        [selector]: guiString,
+        [pseudoClass]: guiString,
       },
     }
     this.style = JSON.stringify(styleObject)
   }
 
   @modelAction
-  deleteFromGuiCss(selector: ElementStyleSelector, propNames: Array<string>) {
+  deleteFromGuiCss(
+    pseudoClass: ElementStylePseudoClass,
+    propNames: Array<string>,
+  ) {
     const breakpoint = this.builderService.selectedBuilderBreakpoint
     const styleObject = this.styleParsed
-    const curGuiCss = JSON.parse(this.guiCss(selector) || '{}')
+    const curGuiCss = JSON.parse(this.guiCss(pseudoClass) || '{}')
 
     propNames.forEach((propName) => {
       if (curGuiCss[propName]) {
@@ -118,7 +121,7 @@ export class ElementStyle
       ...styleObject[breakpoint],
       guiString: {
         ...styleObject[breakpoint]?.guiString,
-        [selector]: guiString,
+        [pseudoClass]: guiString,
       },
     }
     this.style = JSON.stringify(styleObject)

--- a/libs/frontend/domain/element/src/store/element-style.model.ts
+++ b/libs/frontend/domain/element/src/store/element-style.model.ts
@@ -5,14 +5,14 @@ import type {
 import {
   BuilderWidthBreakPoint,
   CssMap,
-  defaultBuilderWidthBreakPoints,
+  ElementStyleSelector,
   getBuilderDomainService,
   IElementStyle,
 } from '@codelab/frontend/abstract/domain'
 import type { Nullable } from '@codelab/shared/abstract/types'
 import { computed } from 'mobx'
 import { Model, model, modelAction, prop } from 'mobx-keystone'
-import { jsonStringToCss, parseCssStringIntoObject } from './utils'
+import { parseCssStringIntoObject } from './utils'
 
 @model('@codelab/ElementStyle')
 export class ElementStyle
@@ -42,10 +42,12 @@ export class ElementStyle
 
   @computed
   get guiCss() {
-    const breakpoint = this.builderService.selectedBuilderBreakpoint
-    const { guiString } = this.styleParsed[breakpoint] ?? {}
+    return (selector: ElementStyleSelector) => {
+      const breakpoint = this.builderService.selectedBuilderBreakpoint
+      const { guiString } = this.styleParsed[breakpoint] ?? {}
 
-    return guiString
+      return guiString?.[selector] ?? '{}'
+    }
   }
 
   @computed
@@ -66,36 +68,42 @@ export class ElementStyle
 
       const { cssString, guiString } = parsedStyle[breakpoint] ?? {}
       const cssObject = parseCssStringIntoObject(cssString ?? '')
-      const guiObject = JSON.parse(guiString ?? '{}')
+      const guiObject = JSON.parse(guiString?.none ?? '{}')
 
       inheritedStyles = { ...inheritedStyles, ...cssObject, ...guiObject }
     }
 
     const { cssString, guiString } = parsedStyle[currentBreakpoint] ?? {}
     const cssObject = parseCssStringIntoObject(cssString ?? '')
-    const guiObject = JSON.parse(guiString ?? '{}')
+    const guiObject = JSON.parse(guiString?.none ?? '{}')
     const currentStyles = { ...cssObject, ...guiObject }
 
     return { currentStyles, inheritedStyles }
   }
 
   @modelAction
-  appendToGuiCss(css: CssMap) {
+  appendToGuiCss(selector: ElementStyleSelector, css: CssMap) {
     const breakpoint = this.builderService.selectedBuilderBreakpoint
     const styleObject = this.styleParsed
-    const curGuiCss = JSON.parse(this.guiCss || '{}')
+    const curGuiCss = JSON.parse(this.guiCss(selector) || '{}')
     const newGuiCss = { ...curGuiCss, ...css }
     const guiString = JSON.stringify(newGuiCss)
 
-    styleObject[breakpoint] = { ...styleObject[breakpoint], guiString }
+    styleObject[breakpoint] = {
+      ...styleObject[breakpoint],
+      guiString: {
+        ...styleObject[breakpoint]?.guiString,
+        [selector]: guiString,
+      },
+    }
     this.style = JSON.stringify(styleObject)
   }
 
   @modelAction
-  deleteFromGuiCss(propNames: Array<string>) {
+  deleteFromGuiCss(selector: ElementStyleSelector, propNames: Array<string>) {
     const breakpoint = this.builderService.selectedBuilderBreakpoint
     const styleObject = this.styleParsed
-    const curGuiCss = JSON.parse(this.guiCss || '{}')
+    const curGuiCss = JSON.parse(this.guiCss(selector) || '{}')
 
     propNames.forEach((propName) => {
       if (curGuiCss[propName]) {
@@ -106,7 +114,13 @@ export class ElementStyle
 
     const guiString = JSON.stringify(curGuiCss)
 
-    styleObject[breakpoint] = { ...styleObject[breakpoint], guiString }
+    styleObject[breakpoint] = {
+      ...styleObject[breakpoint],
+      guiString: {
+        ...styleObject[breakpoint]?.guiString,
+        [selector]: guiString,
+      },
+    }
     this.style = JSON.stringify(styleObject)
   }
 


### PR DESCRIPTION
<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(libs-ui-component): must begin with lowercase` -->

## Description
Allows setting CSS styles for different states (hover, focus...) of elements.

- [x] Styles for different states of an element
- [x] fix Style specificity issues

<!-- This is a short description on the Pull Request -->

## Video or Image

https://github.com/codelab-app/platform/assets/48331678/52fd2f94-2bbd-4f67-bdea-ec773a6e4d0b

<!-- Add video or image showing how the new feature works -->

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged -->

Fixes #3221 
