### PR TITLE
fix: components and explorer tree issues

### DIFF
--- a/apps/platform/pages/components/[componentSlug]/builder.tsx
+++ b/apps/platform/pages/components/[componentSlug]/builder.tsx
@@ -1,0 +1,75 @@
+import { RendererType } from '@codelab/frontend/abstract/application'
+import type { CodelabPage } from '@codelab/frontend/abstract/types'
+import { ExplorerPaneType } from '@codelab/frontend/abstract/types'
+import {
+  BuilderPrimarySidebar,
+  BuilderTabs,
+  BuilderViewLayout,
+  ComponentsPrimarySidebar,
+  ConfigPaneInspectorTabContainer,
+} from '@codelab/frontend/application/builder'
+import { PageDetailHeader } from '@codelab/frontend/application/page'
+import { withPageAuthRedirect } from '@codelab/frontend/application/shared/auth'
+import {
+  useCurrentComponent,
+  useRenderedComponent,
+} from '@codelab/frontend/presentation/container'
+import {
+  DynamicDashboardTemplate,
+  SkeletonWrapper,
+} from '@codelab/frontend/presentation/view'
+import { observer } from 'mobx-react-lite'
+import Head from 'next/head'
+import React, { useEffect, useMemo } from 'react'
+
+const ComponentBuilderView: CodelabPage = observer(() => {
+  const { componentName } = useCurrentComponent()
+
+  const [{ error, status }, loadCurrentComponent] = useRenderedComponent(
+    RendererType.ComponentBuilder,
+  )
+
+  const isLoading = status !== 'success'
+  const contentStyles = useMemo(() => ({ paddingTop: '0rem' }), [])
+
+  useEffect(() => {
+    void loadCurrentComponent.execute()
+  }, [componentName])
+
+  return (
+    <DynamicDashboardTemplate
+      ConfigPane={() => (
+        <SkeletonWrapper isLoading={isLoading}>
+          <ConfigPaneInspectorTabContainer />
+        </SkeletonWrapper>
+      )}
+      Header={PageDetailHeader}
+      PrimarySidebar={{
+        default: ExplorerPaneType.Explorer,
+        items: [
+          {
+            key: ExplorerPaneType.Components,
+            render: () => <ComponentsPrimarySidebar isLoading={isLoading} />,
+          },
+          {
+            key: ExplorerPaneType.Explorer,
+            render: () => <BuilderPrimarySidebar isLoading={isLoading} />,
+          },
+        ],
+      }}
+      contentStyles={contentStyles}
+    >
+      <Head>
+        <title>{componentName} | Builder | Codelab</title>
+      </Head>
+
+      <BuilderTabs error={error} isLoading={isLoading} />
+    </DynamicDashboardTemplate>
+  )
+})
+
+export const getServerSideProps = withPageAuthRedirect()
+
+ComponentBuilderView.Layout = BuilderViewLayout
+
+export default ComponentBuilderView

--- a/apps/platform/pages/components/[componentSlug]/index.tsx
+++ b/apps/platform/pages/components/[componentSlug]/index.tsx
@@ -1,0 +1,47 @@
+import { RendererType } from '@codelab/frontend/abstract/application'
+import type { CodelabPage } from '@codelab/frontend/abstract/types'
+import { BuilderViewLayout } from '@codelab/frontend/application/builder'
+import { PageDetailHeader } from '@codelab/frontend/application/page'
+import { RootRenderer } from '@codelab/frontend/application/renderer'
+import { withPageAuthRedirect } from '@codelab/frontend/application/shared/auth'
+import {
+  useCurrentComponent,
+  useRenderedComponent,
+} from '@codelab/frontend/presentation/container'
+import { DynamicDashboardTemplate } from '@codelab/frontend/presentation/view'
+import { extractErrorMessage } from '@codelab/frontend/shared/utils'
+import { Alert, Spin } from 'antd'
+import { observer } from 'mobx-react-lite'
+import Head from 'next/head'
+import React, { useEffect } from 'react'
+
+const ComponentPreviewView: CodelabPage = observer(() => {
+  const { componentName } = useCurrentComponent()
+
+  const [{ error, result, status }, loadCurrentComponent] =
+    useRenderedComponent(RendererType.Preview)
+
+  const isLoading = status !== 'success'
+
+  useEffect(() => {
+    void loadCurrentComponent.execute()
+  }, [componentName])
+
+  return (
+    <DynamicDashboardTemplate Header={PageDetailHeader}>
+      <Head>
+        <title>{componentName} | Preview | Codelab</title>
+      </Head>
+
+      {error && <Alert message={extractErrorMessage(error)} type="error" />}
+      {isLoading && <Spin />}
+      {result?.elementTree && <RootRenderer renderer={result.renderer} />}
+    </DynamicDashboardTemplate>
+  )
+})
+
+export const getServerSideProps = withPageAuthRedirect()
+
+ComponentPreviewView.Layout = BuilderViewLayout
+
+export default ComponentPreviewView

