### PR TITLE
chore: in-app routing specs

### DIFF
--- a/apps/platform-e2e/src/e2e/builder/in-app-routing.cy.ts
+++ b/apps/platform-e2e/src/e2e/builder/in-app-routing.cy.ts
@@ -1,292 +1,106 @@
-import { FIELD_TYPE } from '@codelab/frontend/test/cypress/antd'
-import type { IAppDto } from '@codelab/shared/abstract/core'
-import { IAtomType, IPageKindName } from '@codelab/shared/abstract/core'
-import { ROOT_ELEMENT_NAME } from '@codelab/shared/config'
-import { slugify } from '@codelab/shared/utils'
+import type { App } from '@codelab/shared/abstract/codegen'
+import type { IAppDto, IPage, IPageDto } from '@codelab/shared/abstract/core'
+import { IPageKind, IPageKindName } from '@codelab/shared/abstract/core'
+import { findOrFail, slugify } from '@codelab/shared/utils'
+import { buildTestData } from './in-app-routing.data'
 
 const TestPageText = 'this is the test page'
 const DynamicPageText = 'this is the dynamic page'
 const GoToTestPageText = 'go to test page'
 const GoToDynamicPageText = 'go to dynamic page'
-const dynamicUrlSegment1 = 'first-url-segment'
-const dynamicUrlSegment2 = 'second-url-segment'
+const dynamicUrlFirstSegmentKey = 'testId'
+const dynamicUrlFirstSegment = 'first-url-segment'
+const dynamicUrlSecondSegmentKey = 'subtestId'
+const dynamicUrlSecondSegment = 'second-url-segment'
+
+const setupTest = () => {
+  let app: IAppDto
+  let providerPage: IPageDto
+
+  cy.postApiRequest<App>('/app/seed-cypress-app')
+    .then(({ body }) => {
+      app = body
+
+      providerPage = findOrFail(
+        app.pages,
+        (_page) => _page.kind === IPageKind.Provider,
+      )
+    })
+    .as('appCreated')
+
+  cy.get('@appCreated').then(() => {
+    const {
+      dynamicPageCreateData,
+      dynamicPageTextElementCreateData,
+      providerPageLinkElementCreateData,
+      staticPageCreateData,
+      staticPageLinkElementCreateData,
+      staticPageTextElementCreateData,
+    } = buildTestData(app)
+
+    cy.postApiRequest(`/element/${providerPage.id}/create-element`, {
+      ...providerPageLinkElementCreateData,
+      parentElement: { id: providerPage.rootElement.id },
+    }).as('providerPageLinkElementCreated')
+
+    cy.postApiRequest('/page/create-page', staticPageCreateData).as(
+      'staticPageCreated',
+    )
+
+    cy.get<Cypress.Response<IPage>>('@staticPageCreated').then(
+      ({ body: staticPage }) => {
+        cy.postApiRequest(`/element/${staticPage.id}/create-elements`, [
+          {
+            ...staticPageTextElementCreateData,
+            parentElement: { id: staticPage.rootElement.id },
+          },
+          staticPageLinkElementCreateData,
+        ]).as('staticPageElementsCreated')
+      },
+    )
+
+    cy.postApiRequest('/page/create-page', dynamicPageCreateData).as(
+      'dynamicPageCreated',
+    )
+
+    cy.get<Cypress.Response<IPage>>('@dynamicPageCreated').then(
+      ({ body: dynamicPage }) => {
+        cy.postApiRequest(`/element/${dynamicPage.id}/create-element`, {
+          ...dynamicPageTextElementCreateData,
+          parentElement: { id: dynamicPage.rootElement.id },
+        }).as('dynamicPageContentElementCreated')
+      },
+    )
+  })
+
+  cy.get('@providerPageLinkElementCreated')
+    .get('@staticPageElementsCreated')
+    .get('@dynamicPageContentElementCreated')
+    .then(() => {
+      cy.visit(
+        `/apps/cypress/${slugify(app.name)}/pages/${slugify(
+          IPageKindName.Provider,
+        )}`,
+      )
+    })
+}
 
 describe('Routing between app pages within the builder', () => {
-  let app: IAppDto
-
   before(() => {
-    cy.postApiRequest<IAppDto>('/app/seed-cypress-app').then((apps) => {
-      app = apps.body
-    })
-  })
-
-  it('should create a page with a static url - /test-page', () => {
-    // create the page to route to
-    cy.visit(
-      `/apps/cypress/${slugify(app.name)}/pages/${slugify(
-        IPageKindName.Provider,
-      )}/builder?primarySidebarKey=pageList`,
-    )
-    // GetRenderedPageAndCommonAppData
-    cy.waitForApiCalls()
-    cy.waitForSpinners()
-
-    cy.getCuiSidebar('Pages').getCuiToolbarItem('Create Page').first().click()
-
-    cy.findByTestId('create-page-form')
-      .findByLabelText('Name')
-      .type('Test Page')
-    cy.findByTestId('create-page-form')
-      .findByLabelText('Deployed Page URL')
-      .type('/test-page')
-
-    cy.getCuiPopover('Create Page').getCuiToolbarItem('Create').click()
-
-    cy.findByTestId('create-page-form').should('not.exist')
-  })
-
-  it('should create a page with a dynamic url - /tests/:testId/subtests/:subtestId', () => {
-    cy.getCuiSidebar('Pages').getCuiToolbarItem('Create Page').first().click()
-
-    cy.findByTestId('create-page-form')
-      .findByLabelText('Name')
-      .type('Test Dynamic Page')
-    cy.findByTestId('create-page-form')
-      .findByLabelText('Deployed Page URL')
-      .type('/tests/:testId/subtests/:subtestId')
-
-    cy.getCuiPopover('Create Page').getCuiToolbarItem('Create').click()
-
-    cy.findByTestId('create-page-form').should('not.exist')
-  })
-
-  it('should create a text element in the test-dynamic-page', () => {
-    // go to the regular page
-    cy.visit(
-      `/apps/cypress/codelab-app/pages/test-dynamic-page/builder?primarySidebarKey=explorer`,
-    )
-    // GetRenderedPageAndCommonAppData
-    cy.waitForApiCalls()
-    cy.waitForSpinners()
-
-    cy.getCuiTreeItemByPrimaryTitle('Body').click({ force: true })
-
-    cy.getCuiSidebar('Explorer')
-      .getCuiToolbarItem('Add Element')
-      .first()
-      .click()
-
-    cy.findByTestId('create-element-form').setFormFieldValue({
-      label: 'Atom',
-      type: FIELD_TYPE.SELECT,
-      value: IAtomType.AntDesignTypographyText,
-    })
-
-    // need to wait for the code to put the autocomputed name before typing
-    // eslint-disable-next-line cypress/no-unnecessary-waiting
-    cy.wait(1000)
-
-    cy.findByTestId('create-element-form').setFormFieldValue({
-      label: 'Name',
-      type: FIELD_TYPE.INPUT,
-      value: 'Typography Element',
-    })
-
-    cy.getCuiPopover('Create Element').getCuiToolbarItem('Create').click()
-
-    cy.findByTestId('create-element-form').should('not.exist', {
-      timeout: 10000,
-    })
-
-    // editorjs fails internally without this, maybe some kind of initialization - Cannot read properties of undefined (reading 'contains')
-    // eslint-disable-next-line cypress/no-unnecessary-waiting
-    cy.wait(2000)
-
-    cy.getCuiTreeItemByPrimaryTitle('Typography Element').click({
-      force: true,
-    })
-
-    cy.typeIntoTextEditor(
-      `${DynamicPageText} - {{url.testId}} - {{url.subtestId}}`,
-    )
-
-    cy.waitForApiCalls()
-
-    cy.openPreview()
-    cy.get('#render-root')
-      .contains(`${DynamicPageText} - undefined - undefined`)
-      .should('exist')
-  })
-
-  it('should create a text element in the test-page', () => {
-    // go to the regular page
-    cy.visit(
-      `/apps/cypress/codelab-app/pages/test-page/builder?primarySidebarKey=explorer`,
-    )
-    // GetRenderedPageAndCommonAppData
-    cy.waitForApiCalls()
-    cy.waitForSpinners()
-
-    cy.getCuiTreeItemByPrimaryTitle('Body').click({ force: true })
-
-    cy.getCuiSidebar('Explorer')
-      .getCuiToolbarItem('Add Element')
-      .first()
-      .click()
-
-    cy.findByTestId('create-element-form').setFormFieldValue({
-      label: 'Atom',
-      type: FIELD_TYPE.SELECT,
-      value: IAtomType.AntDesignTypographyText,
-    })
-    // need to wait for the code to put the autocomputed name before typing
-    // eslint-disable-next-line cypress/no-unnecessary-waiting
-    cy.wait(1000)
-
-    cy.findByTestId('create-element-form').setFormFieldValue({
-      label: 'Name',
-      type: FIELD_TYPE.INPUT,
-      value: 'Typography Element',
-    })
-
-    cy.getCuiPopover('Create Element').getCuiToolbarItem('Create').click()
-
-    cy.findByTestId('create-element-form').should('not.exist', {
-      timeout: 10000,
-    })
-
-    // editorjs fails internally without this, maybe some kind of initialization - Cannot read properties of undefined (reading 'contains')
-    // eslint-disable-next-line cypress/no-unnecessary-waiting
-    cy.wait(2000)
-
-    cy.getCuiTreeItemByPrimaryTitle('Typography Element').click({
-      force: true,
-    })
-
-    cy.typeIntoTextEditor(TestPageText)
-
-    cy.get('#render-root').contains(TestPageText).should('exist')
-  })
-
-  it('should create a NextLink in the test-page to go to the dynamic page', () => {
-    cy.getCuiTreeItemByPrimaryTitle('Body').click({ force: true })
-
-    cy.getCuiSidebar('Explorer')
-      .getCuiToolbarItem('Add Element')
-      .first()
-      .click()
-
-    cy.findByTestId('create-element-form').setFormFieldValue({
-      label: 'Atom',
-      type: FIELD_TYPE.SELECT,
-      value: IAtomType.NextLink,
-    })
-    // need to wait for the code to put the autocomputed name before typing
-    // eslint-disable-next-line cypress/no-unnecessary-waiting
-    cy.wait(1000)
-
-    cy.findByTestId('create-element-form').setFormFieldValue({
-      label: 'Name',
-      type: FIELD_TYPE.INPUT,
-      value: 'Next Link Element',
-    })
-
-    cy.findByTestId('create-element-form').setFormFieldValue({
-      label: 'Props Data',
-      type: FIELD_TYPE.INPUT,
-      value: `{ "href": "/tests/${dynamicUrlSegment1}/subtests/${dynamicUrlSegment2}", "customText": "${GoToDynamicPageText}" }`,
-    })
-
-    // Create an alias of the new element id to later be used for
-    // getting its corresponding text editor
-    cy.createElementAndStoreId()
-
-    cy.findByTestId('create-element-form').should('not.exist', {
-      timeout: 10000,
-    })
-
-    cy.get('#render-root').contains(GoToDynamicPageText).should('exist')
-  })
-
-  it('should create a NextLink in the provider with link to the test-page', () => {
-    // go to the provider page
-    cy.visit(
-      `/apps/cypress/${slugify(app.name)}/pages/${slugify(
-        IPageKindName.Provider,
-      )}/builder?primarySidebarKey=explorer`,
-    )
-
-    // select root now so we can update its child later
-    // there is an issue with tree interaction
-    // Increased timeout since builder may take longer to load
-    cy.findByText(ROOT_ELEMENT_NAME, { timeout: 30000 })
-      .should('be.visible')
-      .click({ force: true })
-
-    cy.getCuiSidebar('Explorer')
-      .getCuiToolbarItem('Add Element')
-      .first()
-      .click()
-
-    cy.findByTestId('create-element-form').setFormFieldValue({
-      label: 'Atom',
-      type: FIELD_TYPE.SELECT,
-      value: IAtomType.NextLink,
-    })
-    // need to wait for the code to put the autocomputed name before typing
-    // eslint-disable-next-line cypress/no-unnecessary-waiting
-    cy.wait(1000)
-
-    cy.findByTestId('create-element-form').setFormFieldValue({
-      label: 'Name',
-      type: FIELD_TYPE.INPUT,
-      value: 'Next Link Element',
-    })
-
-    cy.findByTestId('create-element-form').setFormFieldValue({
-      label: 'Props Data',
-      type: FIELD_TYPE.INPUT,
-      value: '{ "href": "/test-page" }',
-    })
-
-    cy.createElementAndStoreId()
-
-    cy.findByTestId('create-element-form').should('not.exist', {
-      timeout: 10000,
-    })
-
-    // editorjs fails internally without this, maybe some kind of initialization - Cannot read properties of undefined (reading 'contains')
-    // eslint-disable-next-line cypress/no-unnecessary-waiting
-    cy.wait(2000)
-
-    cy.getCuiTreeItemByPrimaryTitle('Next Link Element').click({ force: true })
-
-    cy.getNewElementId().then((nextLinkId) => {
-      // Prevent default to be able to type into the text editor
-      cy.preventDefaultOnClick(`[data-element-id="${nextLinkId}"]`)
-      cy.typeIntoTextEditor(GoToTestPageText, nextLinkId)
-      // Remove the prevent default so the link works for the next tests
-      cy.removePreventDefaultOnClick(`[data-element-id="${nextLinkId}"]`)
-    })
-
-    cy.waitForApiCalls()
-
-    cy.openPreview()
-
-    cy.get('#render-root').contains(GoToTestPageText).should('exist')
+    setupTest()
   })
 
   // Skip this for now until we re-worked the routing within the builder preview
-  it.skip('should navigate to /test-page of the app within the builder when NextLink in the provider is clicked', () => {
+  it('should navigate to /test-page of the app within the builder when NextLink in the provider is clicked', () => {
     cy.get('#render-root').contains(GoToTestPageText).click()
     cy.contains(TestPageText).should('exist')
   })
 
   // Skip this for now until we re-worked the routing within the builder preview
-  it.skip('should navigate to the dynamic page within the builder when NextLink in the /test-page is clicked', () => {
+  it('should navigate to the dynamic page within the builder when NextLink in the /test-page is clicked', () => {
     cy.get('#render-root').contains(GoToDynamicPageText).click()
     cy.findByText(
-      `${DynamicPageText} - ${dynamicUrlSegment1} - ${dynamicUrlSegment2}`,
+      `${DynamicPageText} - ${dynamicUrlFirstSegmentKey}: "${dynamicUrlFirstSegment}", ${dynamicUrlSecondSegmentKey}: "${dynamicUrlSecondSegment}"`,
     ).should('exist')
   })
 })

--- a/apps/platform-e2e/src/e2e/builder/in-app-routing.data.ts
+++ b/apps/platform-e2e/src/e2e/builder/in-app-routing.data.ts
@@ -2,27 +2,49 @@ import type { IAppDto, ICreateElementData } from '@codelab/shared/abstract/core'
 import { IAtomType, IPageKind } from '@codelab/shared/abstract/core'
 import { v4 } from 'uuid'
 
-const TestPageText = 'this is the test page'
-const DynamicPageText = 'this is the dynamic page'
-const GoToTestPageText = 'go to test page'
-const GoToDynamicPageText = 'go to dynamic page'
-const dynamicUrlFirstSegmentKey = 'testId'
-const dynamicUrlFirstSegment = 'first-url-segment'
-const dynamicUrlSecondSegmentKey = 'subtestId'
-const dynamicUrlSecondSegment = 'second-url-segment'
+export const testUrlProps = {
+  subtestId: 'second-url-segment',
+  testId: 'first-url-segment',
+}
 
-export const buildTestData = (app: IAppDto) => {
-  const providerPageLinkElementCreateData: ICreateElementData = {
-    atom: IAtomType.NextLink,
-    id: v4(),
-    name: 'Test Page Link',
-    // parentElement: { id: providerPage.rootElement.id },
-    propsData: {
-      customText: GoToTestPageText,
-      href: '/test-page',
-    },
-  }
+export const providerPageLinkElementCreateData: ICreateElementData = {
+  atom: IAtomType.NextLink,
+  id: v4(),
+  name: 'Test Page Link',
+  propsData: {
+    customText: 'go to test page',
+    href: '/test-page',
+  },
+}
+export const staticPageTextElementCreateData: ICreateElementData = {
+  atom: IAtomType.AntDesignTypographyText,
+  id: v4(),
+  name: 'Test Page Content',
+  propsData: {
+    customText: 'this is the test page',
+  },
+}
+export const staticPageLinkElementCreateData: ICreateElementData = {
+  atom: IAtomType.NextLink,
+  id: v4(),
+  name: 'Dynamic Page Link',
+  prevSibling: { id: staticPageTextElementCreateData.id },
+  propsData: {
+    customText: 'go to dynamic page',
+    href: `/tests/${testUrlProps.testId}/subtests/${testUrlProps.subtestId}`,
+  },
+}
+export const dynamicPageTextElementCreateData: ICreateElementData = {
+  atom: IAtomType.AntDesignTypographyText,
+  id: v4(),
+  name: 'Dynamic Page Content',
+  propsData: {
+    customText:
+      'testId: "{{urlProps.testId}}", subtestId: "{{urlProps.subtestId}}"',
+  },
+}
 
+export const buildTestPages = (app: IAppDto) => {
   const staticPageCreateData = {
     app,
     id: v4(),
@@ -31,51 +53,16 @@ export const buildTestData = (app: IAppDto) => {
     url: '/test-page',
   }
 
-  const staticPageTextElementCreateData: ICreateElementData = {
-    atom: IAtomType.AntDesignTypographyText,
-    id: v4(),
-    name: 'Test Page Content',
-    // parentElement: { id: staticPage.rootElement.id },
-    propsData: {
-      customText: TestPageText,
-    },
-  }
-
-  const staticPageLinkElementCreateData: ICreateElementData = {
-    atom: IAtomType.NextLink,
-    id: v4(),
-    name: 'Dynamic Page Link',
-    prevSibling: { id: staticPageTextElementCreateData.id },
-    propsData: {
-      customText: GoToDynamicPageText,
-      href: `/tests/${dynamicUrlFirstSegment}/subtests/${dynamicUrlSecondSegment}`,
-    },
-  }
-
   const dynamicPageCreateData = {
     app,
     id: v4(),
     kind: IPageKind.Regular,
     name: 'Dynamic Page',
-    url: `/tests/:${dynamicUrlFirstSegmentKey}/subtests/:${dynamicUrlSecondSegmentKey}`,
-  }
-
-  const dynamicPageTextElementCreateData: ICreateElementData = {
-    atom: IAtomType.AntDesignTypographyText,
-    id: v4(),
-    name: 'Dynamic Page Content',
-    // parentElement: { id: dynamicPage.rootElement.id },
-    propsData: {
-      customText: `${DynamicPageText} - ${dynamicUrlFirstSegmentKey}: "{{urlProps.${dynamicUrlFirstSegmentKey}}}", ${dynamicUrlSecondSegmentKey}: "{{urlProps.${dynamicUrlSecondSegmentKey}}}"`,
-    },
+    url: `/tests/:testId/subtests/:subtestId`,
   }
 
   return {
     dynamicPageCreateData,
-    dynamicPageTextElementCreateData,
-    providerPageLinkElementCreateData,
     staticPageCreateData,
-    staticPageLinkElementCreateData,
-    staticPageTextElementCreateData,
   }
 }

--- a/apps/platform-e2e/src/e2e/builder/in-app-routing.data.ts
+++ b/apps/platform-e2e/src/e2e/builder/in-app-routing.data.ts
@@ -1,0 +1,81 @@
+import type { IAppDto, ICreateElementData } from '@codelab/shared/abstract/core'
+import { IAtomType, IPageKind } from '@codelab/shared/abstract/core'
+import { v4 } from 'uuid'
+
+const TestPageText = 'this is the test page'
+const DynamicPageText = 'this is the dynamic page'
+const GoToTestPageText = 'go to test page'
+const GoToDynamicPageText = 'go to dynamic page'
+const dynamicUrlFirstSegmentKey = 'testId'
+const dynamicUrlFirstSegment = 'first-url-segment'
+const dynamicUrlSecondSegmentKey = 'subtestId'
+const dynamicUrlSecondSegment = 'second-url-segment'
+
+export const buildTestData = (app: IAppDto) => {
+  const providerPageLinkElementCreateData: ICreateElementData = {
+    atom: IAtomType.NextLink,
+    id: v4(),
+    name: 'Test Page Link',
+    // parentElement: { id: providerPage.rootElement.id },
+    propsData: {
+      customText: GoToTestPageText,
+      href: '/test-page',
+    },
+  }
+
+  const staticPageCreateData = {
+    app,
+    id: v4(),
+    kind: IPageKind.Regular,
+    name: 'Test Page',
+    url: '/test-page',
+  }
+
+  const staticPageTextElementCreateData: ICreateElementData = {
+    atom: IAtomType.AntDesignTypographyText,
+    id: v4(),
+    name: 'Test Page Content',
+    // parentElement: { id: staticPage.rootElement.id },
+    propsData: {
+      customText: TestPageText,
+    },
+  }
+
+  const staticPageLinkElementCreateData: ICreateElementData = {
+    atom: IAtomType.NextLink,
+    id: v4(),
+    name: 'Dynamic Page Link',
+    prevSibling: { id: staticPageTextElementCreateData.id },
+    propsData: {
+      customText: GoToDynamicPageText,
+      href: `/tests/${dynamicUrlFirstSegment}/subtests/${dynamicUrlSecondSegment}`,
+    },
+  }
+
+  const dynamicPageCreateData = {
+    app,
+    id: v4(),
+    kind: IPageKind.Regular,
+    name: 'Dynamic Page',
+    url: `/tests/:${dynamicUrlFirstSegmentKey}/subtests/:${dynamicUrlSecondSegmentKey}`,
+  }
+
+  const dynamicPageTextElementCreateData: ICreateElementData = {
+    atom: IAtomType.AntDesignTypographyText,
+    id: v4(),
+    name: 'Dynamic Page Content',
+    // parentElement: { id: dynamicPage.rootElement.id },
+    propsData: {
+      customText: `${DynamicPageText} - ${dynamicUrlFirstSegmentKey}: "{{urlProps.${dynamicUrlFirstSegmentKey}}}", ${dynamicUrlSecondSegmentKey}: "{{urlProps.${dynamicUrlSecondSegmentKey}}}"`,
+    },
+  }
+
+  return {
+    dynamicPageCreateData,
+    dynamicPageTextElementCreateData,
+    providerPageLinkElementCreateData,
+    staticPageCreateData,
+    staticPageLinkElementCreateData,
+    staticPageTextElementCreateData,
+  }
+}

--- a/libs/frontend/abstract/application/src/renderer/render.interface.ts
+++ b/libs/frontend/abstract/application/src/renderer/render.interface.ts
@@ -10,7 +10,7 @@ export interface IRenderOutput {
   atomType?: IAtomType
   /** Any props that should get passed to descendants of this element, mapped by id */
   globalProps?: IPropDataByElementId
-  props?: IPropData
+  props: IPropData
   /** This is the element which this RenderOutput was rendered from */
   runtimeElement: IRuntimeElementModel
 }

--- a/libs/frontend/application/renderer/src/element/ElementWrapper.tsx
+++ b/libs/frontend/application/renderer/src/element/ElementWrapper.tsx
@@ -3,7 +3,6 @@ import { RendererType } from '@codelab/frontend/abstract/application'
 import { type IComponentType } from '@codelab/frontend/abstract/domain'
 import { useStore } from '@codelab/frontend/application/shared/store'
 import { mergeProps } from '@codelab/frontend/domain/prop'
-import { IAtomType } from '@codelab/shared/abstract/core'
 import { observer } from 'mobx-react-lite'
 import React, { useEffect } from 'react'
 import { ErrorBoundary } from 'react-error-boundary'
@@ -13,6 +12,7 @@ import {
   extractValidProps,
   generateTailwindClasses,
   getReactComponent,
+  makeOverrideAtomProps,
 } from './wrapper.utils'
 
 /**
@@ -36,12 +36,6 @@ export const ElementWrapper = observer<ElementWrapperProps>(
 
     const { atomService } = useStore()
 
-    if (renderOutput.props && renderOutput.atomType === IAtomType.GridLayout) {
-      renderOutput.props['static'] =
-        renderer.rendererType === RendererType.Preview ||
-        renderer.rendererType === RendererType.Production
-    }
-
     const ReactComponent: IComponentType =
       renderOutput.atomType &&
       atomService.atomDomainService.dynamicComponents[renderOutput.atomType]
@@ -64,6 +58,12 @@ export const ElementWrapper = observer<ElementWrapperProps>(
       renderer.rendererType,
     )
 
+    const propsOverrides = makeOverrideAtomProps(
+      renderer.rendererType,
+      extractedProps,
+      renderOutput.atomType,
+    )
+
     // leave ElementWrapper pass-through so refs are attached to correct element
     // selectionHandlers should be first so they will be overridden if
     // a prop contains an action such as `onClick`, `onSelect`, etc.
@@ -72,6 +72,7 @@ export const ElementWrapper = observer<ElementWrapperProps>(
       extractedProps,
       rest,
       tailwindClassNames,
+      propsOverrides,
     )
 
     const isDroppable =

--- a/libs/shared/abstract/core/src/element/element.data.interface.ts
+++ b/libs/shared/abstract/core/src/element/element.data.interface.ts
@@ -2,6 +2,7 @@ import { AtomType } from '@codelab/shared/abstract/codegen'
 import { Typebox } from '@codelab/shared/abstract/typebox'
 import type { Static } from '@sinclair/typebox'
 import { Type } from '@sinclair/typebox'
+import type { IPropData } from '../prop/prop.dto.interface'
 
 /**
  * This allows for a shortened object to be specified as input. Good for seeding data in cases where the input is manually specified (such as Cypress)
@@ -18,7 +19,7 @@ export const ICreateElementData = Type.Object({
   name: Type.String(),
   parentElement: Type.Optional(Typebox.Ref()),
   prevSibling: Type.Optional(Typebox.Ref()),
-  propsData: Type.Optional(Type.Object({})),
+  propsData: Type.Optional(Type.Object<IPropData>({})),
   // atom?: IAtomType
   // id: string
   // name: string


### PR DESCRIPTION
<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(libs-ui-component): must begin with lowercase` -->

## Description

<!-- This is a short description on the Pull Request -->
This is for improving the in-app routing specs
- when in preview mode, should be able to navigate to static and dynamic page
- when in builder mode, navigation is prevented in the app
- refactored spec to seed setup data via api

Also implemented an override props for props like `href` so it is changed to `#` when in builder mode so it doesn't navigate when clicked.

## Video or Image

<!-- Add video or image showing how the new feature works -->

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged -->

Fixes #3011 
