### PR TITLE
3224 atom and types issues

### DIFF
--- a/libs/frontend/abstract/application/src/atom/atom.service.interface.ts
+++ b/libs/frontend/abstract/application/src/atom/atom.service.interface.ts
@@ -42,4 +42,5 @@ export interface IAtomService
     fieldProps: GuaranteedProps<string | undefined>,
     parent: IAtomModel | undefined,
   ): Promise<Array<DefaultOptionType>>
+  loadApi(atomId: string): Promise<void>
 }

--- a/libs/frontend/application/atom/src/services/atom.service.ts
+++ b/libs/frontend/application/atom/src/services/atom.service.ts
@@ -156,13 +156,6 @@ export class AtomService
     parent?: IAtomModel,
   ) {
     const atoms = yield* _await(this.atomRepository.getSelectAtomOptions())
-
-    this.typeService.typeDomainService.hydrateTypes({
-      interfaceTypes: atoms.flatMap((atom) => atom.api),
-    })
-
-    atoms.forEach((atom) => this.atomDomainService.hydrate(atom))
-
     const atomOptions = parent ? filterAtoms(atoms, parent) : atoms
 
     return atomOptions.map(mapAtomOptions)

--- a/libs/frontend/application/atom/src/services/atom.service.ts
+++ b/libs/frontend/application/atom/src/services/atom.service.ts
@@ -162,6 +162,15 @@ export class AtomService
   })
 
   @modelFlow
+  loadApi = _async(function* (this: AtomService, id: string) {
+    const atom = this.atomDomainService.atoms.get(id)
+
+    if (atom?.api) {
+      yield* _await(this.typeService.getInterface(atom.api.id))
+    }
+  })
+
+  @modelFlow
   @transaction
   update = _async(function* (
     this: AtomService,

--- a/libs/frontend/application/atom/src/use-cases/get-select-atom-options/get-select-atom-options.endpoints.graphql
+++ b/libs/frontend/application/atom/src/use-cases/get-select-atom-options/get-select-atom-options.endpoints.graphql
@@ -1,16 +1,11 @@
 query GetSelectAtomOptions {
   atoms {
-    # Need to load API as well
     __typename
-    api {
-      ...InterfaceType
-    }
     id
     name
     requiredParents {
       id
       type
     }
-    type
   }
 }

--- a/libs/frontend/application/atom/src/use-cases/get-select-atom-options/get-select-atom-options.endpoints.graphql
+++ b/libs/frontend/application/atom/src/use-cases/get-select-atom-options/get-select-atom-options.endpoints.graphql
@@ -7,5 +7,6 @@ query GetSelectAtomOptions {
       id
       type
     }
+    type
   }
 }

--- a/libs/frontend/application/atom/src/use-cases/get-select-atom-options/get-select-atom-options.endpoints.graphql.gen.ts
+++ b/libs/frontend/application/atom/src/use-cases/get-select-atom-options/get-select-atom-options.endpoints.graphql.gen.ts
@@ -12,7 +12,6 @@ export type GetSelectAtomOptionsQuery = {
     __typename: 'Atom'
     id: string
     name: string
-    type: Types.AtomType
     requiredParents: Array<{ id: string; type: Types.AtomType }>
   }>
 }
@@ -27,7 +26,6 @@ export const GetSelectAtomOptionsDocument = gql`
         id
         type
       }
-      type
     }
   }
 `

--- a/libs/frontend/application/atom/src/use-cases/get-select-atom-options/get-select-atom-options.endpoints.graphql.gen.ts
+++ b/libs/frontend/application/atom/src/use-cases/get-select-atom-options/get-select-atom-options.endpoints.graphql.gen.ts
@@ -12,6 +12,7 @@ export type GetSelectAtomOptionsQuery = {
     __typename: 'Atom'
     id: string
     name: string
+    type: Types.AtomType
     requiredParents: Array<{ id: string; type: Types.AtomType }>
   }>
 }
@@ -26,6 +27,7 @@ export const GetSelectAtomOptionsDocument = gql`
         id
         type
       }
+      type
     }
   }
 `

--- a/libs/frontend/application/atom/src/use-cases/get-select-atom-options/get-select-atom-options.endpoints.graphql.gen.ts
+++ b/libs/frontend/application/atom/src/use-cases/get-select-atom-options/get-select-atom-options.endpoints.graphql.gen.ts
@@ -1,10 +1,8 @@
 import * as Types from '@codelab/shared/abstract/codegen'
 
-import { InterfaceTypeFragment } from '../../../../../abstract/domain/src/type/fragments/interface.fragment.graphql.gen'
 import { GraphQLClient } from 'graphql-request'
 import { GraphQLClientRequestHeaders } from 'graphql-request/build/cjs/types'
 import { gql } from 'graphql-tag'
