### PR TITLE
fix: syntax highlight for code mirror editor

### DIFF
--- a/libs/frontend/presentation/components/codemirror/src/CodeMirrorInput.tsx
+++ b/libs/frontend/presentation/components/codemirror/src/CodeMirrorInput.tsx
@@ -64,6 +64,7 @@ export const CodeMirrorInput = ({
             'aria-label': title ?? '',
             id: props.id ?? '',
           }),
+          ...(props.extensions || []),
         ],
         onChange: (_value: string, view: ViewUpdate) => {
           onChange(_value)


### PR DESCRIPTION
<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(libs-ui-component): must begin with lowercase` -->

## Video or Image

<img width="617" alt="Screenshot 2025-07-06 at 11 20 08" src="https://github.com/user-attachments/assets/a5b16672-9110-4098-a593-bbefa5909bb4" />


## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged -->

Fixes #3753