--- a/apps/platform/pages/components/index.tsx
+++ b/apps/platform/pages/components/index.tsx
@@ -1,0 +1,39 @@
+import type { CodelabPage } from '@codelab/frontend/abstract/types'
+import { ExplorerPaneType } from '@codelab/frontend/abstract/types'
+import {
+  BuilderViewLayout,
+  ComponentsPrimarySidebar,
+} from '@codelab/frontend/application/builder'
+import { ComponentDetailHeader } from '@codelab/frontend/application/component'
+import { withPageAuthRedirect } from '@codelab/frontend/application/shared/auth'
+import { DynamicDashboardTemplate } from '@codelab/frontend/presentation/view'
+import { observer } from 'mobx-react-lite'
+import Head from 'next/head'
+import React from 'react'
+
+const ComponentsView: CodelabPage = observer(() => {
+  return (
+    <DynamicDashboardTemplate
+      Header={ComponentDetailHeader}
+      PrimarySidebar={{
+        default: ExplorerPaneType.Components,
+        items: [
+          {
+            key: ExplorerPaneType.Components,
+            render: () => <ComponentsPrimarySidebar isLoading={false} />,
+          },
+        ],
+      }}
+    >
+      <Head>
+        <title>Components</title>
+      </Head>
+    </DynamicDashboardTemplate>
+  )
+})
+
+export const getServerSideProps = withPageAuthRedirect()
+
+ComponentsView.Layout = BuilderViewLayout
+
+export default ComponentsView

--- a/libs/frontend/application/builder/src/sections/config-pane/ConfigPane-InspectorTabContainer/ConfigPaneInspectorTabContainer.tsx
+++ b/libs/frontend/application/builder/src/sections/config-pane/ConfigPane-InspectorTabContainer/ConfigPaneInspectorTabContainer.tsx
@@ -1,4 +1,5 @@
 import CodeOutlined from '@ant-design/icons/CodeOutlined'
+import CodeSandboxOutlined from '@ant-design/icons/CodeSandboxOutlined'
 import FileOutlined from '@ant-design/icons/FileOutlined'
 import FormatPainterOutlined from '@ant-design/icons/FormatPainterOutlined'
 import NodeIndexOutlined from '@ant-design/icons/NodeIndexOutlined'
@@ -25,6 +26,7 @@ import { useStore } from '@codelab/frontend/application/shared/store'
 import { FormContextProvider } from '@codelab/frontend/presentation/view'
 import { Tabs, Tooltip } from 'antd'
 import classNames from 'classnames'
+import isNil from 'lodash/isNil'
 import { observer } from 'mobx-react-lite'
 import type { ReactNode } from 'react'
 import React from 'react'
