### PR TITLE
feat: make resizable panels collapsible

### DIFF
--- a/libs/frontend/application/builder/src/sections/content/Builder.tsx
+++ b/libs/frontend/application/builder/src/sections/content/Builder.tsx
@@ -94,7 +94,6 @@ const StyledBuilderContainer = styled.div`
   width: 100%;
   height: 100%;
   background: transparent;
-  overflow: scroll;
   .ant-modal-mask,
   .ant-modal-wrap {
     position: absolute;

--- a/libs/frontend/presentation/codelab-ui/src/layout/CuiResizablePanel/CuiResizablePanel.tsx
+++ b/libs/frontend/presentation/codelab-ui/src/layout/CuiResizablePanel/CuiResizablePanel.tsx
@@ -1,0 +1,17 @@
+import React from 'react'
+import { type CuiResizablePanelProps, useResizeHandler } from './hooks'
+
+export const CuiResizablePanel = (props: CuiResizablePanelProps) => {
+  const { collapseControl, handler, panel } = useResizeHandler(props)
+  const { resizeDirection } = props
+
+  return (
+    <>
+      {resizeDirection === 'left' && collapseControl}
+      {resizeDirection === 'left' && handler}
+      {panel}
+      {resizeDirection === 'right' && handler}
+      {resizeDirection === 'right' && collapseControl}
+    </>
+  )
+}

--- a/libs/frontend/presentation/codelab-ui/src/layout/CuiResizablePanel/components/CollapseControl.tsx
+++ b/libs/frontend/presentation/codelab-ui/src/layout/CuiResizablePanel/components/CollapseControl.tsx
@@ -1,0 +1,28 @@
+import LeftOutlined from '@ant-design/icons/LeftOutlined'
+import RightOutlined from '@ant-design/icons/RightOutlined'
+import React from 'react'
+
+interface CollapseControlProps {
+  collapsed: boolean
+  resizeDirection: 'left' | 'right'
+  onClick?(): void
+}
+
+export const CollapseControl = ({
+  collapsed,
+  onClick,
+  resizeDirection,
+}: CollapseControlProps) => {
+  return (
+    <div className="flex h-full items-center justify-center align-middle">
+      <div className="cursor-pointer bg-gray-200" onClick={onClick}>
+        <div className="flex space-x-0.5 rounded-r bg-inherit p-0.5 py-3">
+          {resizeDirection === 'right' && collapsed && <RightOutlined />}
+          {resizeDirection === 'right' && !collapsed && <LeftOutlined />}
+          {resizeDirection === 'left' && collapsed && <LeftOutlined />}
+          {resizeDirection === 'left' && !collapsed && <RightOutlined />}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/libs/frontend/presentation/codelab-ui/src/layout/CuiResizablePanel/components/CuiResizeHandler.tsx
+++ b/libs/frontend/presentation/codelab-ui/src/layout/CuiResizablePanel/components/CuiResizeHandler.tsx
@@ -1,12 +1,8 @@
 import React from 'react'
 import { PanelResizeHandle } from 'react-resizable-panels'
 
-const ResizeHandle = () => {
+export const CuiResizeHandler = () => {
   return (
     <PanelResizeHandle className="h-full w-[3px] bg-gray-200 hover:bg-blue-300 active:bg-blue-400" />
   )
 }
-
-ResizeHandle.displayName = 'ResizeHandle'
-
-export default ResizeHandle

--- a/libs/frontend/presentation/codelab-ui/src/layout/CuiResizablePanel/components/index.ts
+++ b/libs/frontend/presentation/codelab-ui/src/layout/CuiResizablePanel/components/index.ts
@@ -1,0 +1,2 @@
+export * from './CollapseControl'
+export * from './CuiResizeHandler'

--- a/libs/frontend/presentation/codelab-ui/src/layout/CuiResizablePanel/hooks/UseResizablePanel.tsx
+++ b/libs/frontend/presentation/codelab-ui/src/layout/CuiResizablePanel/hooks/UseResizablePanel.tsx
@@ -1,0 +1,51 @@
+import type { PropsWithChildren } from 'react'
+import React, { useRef, useState } from 'react'
+import { type ImperativePanelHandle, Panel } from 'react-resizable-panels'
+import { CollapseControl, CuiResizeHandler } from '../components'
+
+export type CuiResizablePanelProps = PropsWithChildren<{
+  collapsible?: boolean
+  order: number
+  // can add support for top, buttom later on
+  resizeDirection: 'left' | 'right'
+  showCollapseButton?: boolean
+}>
+
+export const useResizeHandler = ({
+  children,
+  collapsible,
+  order,
+  resizeDirection,
+  showCollapseButton = true,
+}: CuiResizablePanelProps) => {
+  const [collapsed, setCollapsed] = useState(false)
+  const panelHandler = useRef<ImperativePanelHandle>(null)
+  const showCollapseControl = collapsible && (collapsed || showCollapseButton)
+
+  return {
+    collapseControl: showCollapseControl && (
+      <CollapseControl
+        collapsed={collapsed}
+        onClick={() => {
+          if (collapsed) {
+            panelHandler.current?.expand()
+          } else {
+            panelHandler.current?.collapse()
+          }
+        }}
+        resizeDirection={resizeDirection}
+      />
+    ),
+    handler: <CuiResizeHandler />,
+    panel: (
+      <Panel
+        collapsible={collapsible}
+        onCollapse={setCollapsed}
+        order={order}
+        ref={panelHandler}
+      >
+        {children}
+      </Panel>
+    ),
+  }
+}

--- a/libs/frontend/presentation/codelab-ui/src/layout/CuiResizablePanel/hooks/index.ts
+++ b/libs/frontend/presentation/codelab-ui/src/layout/CuiResizablePanel/hooks/index.ts
@@ -1,0 +1,1 @@
+export * from './UseResizablePanel'

--- a/libs/frontend/presentation/codelab-ui/src/layout/CuiResizablePanel/index.ts
+++ b/libs/frontend/presentation/codelab-ui/src/layout/CuiResizablePanel/index.ts
@@ -1,0 +1,1 @@
+export * from './CuiResizablePanel'

--- a/libs/frontend/presentation/codelab-ui/src/layout/index.ts
+++ b/libs/frontend/presentation/codelab-ui/src/layout/index.ts
@@ -1,5 +1,6 @@
 export * from './CuiHeader'
 export * from './CuiNavigationBar'
+export * from './CuiResizablePanel'
 export * from './CuiSidebar'
 export * from './CuiSidebarPopover'
 export * from './hooks'

--- a/libs/frontend/presentation/view/src/templates/Dashboard/DashboardTemplate.tsx
+++ b/libs/frontend/presentation/view/src/templates/Dashboard/DashboardTemplate.tsx
@@ -1,5 +1,8 @@
 import { useStore } from '@codelab/frontend/application/shared/store'
-import { CuiNavigationBar } from '@codelab/frontend/presentation/codelab-ui'
+import {
+  CuiNavigationBar,
+  CuiResizablePanel,
+} from '@codelab/frontend/presentation/codelab-ui'
 import { Layout } from 'antd'
 import { observer } from 'mobx-react-lite'
 import { useRouter } from 'next/router'
@@ -8,7 +11,6 @@ import { Panel, PanelGroup } from 'react-resizable-panels'
 import { sidebarWidth } from './constants'
 import { DashboardTemplateConfigPane } from './DashboardTemplateConfigPane'
 import { defaultNavigationBarItems } from './NavigationBar'
-import ResizeHandle from './ResizeHandle'
 import type { DashboardTemplateProps } from './Types'
 
 const { Sider } = Layout
@@ -65,17 +67,19 @@ export const DashboardTemplate = observer(
           <Layout style={contentStyles}>
             <PanelGroup direction="horizontal">
               {ActivePrimarySidebar && (
-                <>
-                  <Panel defaultSize={20} order={1}>
-                    <div
-                      className="size-full"
-                      data-cy="temp-primary-panel-wrapper"
-                    >
-                      <ActivePrimarySidebar />
-                    </div>
-                  </Panel>
-                  <ResizeHandle />
-                </>
+                <CuiResizablePanel
+                  collapsible
+                  order={1}
+                  resizeDirection="right"
+                  showCollapseButton={false}
+                >
+                  <div
+                    className="size-full"
+                    data-cy="temp-primary-panel-wrapper"
+                  >
+                    <ActivePrimarySidebar />
+                  </div>
+                </CuiResizablePanel>
               )}
 
               <Panel defaultSize={60} order={2}>
@@ -85,12 +89,9 @@ export const DashboardTemplate = observer(
               </Panel>
 
               {ConfigPane && (
-                <>
-                  <ResizeHandle />
-                  <Panel defaultSize={20} order={3}>
-                    <DashboardTemplateConfigPane ConfigPane={ConfigPane} />
-                  </Panel>
-                </>
+                <CuiResizablePanel collapsible order={3} resizeDirection="left">
+                  <DashboardTemplateConfigPane ConfigPane={ConfigPane} />
+                </CuiResizablePanel>
               )}
             </PanelGroup>
           </Layout>


### PR DESCRIPTION
<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(libs-ui-component): must begin with lowercase` -->

## Description


Abstracted the resizable panels into a single Cui component that allows for collapsing the panel and adds a button to expand it. 

## Video or Image

<!-- Add video or image showing how the new feature works -->

https://github.com/codelab-app/platform/assets/51242349/151771e2-2a78-4ef0-b3af-eaa7e0fa85bc

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged -->

Fixes #3382
