### PR TITLE
fix: convert element to component spec

### DIFF
--- a/apps/platform-e2e/src/e2e/component/convert-element-to-component.cy.ts
+++ b/apps/platform-e2e/src/e2e/component/convert-element-to-component.cy.ts
@@ -1,73 +1,73 @@
 import type { App } from '@codelab/shared/abstract/codegen'
-import type { IAppDto } from '@codelab/shared/abstract/core'
-import { IAtomType, IPageKindName } from '@codelab/shared/abstract/core'
-import { ROOT_ELEMENT_NAME } from '@codelab/shared/config'
-import { slugify } from '@codelab/shared/utils'
+import type { IAppDto, IPageDto } from '@codelab/shared/abstract/core'
+import { IPageKind, IPageKindName } from '@codelab/shared/abstract/core'
+import { findOrFail, slugify } from '@codelab/shared/utils'
+import {
+  elementColCreateData,
+  elementContainerCreateData,
+  elementRowCreateData,
+  elementTextCreateData,
+  providerPageElements,
+} from './convert-element-to-component.data'
 
-const CONVERT_TO_COMPONENT_TEXT = 'Convert To Component'
-const ELEMENT_CONTAINER = 'Element Abc'
-const ELEMENT_ROW = 'Row'
-const ELEMENT_COL_A = 'Col A'
-const ELEMENT_TEXT_1 = 'Text 1'
+let app: IAppDto
+let page: IPageDto
 
