### PR TITLE
refactor: add audience env

### DIFF
--- a/terraform/environments/ci/symlink.sh
+++ b/terraform/environments/ci/symlink.sh
@@ -6,7 +6,6 @@ rm ./*.symlink.tf
 
 ln -s ../shared/module-auth0.tf ./module-auth0.symlink.tf
 ln -s ../shared/vars-auth0.tf ./vars-auth0.symlink.tf
-ln -s ../shared/vars-auth0-audience.tf ./vars-auth0-audience.symlink.tf
 ln -s ../shared/vars-platform-api.tf ./vars-platform-api.symlink.tf
 ln -s ../shared/vars-platform.tf ./vars-platform.symlink.tf
 ln -s ../shared/vars-supabase.tf ./vars-supabase.symlink.tf

--- a/terraform/environments/ci/vars-auth0-audience.symlink.tf
+++ b/terraform/environments/ci/vars-auth0-audience.symlink.tf
@@ -1,1 +1,0 @@
-../shared/vars-auth0-audience.tf

--- a/terraform/environments/prod/module-do-codelab.tf
+++ b/terraform/environments/prod/module-do-codelab.tf
@@ -4,6 +4,7 @@ module "digitalocean-codelab" {
   do_token = var.DIGITALOCEAN_TOKEN
   auth0_secret = var.AUTH0_SECRET
   auth0_issuer_base_url = var.AUTH0_ISSUER_BASE_URL
+  auth0_audience = var.AUTH0_AUDIENCE
   auth0_client_id = module.auth0.web_client.id
   auth0_client_secret = module.auth0.web_client.client_secret
   next_public_platform_host = var.NEXT_PUBLIC_PLATFORM_HOST

--- a/terraform/environments/shared/module-auth0.tf
+++ b/terraform/environments/shared/module-auth0.tf
@@ -2,6 +2,7 @@ module "auth0" {
   source = "../../modules/auth0"
 
   auth0_issuer_base_url     = var.AUTH0_ISSUER_BASE_URL
+  auth0_audience            = var.AUTH0_AUDIENCE
   next_public_platform_host = var.NEXT_PUBLIC_PLATFORM_HOST
   auth0_domain              = var.AUTH0_DOMAIN
   auth0_m2m_client_id       = var.AUTH0_M2M_CLIENT_ID

--- a/terraform/environments/shared/vars-auth0-audience.tf
+++ b/terraform/environments/shared/vars-auth0-audience.tf
@@ -1,3 +1,0 @@
-variable "AUTH0_AUDIENCE" {
-  type = string
-}

--- a/terraform/environments/shared/vars-auth0.tf
+++ b/terraform/environments/shared/vars-auth0.tf
@@ -31,3 +31,6 @@ variable "AUTH0_SECRET" {
   type = string
 }
 
+variable "AUTH0_AUDIENCE" {
+  type = string
+}

--- a/terraform/modules/auth0-vars/vars-audience.tf
+++ b/terraform/modules/auth0-vars/vars-audience.tf
@@ -1,3 +1,0 @@
-variable "auth0_audience" {
-  type        = string
-}

--- a/terraform/modules/auth0/action_upsert_user.tf
+++ b/terraform/modules/auth0/action_upsert_user.tf
@@ -12,7 +12,6 @@ resource "auth0_action" "upsert_user" {
 const { gql, GraphQLClient } = require('graphql-request')
 const { URL } = require('url');
 const axios = require('axios');
-const { v4 } = require('uuid');
 
 /**
   * Handler that will be called during the execution of a PostLogin flow.
@@ -97,10 +96,5 @@ exports.onExecutePostLogin = async (event, api) => {
   dependencies {
     name    = "axios"
     version = "0.24.0"
-  }
-
-  dependencies {
-    name    = "uuid"
-    version = "9.0.0"
   }
 }

--- a/terraform/modules/auth0/client_machine.tf
+++ b/terraform/modules/auth0/client_machine.tf
@@ -3,12 +3,8 @@ resource "auth0_client" "machine_client" {
   description = "A M2M client used by Auth0 Actions Flows"
   app_type    = "non_interactive"
 
-  web_origins = [
-    "${var.next_public_platform_host}",
-  "https://*.vercel.app"]
-  allowed_origins = [
-    "${var.next_public_platform_host}",
-  "https://*.vercel.app"]
+  web_origins = ["${var.next_public_platform_host}"]
+  allowed_origins = ["${var.next_public_platform_host}"]
 }
 
 # Allow machine client to access the scope of the management API

--- a/terraform/modules/auth0/client_web.tf
+++ b/terraform/modules/auth0/client_web.tf
@@ -3,18 +3,10 @@ resource "auth0_client" "web_client" {
   # description         = var.app_description
   app_type        = "regular_web"
   oidc_conformant = true
-  callbacks = [
-    "${var.next_public_platform_host}/api/auth/callback",
-  "https://*.vercel.app/api/auth/callback"]
-  allowed_logout_urls = [
-    "${var.next_public_platform_host}",
-  "https://*.vercel.app"]
-  web_origins = [
-    "${var.next_public_platform_host}",
-  "https://*.vercel.app"]
-  allowed_origins = [
-    "${var.next_public_platform_host}",
-  "https://*.vercel.app"]
+  callbacks = ["${var.next_public_platform_host}/api/auth/callback"]
+  allowed_logout_urls = ["${var.next_public_platform_host}"]
+  web_origins = ["${var.next_public_platform_host}"]
+  allowed_origins = ["${var.next_public_platform_host}"]
   grant_types = ["authorization_code", "implicit", "password", "refresh_token"]
 
   cross_origin_auth = true

--- a/terraform/modules/auth0/vars.tf
+++ b/terraform/modules/auth0/vars.tf
@@ -3,6 +3,10 @@ variable "auth0_issuer_base_url" {
   description = "OIDC issuer URL, the endpoint of the provider we're authorizing against"
 }
 
+variable "auth0_audience" {
+  type        = string
+}
+
 variable "auth0_domain" {
   type        = string
   description = "Auth0 client domain, obtained from Auth0 dashboard"

--- a/terraform/modules/circleci/vars-audience.symlink.tf
+++ b/terraform/modules/circleci/vars-audience.symlink.tf
@@ -1,1 +1,0 @@
-../auth0-vars/vars-audience.tf

--- a/terraform/modules/digitalocean-codelab/platform-web.tf
+++ b/terraform/modules/digitalocean-codelab/platform-web.tf
@@ -41,6 +41,11 @@ resource "digitalocean_app" "platform-web" {
       }
 
       env {
+        key   = "AUTH0_AUDIENCE"
+        value = var.auth0_audience
+      }
+
+      env {
         key   = "NEXT_PUBLIC_PLATFORM_HOST"
         value = var.next_public_platform_host
       }

--- a/terraform/modules/digitalocean-codelab/vars.tf
+++ b/terraform/modules/digitalocean-codelab/vars.tf
@@ -11,6 +11,8 @@ variable "auth0_client_secret" {}
 
 variable "auth0_client_id" {}
 
+variable "auth0_audience" {}
+
 variable "next_public_platform_host" {}
 
 variable "next_public_platform_api_hostname" {}

--- a/terraform/modules/symlink.sh
+++ b/terraform/modules/symlink.sh
@@ -12,7 +12,6 @@ ln -s ../platform-api/vars.tf ./circleci/vars-platform-api.symlink.tf
 ln -s ../auth0-vars/vars-auth0-secret.tf ./circleci/vars-auth0-secret.symlink.tf
 ln -s ../auth0-vars/vars-web-client.tf ./circleci/vars-auth0-web-client.symlink.tf
 ln -s ../auth0-vars/vars-machine-client.tf ./circleci/vars-auth0-machine-client.symlink.tf
-ln -s ../auth0-vars/vars-audience.tf ./circleci/vars-audience.symlink.tf
 ln -s ../slack/vars.tf ./circleci/vars-slack.symlink.tf
 ln -s ../nx/vars.tf ./circleci/vars-nx.symlink.tf
 ln -s ../cypress/vars.tf ./circleci/vars-cypress.symlink.tf


### PR DESCRIPTION
<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(libs-ui-component): must begin with lowercase` -->

## Description

- After migration to DigitalOcean there is no need to have *vercel urls in Auth0 settings
- Remove not used uuid dependency
- Include AUTH0_AUDIENCE env variable to production