-import { InterfaceTypeFragmentDoc } from '../../../../../abstract/domain/src/type/fragments/interface.fragment.graphql.gen'
 export type GetSelectAtomOptionsQueryVariables = Types.Exact<{
   [key: string]: never
 }>
@@ -15,7 +13,6 @@ export type GetSelectAtomOptionsQuery = {
     id: string
     name: string
     type: Types.AtomType
-    api: InterfaceTypeFragment
     requiredParents: Array<{ id: string; type: Types.AtomType }>
   }>
 }
@@ -24,9 +21,6 @@ export const GetSelectAtomOptionsDocument = gql`
   query GetSelectAtomOptions {
     atoms {
       __typename
-      api {
-        ...InterfaceType
-      }
       id
       name
       requiredParents {
@@ -36,7 +30,6 @@ export const GetSelectAtomOptionsDocument = gql`
       type
     }
   }
-  ${InterfaceTypeFragmentDoc}
 `
 
 export type SdkFunctionWrapper = <T>(

--- a/libs/frontend/application/element/src/services/element.service.ts
+++ b/libs/frontend/application/element/src/services/element.service.ts
@@ -87,13 +87,7 @@ export class ElementService
      * Need to fetch the full api, since we don't during atom selection dropdown. The api will be used in subsequent steps such as the `ElementTreeItemElementTitle` for field validation
      */
     if (data.renderType.__typename === 'Atom') {
-      const atom = this.atomService.atomDomainService.atoms.get(
-        data.renderType.id,
-      )
-
-      if (atom) {
-        yield* _await(this.typeService.getInterface(atom.api.id))
-      }
+      yield* _await(this.atomService.loadApi(data.renderType.id))
     }
 
     const element = this.elementDomainService.addTreeNode(data)
@@ -227,6 +221,10 @@ export class ElementService
 
     if (newRenderTypeId !== oldRenderTypeId) {
       this.propService.reset(currentElement.props)
+
+      // Fetch full api for the new atom so that the types
+      // of the fields and sub types are available.
+      yield* _await(this.atomService.loadApi(newRenderTypeId))
     }
 
     currentElement.writeCache(newElement)

--- a/libs/frontend/domain/atom/src/store/atom.filter.ts
+++ b/libs/frontend/domain/atom/src/store/atom.filter.ts
@@ -8,7 +8,6 @@ export const filterAtoms = (
     | {
         id: string
         name: string
-        type: AtomType
         requiredParents: Array<{ id: string; type: AtomType }>
       }
   >,
@@ -54,7 +53,6 @@ export const mapAtomOptions = (
     | {
         id: string
         name: string
-        type: AtomType
         requiredParents: Array<{ id: string; type: AtomType }>
       },
 ) => ({ label: atom.name, value: atom.id })

--- a/libs/shared/abstract/codegen/src/types.api.graphql.gen.ts
+++ b/libs/shared/abstract/codegen/src/types.api.graphql.gen.ts
@@ -22419,7 +22419,6 @@ export type GetSelectAtomOptionsQuery = {
     id: string
     name: string
     type: AtomType
-    api: InterfaceTypeFragment
     requiredParents: Array<{ id: string; type: AtomType }>
   }>
 }

--- a/libs/shared/abstract/codegen/src/types.api.graphql.gen.ts
+++ b/libs/shared/abstract/codegen/src/types.api.graphql.gen.ts
@@ -22418,7 +22418,6 @@ export type GetSelectAtomOptionsQuery = {
     __typename: 'Atom'
     id: string
     name: string
-    type: AtomType
     requiredParents: Array<{ id: string; type: AtomType }>
   }>
 }

--- a/libs/shared/abstract/codegen/src/types.api.graphql.gen.ts
+++ b/libs/shared/abstract/codegen/src/types.api.graphql.gen.ts
@@ -22418,6 +22418,7 @@ export type GetSelectAtomOptionsQuery = {
     __typename: 'Atom'
     id: string
     name: string
+    type: AtomType
     requiredParents: Array<{ id: string; type: AtomType }>
   }>
 }


### PR DESCRIPTION
<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(libs-ui-component): must begin with lowercase` -->

## Description
Removed the unnecessary fields from `GetSelectAtomOptions` query. For example, loading the API is pointless since we need to load the full API (types for fields and sub-types) when creating element. 

So now we fetch the minimal data to just show options in the `SelectAtomField` and load the necessary API and types once the element is created or the `renderType` is changed.

<!-- This is a short description on the Pull Request -->

## Video or Image

<!-- Add video or image showing how the new feature works -->

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged -->

Fixes #3224