-const elements = [
-  {
-    atom: IAtomType.ReactFragment,
-    name: ELEMENT_CONTAINER,
-    parentElement: ROOT_ELEMENT_NAME,
-  },
-  {
-    atom: IAtomType.ReactFragment,
-    name: ELEMENT_ROW,
-    parentElement: ELEMENT_CONTAINER,
-  },
-  {
-    atom: IAtomType.AntDesignGridCol,
-    name: ELEMENT_COL_A,
-    parentElement: ELEMENT_ROW,
-  },
-  {
-    atom: IAtomType.AntDesignTypographyText,
-    name: ELEMENT_TEXT_1,
-    parentElement: ELEMENT_COL_A,
-  },
-]
+const setupTest = () => {
+  cy.postApiRequest<App>('/app/seed-cypress-app')
+    .then(({ body }) => {
+      app = body
+      page = findOrFail(app.pages, (_page) => _page.kind === IPageKind.Provider)
 
-describe('Converting an element to a component', () => {
-  let app: IAppDto
+      cy.wrap(page).should('have.property', 'store')
 
-  before(() => {
-    cy.postApiRequest<App>('/app/seed-cypress-app').then(
-      ({ body }) => (app = body),
-    )
+      return cy.wrap(app)
+    })
+    .as('createdApp')
+
+  cy.get('@createdApp').then(() => {
+    return cy
+      .postApiRequest(
+        `element/${page.rootElement.id}/create-elements`,
+        providerPageElements(page),
+      )
+      .as('cypressProviderElements')
   })
-  it('should convert the element into a component and create an instance of it', () => {
+
+  cy.get('@cypressProviderElements').then(() =>
     cy.visit(
       `/apps/cypress/${slugify(app.name)}/pages/${slugify(
         IPageKindName.Provider,
       )}/builder`,
+    ),
+  )
+}
+
+describe('Converting an element to a component', () => {
+  before(() => {
+    setupTest()
+  })
+  it('should convert the element into a component and create an instance of it', () => {
+    cy.getCuiTreeItemByPrimaryTitle(
+      elementContainerCreateData.name,
+    ).rightclick()
+
+    cy.findByText('Convert To Component').click()
+
+    cy.findByText(`instance of ${elementContainerCreateData.name}`).should(
+      'be.visible',
     )
-    cy.waitForSpinners()
-
-    // select root now so we can update its child later
-    // there is an issue with tree interaction
-    // Increased timeout since builder may take longer to load
-    cy.findByText(ROOT_ELEMENT_NAME, { timeout: 30000 })
-      .should('be.visible')
-      .click({ force: true })
-
-    // cy.createElementTree(elements)
-
-    cy.getCuiTreeItemByPrimaryTitle(ELEMENT_CONTAINER).rightclick()
-
-    cy.findByText(CONVERT_TO_COMPONENT_TEXT).click()
-
-    cy.findByText(`instance of ${ELEMENT_CONTAINER}`).should('be.visible')
 
     // the element descendants of a component instance is not shown
-    cy.getCuiTreeItemByPrimaryTitle(ELEMENT_ROW).should('not.exist')
-    cy.getCuiTreeItemByPrimaryTitle(ELEMENT_COL_A).should('not.exist')
-    cy.getCuiTreeItemByPrimaryTitle(ELEMENT_TEXT_1).should('not.exist')
+    cy.getCuiTreeItemByPrimaryTitle(elementRowCreateData.name).should(
+      'not.exist',
+    )
+    cy.getCuiTreeItemByPrimaryTitle(elementColCreateData.name).should(
+      'not.exist',
+    )
+    cy.getCuiTreeItemByPrimaryTitle(elementTextCreateData.name).should(
+      'not.exist',
+    )
   })
 
   it('should still have the descendant elements of the component', () => {
@@ -87,14 +87,14 @@ describe('Converting an element to a component', () => {
 
     cy.getCuiSidebar('Components')
       .getCuiSidebarViewContent('Custom')
-      .contains('.ant-card-head-title', ELEMENT_CONTAINER)
+      .contains('.ant-card-head-title', elementContainerCreateData.name)
       .next()
       .getButton({ icon: 'edit' })
       .click()
 
     // the element descendants of a component should show on the custom component builder
-    cy.getCuiTreeItemByPrimaryTitle(ELEMENT_ROW).should('exist')
-    cy.getCuiTreeItemByPrimaryTitle(ELEMENT_COL_A).should('exist')
-    cy.getCuiTreeItemByPrimaryTitle(ELEMENT_TEXT_1).should('exist')
+    cy.getCuiTreeItemByPrimaryTitle(elementRowCreateData.name).should('exist')
+    cy.getCuiTreeItemByPrimaryTitle(elementColCreateData.name).should('exist')
+    cy.getCuiTreeItemByPrimaryTitle(elementTextCreateData.name).should('exist')
   })
 })

--- a/apps/platform-e2e/src/e2e/component/convert-element-to-component.cy.ts
+++ b/apps/platform-e2e/src/e2e/component/convert-element-to-component.cy.ts
@@ -57,44 +57,37 @@ describe('Converting an element to a component', () => {
     cy.findByText(`instance of ${elementContainerCreateData.name}`).should(
       'be.visible',
     )
-
-    // the element descendants of a component instance is not shown
-    cy.getCuiTreeItemByPrimaryTitle(elementRowCreateData.name).should(
-      'not.exist',
-    )
-    cy.getCuiTreeItemByPrimaryTitle(elementColCreateData.name).should(
-      'not.exist',
-    )
-    cy.getCuiTreeItemByPrimaryTitle(elementTextCreateData.name).should(
-      'not.exist',
-    )
   })
 
   it('should still have the descendant elements of the component', () => {
     cy.visit(
-      `/apps/cypress/${slugify(app.name)}/pages/${slugify(
-        IPageKindName.Provider,
-      )}/builder?primarySidebarKey=components`,
+      `/apps/cypress/${slugify(app.name)}/components/${slugify(
+        elementContainerCreateData.name,
+      )}/builder?primarySidebarKey=explorer`,
     )
-    // GetRenderedPageAndCommonAppData
-    cy.waitForApiCalls()
-    cy.waitForSpinners()
 
-    // GetAtoms
-    // GetComponents
-    cy.waitForApiCalls()
-    cy.waitForSpinners()
+    // the element descendants should still be in correct order
+    // Container -> Row -> Col -> Text
+    // root element which is the Container
+    cy.getCuiTreeItemByPrimaryTitle(elementContainerCreateData.name).should(
+      'be.visible',
+    )
 
-    cy.getCuiSidebar('Components')
-      .getCuiSidebarViewContent('Custom')
-      .contains('.ant-card-head-title', elementContainerCreateData.name)
-      .next()
-      .getButton({ icon: 'edit' })
-      .click()
-
-    // the element descendants of a component should show on the custom component builder
+    // Row element which is the first child and is already shown initially
     cy.getCuiTreeItemByPrimaryTitle(elementRowCreateData.name).should('exist')
+
+    // this is the child of the Row element and has to expand before it can be seen
+    cy.getCuiTreeItemByPrimaryTitle(elementColCreateData.name).should(
+      'not.exist',
+    )
+    cy.getCuiTreeItemByPrimaryTitle(elementRowCreateData.name).click()
     cy.getCuiTreeItemByPrimaryTitle(elementColCreateData.name).should('exist')
+
+    // this is the child of the Col element and has to expand before it can be seen
+    cy.getCuiTreeItemByPrimaryTitle(elementTextCreateData.name).should(
+      'not.exist',
+    )
+    cy.getCuiTreeItemByPrimaryTitle(elementColCreateData.name).click()
     cy.getCuiTreeItemByPrimaryTitle(elementTextCreateData.name).should('exist')
   })
 })

--- a/apps/platform-e2e/src/e2e/component/convert-element-to-component.data.ts
+++ b/apps/platform-e2e/src/e2e/component/convert-element-to-component.data.ts
@@ -1,0 +1,45 @@
+import type {
+  ICreateElementData,
+  IPageDto,
+} from '@codelab/shared/abstract/core'
+import { IAtomType } from '@codelab/shared/abstract/core'
+import { v4 } from 'uuid'
+
+export const elementContainerCreateData: ICreateElementData = {
+  atom: IAtomType.ReactFragment,
+  id: v4(),
+  name: 'Container',
+}
+
+export const elementRowCreateData: ICreateElementData = {
+  atom: IAtomType.AntDesignGridRow,
+  id: v4(),
+  name: 'Row',
+  parentElement: elementContainerCreateData,
+}
+
+export const elementColCreateData: ICreateElementData = {
+  atom: IAtomType.AntDesignGridCol,
+  id: v4(),
+  name: 'Column',
+  parentElement: elementRowCreateData,
+}
+
+export const elementTextCreateData: ICreateElementData = {
+  atom: IAtomType.AntDesignTypographyText,
+  id: v4(),
+  name: 'Text',
+  parentElement: elementColCreateData,
+}
+
+export const providerPageElements = (
+  page: IPageDto,
+): Array<ICreateElementData> => [
+  {
+    ...elementContainerCreateData,
+    parentElement: page.rootElement,
+  },
+  elementRowCreateData,
+  elementColCreateData,
+  elementTextCreateData,
+]

--- a/libs/frontend/application/renderer/src/runtime-element.model.ts
+++ b/libs/frontend/application/renderer/src/runtime-element.model.ts
@@ -292,9 +292,9 @@ export class RuntimeElementModel
           ? {
               ...child.runtimeRootElement.treeViewNode,
               ...(!isNil(child.childMapperIndex) ? { children: [] } : {}),
-              isChildMapperComponentInstance: isComponent(
-                child.containerNode.current,
-              ),
+              isChildMapperComponentInstance:
+                !isNil(child.childMapperIndex) &&
+                isComponent(child.containerNode.current),
               key: `${child.runtimeRootElement.element.current.id}${
                 !isNil(child.childMapperIndex)
                   ? `-${child.childMapperIndex}`


### PR DESCRIPTION
<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(libs-ui-component): must begin with lowercase` -->

## Description

<!-- This is a short description on the Pull Request -->
This PR fixes the spec `convert-element-to-component.cy` and convert the seeding logic to use the APIs

## Video or Image

<!-- Add video or image showing how the new feature works -->

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged -->

Relates #3249 
