### PR TITLE
refactor: cleanup vercel from auth0 allowed urls

### DIFF
--- a/terraform/modules/auth0/client_machine.tf
+++ b/terraform/modules/auth0/client_machine.tf
@@ -3,12 +3,8 @@ resource "auth0_client" "machine_client" {
   description = "A M2M client used by Auth0 Actions Flows"
   app_type    = "non_interactive"
 
-  web_origins = [
-    "${var.next_public_platform_host}",
-  "https://*.vercel.app"]
-  allowed_origins = [
-    "${var.next_public_platform_host}",
-  "https://*.vercel.app"]
+  web_origins = ["${var.next_public_platform_host}"]
+  allowed_origins = ["${var.next_public_platform_host}"]
 }
 
 # Allow machine client to access the scope of the management API

--- a/terraform/modules/auth0/client_web.tf
+++ b/terraform/modules/auth0/client_web.tf
@@ -3,18 +3,10 @@ resource "auth0_client" "web_client" {
   # description         = var.app_description
   app_type        = "regular_web"
   oidc_conformant = true
-  callbacks = [
-    "${var.next_public_platform_host}/api/auth/callback",
-  "https://*.vercel.app/api/auth/callback"]
-  allowed_logout_urls = [
-    "${var.next_public_platform_host}",
-  "https://*.vercel.app"]
-  web_origins = [
-    "${var.next_public_platform_host}",
-  "https://*.vercel.app"]
-  allowed_origins = [
-    "${var.next_public_platform_host}",
-  "https://*.vercel.app"]
+  callbacks = ["${var.next_public_platform_host}/api/auth/callback"]
+  allowed_logout_urls = ["${var.next_public_platform_host}"]
+  web_origins = ["${var.next_public_platform_host}"]
+  allowed_origins = ["${var.next_public_platform_host}"]
   grant_types = ["authorization_code", "implicit", "password", "refresh_token"]
 
   cross_origin_auth = true


### PR DESCRIPTION
<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(libs-ui-component): must begin with lowercase` -->

## Description

After migration to DigitalOcean there is no need to have `*vercel` urls in Auth0 settings
