### PR TITLE
fix: element added to a wrong parent

### DIFF
--- a/libs/frontend/application/builder/src/sections/explorer-pane/builder-tree/ElementTreeItemElementTitle.tsx
+++ b/libs/frontend/application/builder/src/sections/explorer-pane/builder-tree/ElementTreeItemElementTitle.tsx
@@ -6,9 +6,13 @@ import PlusOutlined from '@ant-design/icons/PlusOutlined'
 import {
   type IBuilderRoute,
   type IElementTreeViewDataNode,
+  IRuntimeNodeType,
+  runtimeComponentRef,
+  runtimeElementRef,
 } from '@codelab/frontend-abstract-application'
 import { UiKey } from '@codelab/frontend-abstract-types'
 import { useElementService } from '@codelab/frontend-application-element/services'
+import { useApplicationStore } from '@codelab/frontend-infra-mobx-context'
 import {
   CuiTreeItem,
   CuiTreeItemToolbar,
@@ -23,12 +27,19 @@ const Toolbar = observer<{
 }>(({ context, treeNode }) => {
   const router = useRouter()
   const { createPopover } = useElementService()
+  const { builderService } = useApplicationStore()
 
   if (!treeNode.element) {
     return
   }
 
   const onClick = () => {
+    builderService.setSelectedNode(
+      treeNode.type === IRuntimeNodeType.Component
+        ? runtimeComponentRef(treeNode.key)
+        : runtimeElementRef(treeNode.key),
+    )
+
     createPopover.open(router, context)
   }
 


### PR DESCRIPTION
<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(libs-ui-component): must begin with lowercase` -->

## Description

If plus icon was clicked in elements tree on a node that was not selected - the Create Element Form picks up the last selected child as a parent, and adds new element to a wrong place

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged -->

Fixes #3724