@@ -60,6 +62,7 @@ export const ConfigPaneInspectorTabContainer = observer(() => {
 
   const elementTree = rendererService.activeElementTree
   const selectedNode = builderService.selectedNode?.current
+  const activeRenderer = rendererService.activeRenderer?.maybeCurrent
 
   if (!selectedNode || isRuntimePage(selectedNode)) {
     return null
@@ -83,8 +86,10 @@ export const ConfigPaneInspectorTabContainer = observer(() => {
             runtimeElement={selectedNode}
           />
         </>
-      ) : (
+      ) : isNil(selectedNode.childMapperIndex) ? (
         <UpdateComponentForm runtimeComponent={selectedNode} />
+      ) : (
+        'Child Mapper Component Props cannot be edited'
       ),
       key: TAB_NAMES.Node,
       label: (
@@ -150,16 +155,40 @@ export const ConfigPaneInspectorTabContainer = observer(() => {
         <TooltipIcon icon={<CodeOutlined />} title={TAB_NAMES.PropsInspector} />
       ),
     },
-    {
-      children: (
-        <UpdatePageTabForm
-          appService={appService}
-          key={selectedNode.compositeKey}
-        />
-      ),
-      key: TAB_NAMES.Page,
-      label: <TooltipIcon icon={<FileOutlined />} title={TAB_NAMES.Page} />,
-    },
+    ...(activeRenderer?.runtimePage
+      ? [
+          {
+            children: (
+              <UpdatePageTabForm
+                appService={appService}
+                key={selectedNode.compositeKey}
+              />
+            ),
+            key: TAB_NAMES.Page,
+            label: (
+              <TooltipIcon icon={<FileOutlined />} title={TAB_NAMES.Page} />
+            ),
+          },
+        ]
+      : []),
+    ...(activeRenderer?.runtimeComponent
+      ? [
+          {
+            children: (
+              <UpdateComponentForm
+                runtimeComponent={activeRenderer.runtimeComponent}
+              />
+            ),
+            key: TAB_NAMES.Component,
+            label: (
+              <TooltipIcon
+                icon={<CodeSandboxOutlined />}
+                title={TAB_NAMES.Component}
+              />
+            ),
+          },
+        ]
+      : []),
   ]
 
   return (

--- a/libs/frontend/application/builder/src/sections/config-pane/ConfigPane-InspectorTabContainer/data.ts
+++ b/libs/frontend/application/builder/src/sections/config-pane/ConfigPane-InspectorTabContainer/data.ts
@@ -1,5 +1,6 @@
 export enum TAB_NAMES {
   CSS = 'CSS',
+  Component = 'Component',
   Node = 'Node',
   Page = 'Page',
   Props = 'Props',

--- a/libs/frontend/application/builder/src/sections/explorer-pane/builder-tree/ElementTreeItemElementTitle.tsx
+++ b/libs/frontend/application/builder/src/sections/explorer-pane/builder-tree/ElementTreeItemElementTitle.tsx
@@ -34,9 +34,7 @@ export const ElementTreeItemElementTitle = observer(
     const { popover } = useCui()
     const atomName = element.atomName
 
-    const componentInstanceName = treeNode.isChildMapperComponentInstance
-      ? element.parentComponent?.maybeCurrent?.name
-      : isComponentRef(element.renderType)
+    const componentInstanceName = isComponentRef(element.renderType)
       ? element.renderType.maybeCurrent?.name
       : null
 

--- a/libs/frontend/application/builder/src/sections/explorer-pane/builder-tree/ElementTreeItemTitle.tsx
+++ b/libs/frontend/application/builder/src/sections/explorer-pane/builder-tree/ElementTreeItemTitle.tsx
@@ -1,3 +1,4 @@
+import BorderOuterOutlined from '@ant-design/icons/BorderOuterOutlined'
 import {
   type IElementTreeViewDataNode,
   type IRuntimeModel,
@@ -40,6 +41,7 @@ export const ElementTreeItemTitle = observer<ElementTreeItemTitleProps>(
 
     return (
       <CuiTreeItem
+        icon={<BorderOuterOutlined style={{ color: 'gray' }} />}
         primaryTitle={data.primaryTitle}
         secondaryTitle={data.secondaryTitle}
       />

--- a/libs/frontend/application/element/src/use-cases/element/update-element/UpdateElementForm.tsx
+++ b/libs/frontend/application/element/src/use-cases/element/update-element/UpdateElementForm.tsx
@@ -61,6 +61,44 @@ export const UpdateElementForm = observer<UpdateElementFormProps>(
 
     const runtimeProps = runtimeElement.runtimeProps
 
+    const collapseItems = [
+      {
+        children: <RenderTypeCompositeField name="renderType" />,
+        key: 'renderer',
+        label: 'Renderer',
+      },
+      {
+        children: (
+          <AutoField
+            component={CodeMirrorField({
+              customOptions: createAutoCompleteOptions(
+                runtimeProps.expressionEvaluationContext,
+              ),
+              language: CodeMirrorLanguage.Javascript,
+            })}
+            name="renderIfExpression"
+          />
+        ),
+        key: 'renderCondition',
+        label: 'Render Condition',
+      },
+      {
+        children: (
+          <>
+            <SelectActionField name="preRenderAction" />
+            <SelectActionField name="postRenderAction" />
+          </>
+        ),
+        key: 'actions',
+        label: 'Hooks Actions',
+      },
+      {
+        children: <ChildMapperCompositeField runtimeElement={runtimeElement} />,
+        key: 'childMapper',
+        label: 'Child Mapper',
+      },
+    ]
+
     return (
       <div key={element.id}>
         <Form<IUpdateBaseElementData>
@@ -90,29 +128,7 @@ export const UpdateElementForm = observer<UpdateElementFormProps>(
               'name',
             ]}
           />
-          <Collapse defaultActiveKey={expandedFields}>
-            <Collapse.Panel header="Renderer" key="renderer">
-              <RenderTypeCompositeField name="renderType" />
-            </Collapse.Panel>
-            <Collapse.Panel header="Render Condition" key="renderCondition">
-              <AutoField
-                component={CodeMirrorField({
-                  customOptions: createAutoCompleteOptions(
-                    runtimeProps.expressionEvaluationContext,
-                  ),
-                  language: CodeMirrorLanguage.Javascript,
-                })}
-                name="renderIfExpression"
-              />
-            </Collapse.Panel>
-            <Collapse.Panel header="Hooks Actions" key="actions">
-              <SelectActionField name="preRenderAction" />
-              <SelectActionField name="postRenderAction" />
-            </Collapse.Panel>
-            <Collapse.Panel header="Child Mapper" key="childMapper">
-              <ChildMapperCompositeField runtimeElement={runtimeElement} />
-            </Collapse.Panel>
-          </Collapse>
+          <Collapse defaultActiveKey={expandedFields} items={collapseItems} />
         </Form>
       </div>
     )

--- a/libs/frontend/application/renderer/src/model/runtime-component.model.ts
+++ b/libs/frontend/application/renderer/src/model/runtime-component.model.ts
@@ -121,13 +121,20 @@ export class RuntimeComponentModel
 
   @computed
   get treeViewNode(): IElementTreeViewDataNode {
+    const isChildMapperComponentInstance = !isNil(this.childMapperIndex)
+
     return {
-      children: [this.runtimeRootElement.treeViewNode],
-      isChildMapperComponentInstance: false,
+      ...this.runtimeRootElement.treeViewNode,
+      ...(isChildMapperComponentInstance ? { children: [] } : {}),
+      isChildMapperComponentInstance,
       key: this.compositeKey,
       node: this,
-      primaryTitle: this.component.current.name,
-      rootKey: this.component.current.id,
+      primaryTitle: `${this.runtimeRootElement.element.current.name}${
+        isChildMapperComponentInstance ? ` ${this.childMapperIndex}` : ''
+      }`,
+      secondaryTitle: isChildMapperComponentInstance
+        ? `child mapper component (${this.component.current.name} instance)`
+        : '',
     }
   }
 }

--- a/libs/frontend/presentation/container/src/pageHooks/useRenderedComponent.hook.ts
+++ b/libs/frontend/presentation/container/src/pageHooks/useRenderedComponent.hook.ts
@@ -13,13 +13,8 @@ import { loadAllTypesForElements } from './utils'
  * Fetch related data for rendering component, and load them into store
  */
 export const useRenderedComponent = (rendererType: RendererType) => {
-  const {
-    builderService,
-    componentService,
-    elementService,
-    rendererService,
-    typeService,
-  } = useStore()
+  const { builderService, componentService, rendererService, typeService } =
+    useStore()
 
   const { componentName } = useCurrentComponent()
   const router = useRouter()
@@ -34,13 +29,13 @@ export const useRenderedComponent = (rendererType: RendererType) => {
       return null
     }
 
-    const rootElement = elementService.elementDomainService.maybeElement(
-      component.rootElement.id,
-    )
+    // const rootElement = elementService.elementDomainService.maybeElement(
+    //  component.rootElement.id,
+    // )
 
-    if (rootElement) {
-      await elementService.loadDependantTypes(rootElement)
-    }
+    //if (rootElement) {
+    //  await elementService.loadDependantTypes(rootElement)
+    // }
 
     // TODO: Remove this in favor of loadDependantTypes
     await loadAllTypesForElements(
@@ -59,7 +54,6 @@ export const useRenderedComponent = (rendererType: RendererType) => {
       builderService.selectElementNode(
         renderer.runtimeRootContainerNode.runtimeRootElement,
       )
-      builderService.selectComponentNode(renderer.runtimeComponent)
     }
 
     rendererService.setActiveRenderer(rendererRef(renderer.id))

--- a/libs/frontend/presentation/container/src/pageHooks/utils.ts
+++ b/libs/frontend/presentation/container/src/pageHooks/utils.ts
@@ -8,7 +8,7 @@ import type {
 } from '@codelab/frontend/abstract/domain'
 import {
   extractTypedPropValue,
-  isComponent,
+  isComponentRef,
   isTypedProp,
 } from '@codelab/frontend/abstract/domain'
 import type { IPropData } from '@codelab/shared/abstract/core'
@@ -37,7 +37,7 @@ const getComponentIdsFromElements = (elements: Array<IElementModel>) =>
   elements
     .reduce<Array<string>>((acc, element) => {
       // Component as an element
-      if (isComponent(element.renderType)) {
+      if (isComponentRef(element.renderType)) {
         acc.push(element.renderType.id)
       }
 


### PR DESCRIPTION
## Description

A couple of problem is fixed in this PR:
1. #3308 issue is that in component builder it was impossible to open components props form after any elmenet in builder tree was selected. The issue is resolved by adding new `Components` tabs (similar to `Page` tab for page builder).

https://github.com/codelab-app/platform/assets/74900868/79972a21-f7d5-4a56-b05a-b7a9c9dc36a0

2. Builder tree issues. The child mapper components, regular components was displaying incorrectly.

https://github.com/codelab-app/platform/assets/74900868/c806e94f-673a-4521-b271-2596f7271c99

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged -->

Fixes #3308
Fixes #2972 
