### PR TITLE
fix: drag drop runtime keys

### DIFF
--- a/libs/frontend/application/builder/src/hooks/useElementTreeDrop/useElementTreeDrop.hook.ts
+++ b/libs/frontend/application/builder/src/hooks/useElementTreeDrop/useElementTreeDrop.hook.ts
@@ -23,23 +23,29 @@ export interface UseElementTreeDropProps {
  * This can be optimized by batching data changes in the API
  */
 export const useElementTreeDrop = () => {
-  const { elementService } = useStore()
+  const { elementService, runtimeElementService } = useStore()
   const { validateParentForMove } = useRequiredParentValidator()
 
   const handleDrop: TreeProps<IElementTreeViewDataNode>['onDrop'] = async (
     info,
   ) => {
-    const draggedElementId = info.dragNode.key.toString()
-    const draggedElement = elementService.element(draggedElementId)
+    const runtimeDraggedElement = runtimeElementService.runtimeElement(
+      info.dragNode.key.toString(),
+    )
+
+    const runtimeDropElement = runtimeElementService.runtimeElement(
+      info.node.key.toString(),
+    )
+
+    const draggedElement = runtimeDraggedElement.element.current
     const draggedRootId = info.dragNode.rootKey?.toString()
-    const dropElementId = info.node.key.toString()
-    const dropElement = elementService.element(dropElementId)
+    const dropElement = runtimeDropElement.element.current
     const dropRootId = info.node.rootKey?.toString()
 
     // check if the dropNode lives in a different component
     // move the element into the other component
     if (draggedRootId !== dropRootId) {
-      if (draggedElementId === draggedRootId) {
+      if (draggedElement.id === draggedRootId) {
         // We can't move the root because the drag component
         // can't stay without a root element
         return
@@ -54,7 +60,7 @@ export const useElementTreeDrop = () => {
       return
     }
 
-    if (!validateParentForMove(draggedElementId, dropElementId)) {
+    if (!validateParentForMove(draggedElement.id, dropElement.id)) {
       return
     }
 

--- a/libs/frontend/application/renderer/src/renderer.model.ts
+++ b/libs/frontend/application/renderer/src/renderer.model.ts
@@ -46,11 +46,19 @@ import { typedPropTransformersFactory } from './typed-prop-transformers'
  */
 
 const create = ({ containerNode, rendererType }: IRendererDto) => {
+  const runtimeRootContainerNode = isPage(containerNode)
+    ? RuntimePageModel.create({ page: containerNode })
+    : RuntimeComponentModel.create({
+        component: containerNode,
+        compositeKey: RuntimeComponentModel.compositeKey(containerNode),
+      })
+
   return new Renderer({
     containerNode: isPage(containerNode)
       ? pageRef(containerNode)
       : componentRef(containerNode),
     rendererType,
+    runtimeRootContainerNode,
   })
 }
 


### PR DESCRIPTION
<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(libs-ui-component): must begin with lowercase` -->

## Description

<!-- This is a short description on the Pull Request -->
- `key` stores runtime-element.model keys. it used to store element.model id for in the past
## Video or Image

<!-- Add video or image showing how the new feature works -->

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged -->

Fixes #3323
